### PR TITLE
feat: add custom elements hint to get_screen_state compact output

### DIFF
--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/CompactTreeFormatter.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/CompactTreeFormatter.kt
@@ -8,10 +8,11 @@ import javax.inject.Inject
  *
  * Output format:
  * - Line 1: `note:structural-only nodes are omitted from the tree`
- * - Line 2: `app:<package> activity:<activity>`
- * - Line 3: `screen:<w>x<h> density:<dpi> orientation:<orientation>`
- * - Line 4: TSV header: `id\tclass\ttext\tdesc\tres_id\tbounds\tflags`
- * - Lines 5+: one TSV row per kept node (flat, no depth)
+ * - Line 2: `note:certain elements are custom and will not be properly reported, ...`
+ * - Line 3: `app:<package> activity:<activity>`
+ * - Line 4: `screen:<w>x<h> density:<dpi> orientation:<orientation>`
+ * - Line 5: TSV header: `id\tclass\ttext\tdesc\tres_id\tbounds\tflags`
+ * - Lines 6+: one TSV row per kept node (flat, no depth)
  *
  * Nodes are filtered: a node is KEPT if ANY of:
  * - has non-null, non-empty text
@@ -42,19 +43,22 @@ class CompactTreeFormatter
             // Line 1: note
             sb.appendLine(NOTE_LINE)
 
-            // Line 2: app metadata
+            // Line 2: note about custom elements
+            sb.appendLine(NOTE_LINE_CUSTOM_ELEMENTS)
+
+            // Line 3: app metadata
             sb.appendLine("app:$packageName activity:$activityName")
 
-            // Line 3: screen info
+            // Line 4: screen info
             sb.appendLine(
                 "screen:${screenInfo.width}x${screenInfo.height} " +
                     "density:${screenInfo.densityDpi} orientation:${screenInfo.orientation}",
             )
 
-            // Line 4: header
+            // Line 5: header
             sb.appendLine(HEADER)
 
-            // Lines 5+: walk tree and append kept nodes
+            // Lines 6+: walk tree and append kept nodes
             walkNode(sb, tree)
 
             return sb.toString().trimEnd('\n')
@@ -171,6 +175,10 @@ class CompactTreeFormatter
             const val MAX_TEXT_LENGTH = 100
             const val TRUNCATION_SUFFIX = "...truncated"
             const val NOTE_LINE = "note:structural-only nodes are omitted from the tree"
+            const val NOTE_LINE_CUSTOM_ELEMENTS =
+                "note:certain elements are custom and will not be properly reported, " +
+                    "if needed or if tools are not working as expected set " +
+                    "include_screenshot=true to see the screen and take what you see into account"
             const val HEADER =
                 "id${COLUMN_SEPARATOR}class${COLUMN_SEPARATOR}text${COLUMN_SEPARATOR}" +
                     "desc${COLUMN_SEPARATOR}res_id${COLUMN_SEPARATOR}bounds${COLUMN_SEPARATOR}flags"

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/ScreenIntrospectionIntegrationTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/ScreenIntrospectionIntegrationTest.kt
@@ -91,6 +91,7 @@ class ScreenIntrospectionIntegrationTest {
 
                 val textContent = (result.content[0] as TextContent).text
                 assertTrue(textContent.contains("note:structural-only nodes are omitted from the tree"))
+                assertTrue(textContent.contains("note:certain elements are custom and will not be properly reported"))
                 assertTrue(textContent.contains("app:com.example.app activity:.MainActivity"))
                 assertTrue(textContent.contains("screen:1080x2400 density:420 orientation:portrait"))
                 assertTrue(textContent.contains("id\tclass\ttext\tdesc\tres_id\tbounds\tflags"))

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/ScreenIntrospectionToolsTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/ScreenIntrospectionToolsTest.kt
@@ -83,6 +83,9 @@ class ScreenIntrospectionToolsTest {
 
     private val sampleCompactOutput =
         "note:structural-only nodes are omitted from the tree\n" +
+            "note:certain elements are custom and will not be properly reported, " +
+            "if needed or if tools are not working as expected set " +
+            "include_screenshot=true to see the screen and take what you see into account\n" +
             "app:com.example activity:.Main\n" +
             "screen:1080x2400 density:420 orientation:portrait\n" +
             "id\tclass\ttext\tdesc\tres_id\tbounds\tflags\n" +

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/CompactTreeFormatterTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/CompactTreeFormatterTest.kt
@@ -65,7 +65,16 @@ class CompactTreeFormatterTest {
             val tree = makeNode(text = "hello")
             val output = formatter.format(tree, "com.example", ".Main", defaultScreenInfo)
             val lines = output.lines()
-            assertEquals("note:structural-only nodes are omitted from the tree", lines[0])
+            assertEquals(CompactTreeFormatter.NOTE_LINE, lines[0])
+        }
+
+        @Test
+        @DisplayName("produces custom elements note as second line")
+        fun producesCustomElementsNoteAsSecondLine() {
+            val tree = makeNode(text = "hello")
+            val output = formatter.format(tree, "com.example", ".Main", defaultScreenInfo)
+            val lines = output.lines()
+            assertEquals(CompactTreeFormatter.NOTE_LINE_CUSTOM_ELEMENTS, lines[1])
         }
 
         @Test
@@ -74,8 +83,8 @@ class CompactTreeFormatterTest {
             val tree = makeNode(text = "hello")
             val output = formatter.format(tree, "com.example.app", ".MainActivity", defaultScreenInfo)
             val lines = output.lines()
-            assertEquals("app:com.example.app activity:.MainActivity", lines[1])
-            assertEquals("screen:1080x2400 density:420 orientation:portrait", lines[2])
+            assertEquals("app:com.example.app activity:.MainActivity", lines[2])
+            assertEquals("screen:1080x2400 density:420 orientation:portrait", lines[3])
         }
 
         @Test
@@ -84,7 +93,7 @@ class CompactTreeFormatterTest {
             val tree = makeNode(text = "hello")
             val output = formatter.format(tree, "com.example", ".Main", defaultScreenInfo)
             val lines = output.lines()
-            assertEquals("id\tclass\ttext\tdesc\tres_id\tbounds\tflags", lines[3])
+            assertEquals("id\tclass\ttext\tdesc\tres_id\tbounds\tflags", lines[4])
         }
 
         @Test
@@ -103,8 +112,8 @@ class CompactTreeFormatterTest {
                 )
             val output = formatter.format(tree, "com.example", ".Main", defaultScreenInfo)
             val lines = output.lines()
-            // Data rows start at line 4 (0-indexed)
-            assertEquals("node_btn\tButton\tOK\t-\tbtn_ok\t100,200,300,260\tvcn", lines[4])
+            // Data rows start at line 5 (0-indexed)
+            assertEquals("node_btn\tButton\tOK\t-\tbtn_ok\t100,200,300,260\tvcn", lines[5])
         }
 
         @Test
@@ -118,8 +127,8 @@ class CompactTreeFormatterTest {
                 )
             val output = formatter.format(tree, "com.example", ".Main", defaultScreenInfo)
             val lines = output.lines()
-            // Only note + metadata + header = 4 lines, no data rows
-            assertEquals(4, lines.size)
+            // Only notes + metadata + header = 5 lines, no data rows
+            assertEquals(5, lines.size)
         }
 
         @Test
@@ -143,8 +152,8 @@ class CompactTreeFormatterTest {
             val output = formatter.format(parent, "com.example", ".Main", defaultScreenInfo)
             val lines = output.lines()
             // Parent is filtered, child appears
-            assertEquals(5, lines.size)
-            assertTrue(lines[4].startsWith("node_child\t"))
+            assertEquals(6, lines.size)
+            assertTrue(lines[5].startsWith("node_child\t"))
         }
 
         @Test
@@ -160,11 +169,11 @@ class CompactTreeFormatterTest {
                 )
             val output = formatter.format(tree, "com.example", ".Main", defaultScreenInfo)
             val lines = output.lines()
-            assertEquals(5, lines.size)
+            assertEquals(6, lines.size)
             // No 'v' flag since not visible
-            assertTrue(lines[4].contains("node_hidden"))
-            assertTrue(lines[4].endsWith("n"))
-            assertFalse(lines[4].endsWith("vn"))
+            assertTrue(lines[5].contains("node_hidden"))
+            assertTrue(lines[5].endsWith("n"))
+            assertFalse(lines[5].endsWith("vn"))
         }
 
         @Test
@@ -184,8 +193,8 @@ class CompactTreeFormatterTest {
                 )
             val output = formatter.format(tree, "com.example", ".Main", defaultScreenInfo)
             val lines = output.lines()
-            // Only note + metadata + header = 4 lines
-            assertEquals(4, lines.size)
+            // Only notes + metadata + header = 5 lines
+            assertEquals(5, lines.size)
         }
 
         @Test
@@ -199,7 +208,7 @@ class CompactTreeFormatterTest {
                 )
             val output = formatter.format(tree, "com.example", ".Main", defaultScreenInfo)
             val lines = output.lines()
-            assertTrue(lines[4].contains("10,20,300,400"))
+            assertTrue(lines[5].contains("10,20,300,400"))
         }
     }
 

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -190,7 +190,7 @@ Replaces the previous `get_accessibility_tree`, `capture_screenshot`, `get_curre
     "content": [
       {
         "type": "text",
-        "text": "note:structural-only nodes are omitted from the tree\napp:com.android.calculator2 activity:.Calculator\nscreen:1080x2400 density:420 orientation:portrait\nid\tclass\ttext\tdesc\tres_id\tbounds\tflags\nnode_1\tTextView\tCalculator\t-\tcom.android.calculator2:id/title\t100,50,500,120\tvn\nnode_2\tButton\t7\t-\tcom.android.calculator2:id/digit_7\t50,800,270,1000\tvcn"
+        "text": "note:structural-only nodes are omitted from the tree\nnote:certain elements are custom and will not be properly reported, if needed or if tools are not working as expected set include_screenshot=true to see the screen and take what you see into account\napp:com.android.calculator2 activity:.Calculator\nscreen:1080x2400 density:420 orientation:portrait\nid\tclass\ttext\tdesc\tres_id\tbounds\tflags\nnode_1\tTextView\tCalculator\t-\tcom.android.calculator2:id/title\t100,50,500,120\tvn\nnode_2\tButton\t7\t-\tcom.android.calculator2:id/digit_7\t50,800,270,1000\tvcn"
       }
     ]
   }
@@ -206,7 +206,7 @@ Replaces the previous `get_accessibility_tree`, `capture_screenshot`, `get_curre
     "content": [
       {
         "type": "text",
-        "text": "note:structural-only nodes are omitted from the tree\napp:com.android.calculator2 activity:.Calculator\nscreen:1080x2400 density:420 orientation:portrait\nid\tclass\ttext\tdesc\tres_id\tbounds\tflags\n..."
+        "text": "note:structural-only nodes are omitted from the tree\nnote:certain elements are custom and will not be properly reported, if needed or if tools are not working as expected set include_screenshot=true to see the screen and take what you see into account\napp:com.android.calculator2 activity:.Calculator\nscreen:1080x2400 density:420 orientation:portrait\nid\tclass\ttext\tdesc\tres_id\tbounds\tflags\n..."
       },
       {
         "type": "image",
@@ -223,10 +223,11 @@ Replaces the previous `get_accessibility_tree`, `capture_screenshot`, `get_curre
 The text output is a compact flat TSV (tab-separated values) format designed for token-efficient LLM consumption:
 
 1. **Note line**: `note:structural-only nodes are omitted from the tree`
-2. **App line**: `app:<package> activity:<activity>`
-3. **Screen line**: `screen:<width>x<height> density:<dpi> orientation:<orientation>`
-4. **Header**: `id\tclass\ttext\tdesc\tres_id\tbounds\tflags`
-5. **Data rows**: One row per filtered node with tab-separated values
+2. **Note line**: `note:certain elements are custom and will not be properly reported, if needed or if tools are not working as expected set include_screenshot=true to see the screen and take what you see into account`
+3. **App line**: `app:<package> activity:<activity>`
+4. **Screen line**: `screen:<width>x<height> density:<dpi> orientation:<orientation>`
+5. **Header**: `id\tclass\ttext\tdesc\tres_id\tbounds\tflags`
+6. **Data rows**: One row per filtered node with tab-separated values
 
 #### Flags Reference
 


### PR DESCRIPTION
## Summary

- Add a second note line to the `get_screen_state` compact TSV output advising LLMs that certain custom UI elements may not be properly reported by the accessibility tree, and to use `include_screenshot=true` when tools are not working as expected.

## Changes

- **`CompactTreeFormatter.kt`**: Added `NOTE_LINE_CUSTOM_ELEMENTS` constant emitted as line 2 in the compact output. Updated KDoc line numbering.
- **`CompactTreeFormatterTest.kt`**: Added new test for the custom elements note line. Shifted all line index and count assertions by +1.
- **`ScreenIntrospectionToolsTest.kt`**: Updated `sampleCompactOutput` to include the new note line.
- **`ScreenIntrospectionIntegrationTest.kt`**: Added assertion verifying the new note line is present in integration test output.
- **`docs/MCP_TOOLS.md`**: Updated response examples and output format description to document the new note line.

## Testing

- All unit tests pass (`CompactTreeFormatterTest`, `ScreenIntrospectionToolsTest`)
- All integration tests pass (`ScreenIntrospectionIntegrationTest`)
- ktlint check passes

## Checklist

- [x] All tests pass
- [x] Lint passes (`ktlintCheck`)
- [x] Build succeeds