### PR TITLE
fix: notification action fixes (empty filter + BAL)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ test-results/
 
 # Native binaries in jniLibs (build artifacts — cloudflared from make compile-cloudflared, ngrok from Gradle extractNgrokNative)
 app/src/main/jniLibs/
+
+# MCP client configuration (contains tokens)
+.mcp.json

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/notifications/NotificationProviderImpl.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/notifications/NotificationProviderImpl.kt
@@ -1,11 +1,13 @@
 package com.danielealbano.androidremotecontrolmcp.services.notifications
 
+import android.app.ActivityOptions
 import android.app.Notification
 import android.app.PendingIntent
 import android.app.RemoteInput
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import android.service.notification.StatusBarNotification
 import com.danielealbano.androidremotecontrolmcp.utils.Logger
@@ -51,7 +53,7 @@ class NotificationProviderImpl
                 sbn.notification.contentIntent
                     ?: return Result.failure(IllegalStateException("Notification has no content intent"))
             return try {
-                pendingIntent.send()
+                pendingIntent.send(context, 0, null, null, null, null, buildBalOptions())
                 Result.success(Unit)
             } catch (e: PendingIntent.CanceledException) {
                 Result.failure(e)
@@ -102,7 +104,7 @@ class NotificationProviderImpl
                 action.actionIntent
                     ?: return Result.failure(IllegalStateException("Action has no pending intent"))
             return try {
-                pendingIntent.send()
+                pendingIntent.send(context, 0, null, null, null, null, buildBalOptions())
                 Result.success(Unit)
             } catch (e: PendingIntent.CanceledException) {
                 Result.failure(e)
@@ -130,7 +132,7 @@ class NotificationProviderImpl
             }
             RemoteInput.addResultsToIntent(remoteInputs, replyIntent, resultsBundle)
             return try {
-                pendingIntent.send(context, 0, replyIntent)
+                pendingIntent.send(context, 0, replyIntent, null, null, null, buildBalOptions())
                 Result.success(Unit)
             } catch (e: PendingIntent.CanceledException) {
                 Result.failure(e)
@@ -199,15 +201,6 @@ class NotificationProviderImpl
             return null
         }
 
-        private fun hasContent(notification: Notification): Boolean {
-            val extras = notification.extras
-            val hasTitle = extras.getCharSequence(Notification.EXTRA_TITLE) != null
-            val hasText = extras.getCharSequence(Notification.EXTRA_TEXT) != null
-            val hasBigText = extras.getCharSequence(Notification.EXTRA_BIG_TEXT) != null
-            val hasActions = notification.actions != null && notification.actions.size > 0
-            return hasTitle || hasText || hasBigText || hasActions
-        }
-
         companion object {
             private const val TAG = "MCP:NotificationProvider"
             const val HASH_HEX_LENGTH = 8
@@ -219,4 +212,26 @@ class NotificationProviderImpl
                 actionIndex: Int,
             ): String = "%08x".format("$key::$actionIndex".hashCode())
         }
+    }
+
+private fun hasContent(notification: Notification): Boolean {
+    val extras = notification.extras
+    val hasTitle = extras.getCharSequence(Notification.EXTRA_TITLE) != null
+    val hasText = extras.getCharSequence(Notification.EXTRA_TEXT) != null
+    val hasBigText = extras.getCharSequence(Notification.EXTRA_BIG_TEXT) != null
+    val hasActions = notification.actions != null && notification.actions.size > 0
+    return hasTitle || hasText || hasBigText || hasActions
+}
+
+private fun buildBalOptions(): Bundle? =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+        ActivityOptions
+            .makeBasic()
+            .apply {
+                setPendingIntentBackgroundActivityStartMode(
+                    ActivityOptions.MODE_BACKGROUND_ACTIVITY_START_ALLOWED,
+                )
+            }.toBundle()
+    } else {
+        null
     }

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/notifications/NotificationProviderImplTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/notifications/NotificationProviderImplTest.kt
@@ -4,6 +4,7 @@ import android.app.Notification
 import android.app.PendingIntent
 import android.app.RemoteInput
 import android.content.Context
+import android.content.Intent
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.os.Bundle
@@ -388,7 +389,17 @@ class NotificationProviderImplTest {
                 val result = provider.openNotification(hash)
 
                 assertTrue(result.isSuccess)
-                verify { pendingIntent.send() }
+                verify {
+                    pendingIntent.send(
+                        mockContext,
+                        0,
+                        null,
+                        null,
+                        null,
+                        null,
+                        any(),
+                    )
+                }
             }
 
         @Test
@@ -421,7 +432,9 @@ class NotificationProviderImplTest {
             runTest {
                 val pendingIntent =
                     mockk<PendingIntent> {
-                        every { send() } throws PendingIntent.CanceledException()
+                        every {
+                            send(any(), any(), any(), any(), any(), any(), any())
+                        } throws PendingIntent.CanceledException()
                     }
                 val sbn = createMockSbn(key = "key1", contentIntent = pendingIntent)
                 setServiceInstance(sbn)
@@ -548,7 +561,17 @@ class NotificationProviderImplTest {
                 val result = provider.executeAction(actionId)
 
                 assertTrue(result.isSuccess)
-                verify { actionPendingIntent.send() }
+                verify {
+                    actionPendingIntent.send(
+                        mockContext,
+                        0,
+                        null,
+                        null,
+                        null,
+                        null,
+                        any(),
+                    )
+                }
             }
 
         @Test
@@ -586,7 +609,9 @@ class NotificationProviderImplTest {
             runTest {
                 val actionPendingIntent =
                     mockk<PendingIntent> {
-                        every { send() } throws PendingIntent.CanceledException()
+                        every {
+                            send(any(), any(), any(), any(), any(), any(), any())
+                        } throws PendingIntent.CanceledException()
                     }
                 val action =
                     createMockAction(
@@ -633,7 +658,17 @@ class NotificationProviderImplTest {
                 val result = provider.replyToAction(actionId, "Hello")
 
                 assertTrue(result.isSuccess)
-                verify { actionPendingIntent.send(mockContext, 0, any()) }
+                verify {
+                    actionPendingIntent.send(
+                        mockContext,
+                        0,
+                        any<Intent>(),
+                        null,
+                        null,
+                        null,
+                        any(),
+                    )
+                }
             }
 
         @Test
@@ -672,8 +707,9 @@ class NotificationProviderImplTest {
             runTest {
                 val actionPendingIntent =
                     mockk<PendingIntent> {
-                        every { send(any<Context>(), any(), any<android.content.Intent>()) } throws
-                            PendingIntent.CanceledException()
+                        every {
+                            send(any(), any(), any(), any(), any(), any(), any())
+                        } throws PendingIntent.CanceledException()
                     }
                 val remoteInput =
                     mockk<RemoteInput> {


### PR DESCRIPTION
## Summary
- Filter out empty notifications (no title, text, big_text, or actions) from `notification_list` results
- Fix PendingIntent.send() silently failing on Android 14+ due to Background Activity Launch (BAL) restrictions — pass `ActivityOptions` with `MODE_BACKGROUND_ACTIVITY_START_ALLOWED` to `openNotification`, `executeAction`, and `replyToAction`
- Add `.mcp.json` to `.gitignore`

## Test plan
- [x] Unit tests updated for BAL options (7-arg `send()` overload)
- [x] All notification tests pass
- [x] ktlint passes
- [x] Build succeeds
- [x] Verified on-device: notification dismiss works, notification open works with BAL fix