### PR TITLE
Plans 33 & 34: UI reorganization and tool permissions

### DIFF
--- a/docs/plans/33_ui_reorganization_20260303181848.md
+++ b/docs/plans/33_ui_reorganization_20260303181848.md
@@ -1,0 +1,696 @@
+<!-- SACRED DOCUMENT — DO NOT MODIFY except for checkmarks ([ ] → [x]) and review findings. -->
+<!-- You MUST NEVER alter, revert, or delete files outside the scope of this plan. -->
+<!-- Plans in docs/plans/ are PERMANENT artifacts. There are ZERO exceptions. -->
+
+# Plan 33 — UI Reorganization
+
+Replace the single-screen `HomeScreen` layout with a 3-tab structure (Server / Settings / About), where Settings is organized into navigable sub-pages. Tool permission management (Plan 34) provides the content for the MCP Tools page; this plan creates a placeholder.
+
+**Implementation ordering constraint**: All leaf screens (ServerScreen, AboutScreen, all 6 settings sub-screens) MUST be created before SettingsScreen (NavHost) and SettingsIndexScreen. SettingsScreen + SettingsIndexScreen MUST be created before MainScreen. MainScreen MUST be created before MainActivity.
+
+**Window insets constraint**: All `TopAppBar` instances placed inside screen composables (which render inside `MainScreen`'s `Scaffold` content area) MUST use `windowInsets = WindowInsets(0)` to avoid double-counting the status bar inset that `MainScreen`'s `Scaffold` already handles.
+
+**TopAppBar placement constraint**: TopAppBar MUST be placed outside any `verticalScroll` modifier. Correct structure for all scrollable screens:
+```kotlin
+Column(modifier = modifier.fillMaxSize()) {
+    TopAppBar(title = { ... }, windowInsets = WindowInsets(0))
+    Column(modifier = Modifier.weight(1f).verticalScroll(rememberScrollState())) {
+        // scrollable content
+    }
+}
+```
+
+**hiltViewModel import**: All new files MUST import `androidx.hilt.navigation.compose.hiltViewModel` (NOT the deprecated `androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel`).
+
+---
+
+## User Story 1 — Foundation: navigation-compose + Routes.kt
+
+Add `navigation-compose` as an explicit BOM-managed dependency and define all route constants used throughout the new navigation structure.
+
+**Acceptance criteria:**
+- [ ] `navigation-compose` declared as explicit dependency (BOM-managed, no version pin)
+- [ ] `Routes.kt` sealed classes compile with no errors
+
+### Task 1.1 — Add navigation-compose dependency
+
+**Action — `gradle/libs.versions.toml` modify:**
+Add under the `# Compose` libs section:
+```
+compose-navigation = { group = "androidx.navigation", name = "navigation-compose" }
+```
+
+**Action — `app/build.gradle.kts` modify:**
+Add alongside the other compose dependencies:
+```kotlin
+implementation(libs.compose.navigation)
+```
+
+**DoD:**
+- [ ] `./gradlew :app:dependencies` shows `navigation-compose` as a direct dependency
+
+---
+
+### Task 1.2 — Create route definitions
+
+**Action — `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/navigation/Routes.kt` create:**
+```kotlin
+package com.danielealbano.androidremotecontrolmcp.ui.navigation
+
+sealed class TopLevelRoute(val route: String) {
+    data object Server : TopLevelRoute("server")
+    data object Settings : TopLevelRoute("settings")
+    data object About : TopLevelRoute("about")
+}
+
+sealed class SettingsRoute(val route: String) {
+    data object Index : SettingsRoute("settings/index")
+    data object General : SettingsRoute("settings/general")
+    data object Security : SettingsRoute("settings/security")
+    data object Tunnel : SettingsRoute("settings/tunnel")
+    data object McpTools : SettingsRoute("settings/mcp_tools")
+    data object Permissions : SettingsRoute("settings/permissions")
+    data object Storage : SettingsRoute("settings/storage")
+}
+```
+
+---
+
+## User Story 2 — Fix ConnectionInfoCard: /mcp URLs and always-real-token Copy All
+
+All URLs in the connection info card must end with `/mcp` (the actual MCP endpoint). "Copy All" must always copy the real bearer token regardless of the eye-icon toggle state. A toast must confirm when the content is copied.
+
+**Acceptance criteria:**
+- [ ] URL displayed and copied includes `/mcp` suffix
+- [ ] Tunnel URL displayed and copied includes `/mcp` suffix
+- [ ] "Copy All" connection string always includes the real bearer token (never masked)
+- [ ] "Copy All" connection string format: `URL: <url>/mcp\nBearer Token: <token>` (+ `\nTunnel: <tunnelUrl>/mcp` when tunnel active)
+- [ ] Tests added covering both behaviors
+
+### Task 2.1 — Fix ConnectionInfoCard URLs and Copy All
+
+**Action — `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/components/ConnectionInfoCard.kt` modify:**
+
+```kotlin
+// was: "$scheme://$displayAddress:$port"
+val serverUrl = "$scheme://$displayAddress:$port/mcp"
+
+tunnelUrl?.let { url ->
+    ConnectionInfoRow(label = stringResource(R.string.remote_access_public_url_label), value = "$url/mcp")
+}
+
+// Replace showToken ternary — always use real bearerToken
+val connectionString = buildString {
+    append("URL: $serverUrl")
+    tunnelUrl?.let { append("\nTunnel: $it/mcp") }
+    append("\nBearer Token: $bearerToken")
+}
+```
+
+---
+
+### Task 2.2 — Add ConnectionInfoCard tests
+
+**File**: `app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/ui/components/ConnectionInfoCardTest.kt` (create)
+
+**Setup**: `ComposeContentTestRule` for composable rendering
+
+| Test | Verifies |
+|------|----------|
+| `serverUrl includes mcp suffix` | Displayed URL ends with `/mcp` |
+| `tunnelUrl includes mcp suffix` | Tunnel URL row shows `<tunnelUrl>/mcp` when provided |
+| `copyAll always uses real bearer token` | `onCopyAll` receives real token regardless of eye-icon toggle state |
+| `connectionString format without tunnel` | Format: `URL: .../mcp\nBearer Token: <token>` |
+| `connectionString format with tunnel` | Format: `URL: .../mcp\nTunnel: .../mcp\nBearer Token: <token>` |
+
+**DoD:**
+- [ ] All test cases pass
+
+---
+
+## User Story 3 — Server tab screen
+
+Consolidate server status, connection info, and logs into a dedicated tab screen. The screen is a top-level tab (no back button in TopAppBar).
+
+**Acceptance criteria:**
+- [ ] `ServerStatusCard`, `ConnectionInfoCard`, `ServerLogsSection` all visible in Server tab
+- [ ] Start/stop button works
+- [ ] "Copy All" copies content to clipboard and shows a toast ("Copied to clipboard")
+- [ ] "Share" opens Android share sheet
+
+### Task 3.1 — Create ServerScreen
+
+**Action — `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/ServerScreen.kt` create:**
+
+```kotlin
+@file:Suppress("FunctionNaming", "LongMethod")
+
+package com.danielealbano.androidremotecontrolmcp.ui.screens
+
+@Composable
+fun ServerScreen(
+    modifier: Modifier = Modifier,
+    viewModel: MainViewModel = hiltViewModel(),
+) {
+    val isServerRunning = serverStatus is ServerStatus.Running || serverStatus is ServerStatus.Starting
+    val deviceIp = remember(context) { NetworkUtils.getDeviceIpAddress(context) ?: "N/A" }
+
+    Column(modifier = modifier.fillMaxSize()) {
+        TopAppBar(title = { Text(stringResource(R.string.tab_server)) }, windowInsets = WindowInsets(0))
+        Column(modifier = Modifier.weight(1f).verticalScroll(rememberScrollState()).padding(16.dp)) {
+            ServerStatusCard(...)
+            Spacer(Modifier.height(16.dp))
+            ConnectionInfoCard(
+                ...
+                onCopyAll = { text ->
+                    clipboardManager.setText(AnnotatedString(text))
+                    Toast.makeText(context, R.string.copied_to_clipboard, Toast.LENGTH_SHORT).show()
+                },
+                onShare = { text ->
+                    val intent = Intent(Intent.ACTION_SEND).apply {
+                        type = "text/plain"
+                        putExtra(Intent.EXTRA_TEXT, text)
+                    }
+                    context.startActivity(Intent.createChooser(intent, null))
+                },
+            )
+            Spacer(Modifier.height(16.dp))
+            ServerLogsSection(...)
+        }
+    }
+}
+```
+
+---
+
+## User Story 4 — About tab screen
+
+Display app metadata, author information, and external links. Top-level tab with no back button.
+
+**Acceptance criteria:**
+- [ ] App icon, name, and version displayed
+- [ ] Author: Daniele Salvatore Albano, d.albano@gmail.com, linkedin.com/in/danielesalvatorealbano, x.com/daniele_dll
+- [ ] Links: GitHub Repository, MIT License, Report an Issue — all tappable, open browser or email app
+- [ ] "Open Source • MIT License" footer visible
+
+### Task 4.1 — Create AboutScreen
+
+**Action — `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/AboutScreen.kt` create:**
+
+URLs: GitHub `https://github.com/danielealbano/android-remote-control-mcp`, License `https://github.com/danielealbano/android-remote-control-mcp/blob/main/LICENSE`, Issues `https://github.com/danielealbano/android-remote-control-mcp/issues`
+
+```kotlin
+@Composable
+fun AboutScreen(modifier: Modifier = Modifier) {
+    Column(modifier = modifier.fillMaxSize()) {
+        TopAppBar(title = { Text(stringResource(R.string.tab_about)) }, windowInsets = WindowInsets(0))
+        Column(modifier = Modifier.weight(1f).verticalScroll(rememberScrollState()).padding(16.dp)) {
+            // centered: app icon + name + version (BuildConfig.VERSION_NAME)
+            // HorizontalDivider
+            // author section: name, tappable email, tappable LinkedIn, tappable X
+            // HorizontalDivider
+            // links section: GitHub, License, Issues (each ListItem with tappable modifier)
+            // footer: "Open Source • MIT License"
+        }
+    }
+}
+```
+
+---
+
+## User Story 5 — General settings sub-page
+
+Extract port, binding address, bearer token, auto-start, and device slug from the current `ConfigurationSection` into a focused screen.
+
+**Acceptance criteria:**
+- [ ] Port field validates and saves
+- [ ] Bearer token: hidden/shown with eye icon, generate button, copy button
+- [ ] Binding address selector works
+- [ ] Auto-start toggle works
+- [ ] Device slug field validates and saves
+- [ ] All controls disabled when `serverStatus is Running || Starting`
+- [ ] Back button in TopAppBar
+
+### Task 5.1 — Create GeneralSettingsScreen
+
+**Action — `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/settings/GeneralSettingsScreen.kt` create:**
+
+Content extracted from `ConfigurationSection.kt` (port, binding address, bearer token, auto-start, device slug). All interactive elements `enabled = isEnabled`.
+
+```kotlin
+@Composable
+fun GeneralSettingsScreen(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: MainViewModel = hiltViewModel(),
+) {
+    val isEnabled = serverStatus !is ServerStatus.Running && serverStatus !is ServerStatus.Starting
+
+    Column(modifier = modifier.fillMaxSize()) {
+        TopAppBar(
+            title = { Text(stringResource(R.string.settings_general_title)) },
+            navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null) } },
+            windowInsets = WindowInsets(0),
+        )
+        Column(modifier = Modifier.weight(1f).verticalScroll(rememberScrollState()).padding(16.dp)) {
+            // port, binding address, bearer token, auto-start, device slug content
+        }
+    }
+}
+```
+
+---
+
+## User Story 6 — Security settings sub-page
+
+Extract HTTPS toggle, certificate source, and certificate hostname into a focused screen.
+
+**Acceptance criteria:**
+- [ ] HTTPS toggle, certificate source selector, hostname field functional
+- [ ] Certificate hostname field visible only when `certificateSource == AUTO_GENERATED`
+- [ ] All controls disabled when server running
+- [ ] Back button in TopAppBar
+
+### Task 6.1 — Create SecuritySettingsScreen
+
+**Action — `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/settings/SecuritySettingsScreen.kt` create:**
+
+Content extracted from `ConfigurationSection.kt` (HTTPS/certificate sections only). Same Column + TopAppBar pattern (`windowInsets = WindowInsets(0)`, back button).
+
+```kotlin
+@Composable
+fun SecuritySettingsScreen(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: MainViewModel = hiltViewModel(),
+)
+```
+
+---
+
+## User Story 7 — Tunnel settings sub-page
+
+Extract tunnel configuration from `RemoteAccessSection`.
+
+**Acceptance criteria:**
+- [ ] Tunnel enabled toggle, provider selection, ngrok authtoken/domain fields functional
+- [ ] ngrok-specific fields visible only when `tunnelProvider == NGROK`
+- [ ] All controls disabled when server running
+- [ ] Back button in TopAppBar
+
+### Task 7.1 — Create TunnelSettingsScreen
+
+**Action — `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/settings/TunnelSettingsScreen.kt` create:**
+
+Content extracted from `RemoteAccessSection.kt` (all of it). Same Column + TopAppBar pattern (`windowInsets = WindowInsets(0)`, back button).
+
+```kotlin
+@Composable
+fun TunnelSettingsScreen(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: MainViewModel = hiltViewModel(),
+)
+```
+
+---
+
+## User Story 8 — MCP Tools placeholder sub-page
+
+Creates a navigable placeholder at `SettingsRoute.McpTools`. Plan 34 replaces this with the full tool permissions UI.
+
+**Acceptance criteria:**
+- [ ] Screen navigable from Settings index
+- [ ] Shows placeholder message
+- [ ] Back button works
+
+### Task 8.1 — Create McpToolsSettingsScreen (placeholder)
+
+**Action — `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/settings/McpToolsSettingsScreen.kt` create:**
+
+`@file:Suppress("FunctionNaming")`. TopAppBar (`"MCP Tools"`, back button, `windowInsets = WindowInsets(0)`) + centered `Text("Tool permissions — available in next update")`. No viewModel.
+
+```kotlin
+@Composable
+fun McpToolsSettingsScreen(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+)
+```
+
+---
+
+## User Story 9 — Permissions settings sub-page
+
+Move accessibility, notification, camera, and microphone permission management into its own always-interactive screen.
+
+**Acceptance criteria:**
+- [ ] All permission status indicators and action buttons functional
+- [ ] Controls NOT disabled when server is running (always interactive)
+- [ ] Permission status refreshes on `ON_RESUME` lifecycle event
+- [ ] Back button in TopAppBar
+
+### Task 9.1 — Create PermissionsSettingsScreen
+
+**Action — `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/settings/PermissionsSettingsScreen.kt` create:**
+
+Content extracted from `PermissionsSection.kt`. Same Column + TopAppBar pattern (`windowInsets = WindowInsets(0)`, back button). Include `DisposableEffect(lifecycleOwner)` from `HomeScreen` that calls `viewModel.refreshPermissionStatus(context)` on `ON_RESUME`.
+
+```kotlin
+@Composable
+fun PermissionsSettingsScreen(
+    onBack: () -> Unit,
+    onRequestNotificationPermission: () -> Unit,
+    onRequestCameraPermission: () -> Unit,
+    onRequestMicrophonePermission: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: MainViewModel = hiltViewModel(),
+)
+```
+
+---
+
+## User Story 10 — Storage settings sub-page
+
+Move storage location management and file/download settings into an always-interactive screen. Uses a standalone `SnackbarHost` (NOT a nested `Scaffold`) for error display.
+
+**Acceptance criteria:**
+- [ ] Storage locations list, add/edit/delete dialogs work
+- [ ] Per-location `allowWrite` / `allowDelete` toggles work
+- [ ] File size limit and download timeout fields work (with validation)
+- [ ] Allow HTTP downloads and allow unverified HTTPS certs toggles work
+- [ ] Controls NOT disabled when server is running
+- [ ] Storage errors shown in a snackbar
+- [ ] Back button in TopAppBar
+
+### Task 10.1 — Create StorageSettingsScreen
+
+**Action — `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/settings/StorageSettingsScreen.kt` create:**
+
+Content from `StorageLocationsSection.kt` + three dialogs (add, edit, delete) and `documentTreeLauncher` from `HomeScreen`. Standalone `SnackbarHost` with `Box` layout (no nested `Scaffold`).
+
+```kotlin
+@Composable
+fun StorageSettingsScreen(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: MainViewModel = hiltViewModel(),
+) {
+    val snackbarHostState = remember { SnackbarHostState() }
+    LaunchedEffect(storageError) {
+        storageError?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.clearStorageError()
+        }
+    }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            TopAppBar(
+                title = { Text(stringResource(R.string.settings_storage_title)) },
+                navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null) } },
+                windowInsets = WindowInsets(0),
+            )
+            Column(modifier = Modifier.weight(1f).verticalScroll(rememberScrollState()).padding(16.dp)) {
+                // storage locations list + add button + dialogs
+                // file size limit, download timeout, allow HTTP, allow unverified HTTPS controls
+            }
+        }
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier.align(Alignment.BottomCenter),
+        )
+    }
+}
+```
+
+---
+
+## User Story 11 — Settings index page
+
+Provide a top-level list of 6 settings categories, each tappable to navigate to its sub-screen.
+
+**Acceptance criteria:**
+- [ ] All 6 entries visible with correct icons and labels
+- [ ] Tapping navigates via `onNavigate(route.route)`
+- [ ] No back button (top-level settings entry)
+
+### Task 11.1 — Create SettingsIndexScreen
+
+**Action — `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/settings/SettingsIndexScreen.kt` create:**
+
+```kotlin
+@Composable
+fun SettingsIndexScreen(onNavigate: (String) -> Unit, modifier: Modifier = Modifier) {
+    Column(modifier = modifier.fillMaxSize()) {
+        TopAppBar(title = { Text(stringResource(R.string.tab_settings)) }, windowInsets = WindowInsets(0))
+        Column(modifier = Modifier.weight(1f).verticalScroll(rememberScrollState())) {
+            // 6 ListItem entries
+        }
+    }
+}
+```
+
+Each `ListItem`: `headlineContent` (title), `supportingContent` (subtitle), `leadingContent` (icon in surface container), `trailingContent` (`Icons.AutoMirrored.Filled.KeyboardArrowRight`), `Modifier.clickable { onNavigate(route.route) }`.
+
+| Route | Icon | Title | Subtitle |
+|---|---|---|---|
+| `SettingsRoute.General` | `Icons.Default.Tune` | "General" | "Port, address, token, auto-start" |
+| `SettingsRoute.Security` | `Icons.Default.Lock` | "Security" | "HTTPS, certificate" |
+| `SettingsRoute.Tunnel` | `Icons.Default.Cloud` | "Tunnel" | "Cloudflare, ngrok, downloads" |
+| `SettingsRoute.McpTools` | `Icons.Default.Build` | "MCP Tools" | "Enable or disable tools" |
+| `SettingsRoute.Permissions` | `Icons.Default.AdminPanelSettings` | "Permissions" | "Accessibility, camera, microphone" |
+| `SettingsRoute.Storage` | `Icons.Default.Folder` | "Storage" | "Storage locations, file limits" |
+
+---
+
+## User Story 12 — Settings NavHost container
+
+Wire all 6 settings sub-pages (and index) into a `NavHost` managed by a local `NavController`.
+
+**Acceptance criteria:**
+- [ ] Settings index shown on entry
+- [ ] Tapping a category navigates to its sub-page
+- [ ] Back button/gesture returns to index from any sub-page
+- [ ] Storage and Permissions sub-pages remain interactive when server is running
+
+### Task 12.1 — Create SettingsScreen
+
+**Action — `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/SettingsScreen.kt` create:**
+
+```kotlin
+@Composable
+fun SettingsScreen(
+    onRequestNotificationPermission: () -> Unit,
+    onRequestCameraPermission: () -> Unit,
+    onRequestMicrophonePermission: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: MainViewModel = hiltViewModel(),
+) {
+    val navController = rememberNavController()
+    NavHost(
+        navController = navController,
+        startDestination = SettingsRoute.Index.route,
+        modifier = modifier,
+    ) {
+        composable(SettingsRoute.Index.route) {
+            SettingsIndexScreen(onNavigate = { navController.navigate(it) })
+        }
+        composable(SettingsRoute.General.route) {
+            GeneralSettingsScreen(onBack = { navController.popBackStack() }, viewModel = viewModel)
+        }
+        composable(SettingsRoute.Security.route) {
+            SecuritySettingsScreen(onBack = { navController.popBackStack() }, viewModel = viewModel)
+        }
+        composable(SettingsRoute.Tunnel.route) {
+            TunnelSettingsScreen(onBack = { navController.popBackStack() }, viewModel = viewModel)
+        }
+        composable(SettingsRoute.McpTools.route) {
+            McpToolsSettingsScreen(onBack = { navController.popBackStack() })
+        }
+        composable(SettingsRoute.Permissions.route) {
+            PermissionsSettingsScreen(
+                onBack = { navController.popBackStack() },
+                onRequestNotificationPermission = onRequestNotificationPermission,
+                onRequestCameraPermission = onRequestCameraPermission,
+                onRequestMicrophonePermission = onRequestMicrophonePermission,
+                viewModel = viewModel,
+            )
+        }
+        composable(SettingsRoute.Storage.route) {
+            StorageSettingsScreen(onBack = { navController.popBackStack() }, viewModel = viewModel)
+        }
+    }
+}
+```
+
+---
+
+## User Story 13 — Main 3-tab root screen
+
+Wire `ServerScreen`, `SettingsScreen`, and `AboutScreen` into a bottom-navigation `Scaffold`. Tab state is a `String` route stored in `rememberSaveable` (Strings are `Serializable` and safe for configuration changes).
+
+**Acceptance criteria:**
+- [ ] Three tabs visible; tapping switches content
+- [ ] Selected tab icon/label highlighted
+- [ ] Tab state survives configuration changes (rotation)
+
+### Task 13.1 — Create MainScreen
+
+**Action — `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/MainScreen.kt` create:**
+
+```kotlin
+@Composable
+fun MainScreen(
+    onRequestNotificationPermission: () -> Unit,
+    onRequestCameraPermission: () -> Unit,
+    onRequestMicrophonePermission: () -> Unit,
+    viewModel: MainViewModel = hiltViewModel(),
+) {
+    // Store tab as String route — data object is Serializable but using String is more explicit
+    var selectedTabRoute by rememberSaveable { mutableStateOf(TopLevelRoute.Server.route) }
+
+    Scaffold(
+        bottomBar = {
+            NavigationBar {
+                listOf(
+                    Triple(TopLevelRoute.Server, Icons.Default.Dns, stringResource(R.string.tab_server)),
+                    Triple(TopLevelRoute.Settings, Icons.Default.Settings, stringResource(R.string.tab_settings)),
+                    Triple(TopLevelRoute.About, Icons.Default.Info, stringResource(R.string.tab_about)),
+                ).forEach { (route, icon, label) ->
+                    NavigationBarItem(
+                        selected = selectedTabRoute == route.route,
+                        onClick = { selectedTabRoute = route.route },
+                        icon = { Icon(icon, contentDescription = label) },
+                        label = { Text(label) },
+                    )
+                }
+            }
+        },
+    ) { paddingValues ->
+        when (selectedTabRoute) {
+            TopLevelRoute.Server.route -> ServerScreen(modifier = Modifier.padding(paddingValues))
+            TopLevelRoute.Settings.route -> SettingsScreen(
+                onRequestNotificationPermission = onRequestNotificationPermission,
+                onRequestCameraPermission = onRequestCameraPermission,
+                onRequestMicrophonePermission = onRequestMicrophonePermission,
+                modifier = Modifier.padding(paddingValues),
+                viewModel = viewModel,
+            )
+            TopLevelRoute.About.route -> AboutScreen(modifier = Modifier.padding(paddingValues))
+            else -> ServerScreen(modifier = Modifier.padding(paddingValues))
+        }
+    }
+}
+```
+
+Note: the Scaffold has no `topBar`; each tab screen provides its own `TopAppBar` with `windowInsets = WindowInsets(0)`.
+
+---
+
+## User Story 14 — Wire MainActivity to MainScreen
+
+**Acceptance criteria:**
+- [ ] App launches showing Server tab
+- [ ] Three permission callbacks pass through correctly
+
+### Task 14.1 — Update MainActivity
+
+**Action — `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/MainActivity.kt` modify:**
+
+Replace `HomeScreen(...)` call with `MainScreen(...)`, passing the same three permission callbacks already defined in `MainActivity`.
+
+Update import: change `import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel` → `import androidx.hilt.navigation.compose.hiltViewModel` in any file that still uses the old import.
+
+---
+
+## User Story 15 — Cleanup: delete HomeScreen and superseded components
+
+Remove files whose content has been fully migrated to the new screens.
+
+**Acceptance criteria:**
+- [ ] No remaining references to deleted files
+- [ ] Build succeeds after deletion
+
+### Task 15.1 — Delete superseded UI files
+
+Before deleting, verify zero remaining usages:
+```bash
+grep -r "HomeScreen\|ConfigurationSection\|RemoteAccessSection\|PermissionsSection\|StorageLocationsSection" app/src/main
+```
+
+Delete only if grep returns no results:
+- `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/HomeScreen.kt`
+- `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/components/ConfigurationSection.kt`
+- `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/components/RemoteAccessSection.kt`
+- `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/components/PermissionsSection.kt`
+- `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/components/StorageLocationsSection.kt`
+
+---
+
+### Task 15.2 — Update or remove affected tests
+
+Update any existing tests referencing `HomeScreen`, `ConfigurationSection`, `RemoteAccessSection`, `PermissionsSection`, or `StorageLocationsSection` to reference the new screen composables.
+
+---
+
+## User Story 16 — Quality gates and end-to-end verification
+
+**Acceptance criteria:**
+- [ ] `make lint` passes with zero warnings/errors
+- [ ] `make test-unit` passes (all tests green)
+- [ ] `./gradlew build` succeeds with no warnings
+- [ ] Manual: Server tab shows status, connection info (URLs with `/mcp`), logs
+- [ ] Manual: Copy All copies real bearer token and `/mcp`-suffixed URLs + shows toast
+- [ ] Manual: Settings → General → change port → back → re-enter General → port reflects change
+- [ ] Manual: Settings → Storage → add location → appears in list
+- [ ] Manual: About → tapping GitHub opens browser
+- [ ] Manual: Server running → Settings → General → all controls greyed out
+- [ ] Manual: Server running → Settings → Storage → controls still interactive
+
+### Task 16.1 — Run quality gates
+
+```bash
+make lint-fix
+make lint
+make test-unit
+./gradlew build
+```
+
+Fix any failures before proceeding.
+
+**DoD:**
+- [ ] Lint: zero errors/warnings
+- [ ] Tests: all passing
+- [ ] Build: success
+
+---
+
+### Task 16.2 — Spawn code-reviewer (plan compliance)
+
+After quality gates pass, spawn `code-reviewer` subagent in plan compliance mode to verify the entire implementation matches this plan. Fix all reported issues and re-run until clean.
+
+**DoD:**
+- [ ] `code-reviewer` reports no issues
+
+---
+
+## Review Findings
+
+_Reserved for findings from plan-reviewer._
+
+### Original review findings (addressed in this revision)
+
+**Critical — Fixed:**
+- O33-1/2/3: Forward dependency ordering — fixed by reordering: leaf screens (US3–US10) before SettingsScreen (US12) before MainScreen (US13)
+- T33-7: `Icons.Default.ChevronRight` does not exist — fixed to `Icons.AutoMirrored.Filled.KeyboardArrowRight` in Task 11.1
+- 33-6: `rememberSaveable` with sealed class `data object` — fixed to store String route in Task 13.1
+
+**Warnings/Info — Fixed:**
+- TopAppBar inside scrollable Column — fixed: all screen descriptions now use Column { TopAppBar; Column(weight+scroll) { content } }
+- `windowInsets` double-counting — fixed: `windowInsets = WindowInsets(0)` specified for all inner TopAppBars
+- Nested Scaffold in StorageSettingsScreen — fixed: Task 10.1 uses Box + standalone SnackbarHost
+- AUTH-1 Copy All exposes real token — by design (user confirmed); toast notification added in Task 3.1
+- `hiltViewModel` deprecated import — fixed: `androidx.hilt.navigation.compose.hiltViewModel` specified in Tasks 5.1–13.1 and 14.1
+- `NetworkUtils.getDeviceIpAddress` on every recomposition — fixed: `remember(context)` specified in Task 3.1
+- Missing ConnectionInfoCard tests — fixed: Task 2.2 added

--- a/docs/plans/34_tool_permissions_20260303181848.md
+++ b/docs/plans/34_tool_permissions_20260303181848.md
@@ -1,0 +1,978 @@
+<!-- SACRED DOCUMENT — DO NOT MODIFY except for checkmarks ([ ] → [x]) and review findings. -->
+<!-- You MUST NEVER alter, revert, or delete files outside the scope of this plan. -->
+<!-- Plans in docs/plans/ are PERMANENT artifacts. There are ZERO exceptions. -->
+
+# Plan 34 — MCP Tool Permissions
+
+Add per-tool enable/disable and per-parameter enable/disable configuration. When a tool is disabled it is not registered with the MCP server (invisible to clients). When a parameter is disabled it is: (1) omitted from the tool's `inputSchema` (invisible to clients) AND (2) enforced at execution time (the server forces the disabled default even if a client sends the parameter). Changes take effect on server restart. All settings are persisted in DataStore and configurable via ADB. This plan depends on Plan 33 being implemented first (it replaces the `McpToolsSettingsScreen` placeholder).
+
+Configurable parameters (only these two):
+- `get_screen_state` → `include_screenshot` (boolean, enforced default: `false`)
+- `save_camera_video` → `audio` (boolean, enforced default: `false`)
+
+**Constraint**: `ToolPermissionsConfig` stores and queries BASE tool names (e.g., `"tap"`, `"get_screen_state"`) — without the `deviceSlug` prefix.
+
+---
+
+## User Story 1 — ToolPermissionsConfig data model
+
+Exception-based model avoids enumerating all tools; JSON serialization on the model itself avoids duplication between `SettingsRepositoryImpl` and `AdbConfigHandler`.
+
+**Acceptance criteria:**
+- [ ] `ToolPermissionsConfig` has `disabledTools: Set<String>` and `disabledParams: Map<String, Set<String>>`
+- [ ] Default instance has empty sets (all tools/params enabled)
+- [ ] `isToolEnabled` and `isParamEnabled` return correct values
+- [ ] `toJson()` serializes to JSON string
+- [ ] `fromJson(json)` returns `null` on parse failure
+- [ ] `fromJsonOrDefault(json?)` returns `ToolPermissionsConfig()` on null or parse failure
+
+### Task 1.1 — Create ToolPermissionsConfig
+
+**Action — `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/data/model/ToolPermissionsConfig.kt` create:**
+
+```kotlin
+package com.danielealbano.androidremotecontrolmcp.data.model
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+data class ToolPermissionsConfig(
+    val disabledTools: Set<String> = emptySet(),
+    val disabledParams: Map<String, Set<String>> = emptyMap(),
+) {
+    fun isToolEnabled(toolName: String): Boolean = toolName !in disabledTools
+
+    fun isParamEnabled(toolName: String, paramName: String): Boolean =
+        paramName !in (disabledParams[toolName] ?: emptySet())
+
+    fun toJson(): String =
+        buildJsonObject {
+            put("disabledTools", buildJsonArray { disabledTools.forEach { add(it) } })
+            put(
+                "disabledParams",
+                buildJsonObject {
+                    disabledParams.forEach { (tool, params) ->
+                        put(tool, buildJsonArray { params.forEach { add(it) } })
+                    }
+                },
+            )
+        }.toString()
+
+    companion object {
+        fun fromJson(json: String): ToolPermissionsConfig? =
+            try {
+                val obj = Json.parseToJsonElement(json).jsonObject
+                val disabledTools =
+                    obj["disabledTools"]?.jsonArray
+                        ?.mapNotNull { it.jsonPrimitive.contentOrNull }
+                        ?.toSet()
+                        ?: emptySet()
+                val disabledParams =
+                    obj["disabledParams"]?.jsonObject
+                        ?.mapValues { (_, v) ->
+                            v.jsonArray.mapNotNull { it.jsonPrimitive.contentOrNull }.toSet()
+                        }
+                        ?: emptyMap()
+                ToolPermissionsConfig(disabledTools = disabledTools, disabledParams = disabledParams)
+            } catch (_: kotlinx.serialization.SerializationException) {
+                null
+            } catch (_: IllegalArgumentException) {
+                null
+            } catch (_: IllegalStateException) {
+                null
+            }
+
+        fun fromJsonOrDefault(json: String?): ToolPermissionsConfig =
+            if (json == null) ToolPermissionsConfig() else fromJson(json) ?: ToolPermissionsConfig()
+    }
+}
+```
+
+**DoD:**
+- [ ] File compiles
+
+---
+
+### Task 1.2 — Unit tests for ToolPermissionsConfig
+
+**Action — `app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/data/model/ToolPermissionsConfigTest.kt` create:**
+
+**Setup**: Direct `ToolPermissionsConfig` instantiation; no mocks needed
+
+| Test | Verifies |
+|------|----------|
+| `isToolEnabled returns true for empty disabledTools` | Default config enables all tools |
+| `isToolEnabled returns false when tool is in disabledTools` | Disabled tool correctly reported |
+| `isToolEnabled returns true for unknown tool names` | Stale names silently ignored |
+| `isParamEnabled returns true for empty disabledParams` | Default config enables all params |
+| `isParamEnabled returns false when param is in disabledParams` | Disabled param correctly reported |
+| `isParamEnabled returns true when tool has no entry` | Unrelated tool's params unaffected |
+| `toJson with empty config produces expected JSON` | `ToolPermissionsConfig().toJson()` → `{"disabledTools":[],"disabledParams":{}}` |
+| `toJson and fromJson round-trip` | Serialize then deserialize recovers original config |
+| `fromJson with empty JSON object` | `fromJson("{}")` → `ToolPermissionsConfig()` with empty sets |
+| `fromJson with valid JSON` | Correct config parsed from JSON with disabled tools and params |
+| `fromJson with invalid JSON returns null` | Malformed JSON → `null` |
+| `fromJsonOrDefault with null returns default` | `null` → `ToolPermissionsConfig()` |
+| `fromJsonOrDefault with invalid JSON returns default` | Invalid → `ToolPermissionsConfig()` |
+| `fromJson with unknown extra JSON keys` | Unknown keys ignored, valid fields parsed |
+| `fromJson with partially valid JSON` | Valid `disabledTools` + corrupt `disabledParams` → `null` |
+
+**DoD:**
+- [ ] All test cases pass
+
+---
+
+## User Story 2 — DataStore persistence
+
+Granular `updateToolEnabled` and `updateParamEnabled` methods live on `SettingsRepository` (not ViewModel) to ensure atomic `dataStore.edit {}` without read-then-write race conditions.
+
+**Acceptance criteria:**
+- [ ] `ServerConfig` has `toolPermissionsConfig: ToolPermissionsConfig = ToolPermissionsConfig()`
+- [ ] DataStore key `"tool_permissions"` stores JSON
+- [ ] `updateToolPermissionsConfig`, `updateToolEnabled`, `updateParamEnabled` on `SettingsRepository`
+- [ ] All three update methods are atomic (use `dataStore.edit {}`)
+- [ ] `serverConfig` Flow reflects changes when tool permissions change
+- [ ] Missing/invalid JSON in DataStore falls back to `ToolPermissionsConfig()` (all enabled)
+
+### Task 2.1 — Add toolPermissionsConfig to ServerConfig
+
+**Action — `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/data/model/ServerConfig.kt` modify:**
+
+Add field at end of data class:
+```kotlin
+val toolPermissionsConfig: ToolPermissionsConfig = ToolPermissionsConfig(),
+```
+
+**DoD:**
+- [ ] `ServerConfig` compiles
+
+---
+
+### Task 2.2 — Add tool permission methods to SettingsRepository interface
+
+**Action — `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/data/repository/SettingsRepository.kt` modify:**
+
+```kotlin
+suspend fun updateToolPermissionsConfig(config: ToolPermissionsConfig)
+suspend fun updateToolEnabled(toolName: String, enabled: Boolean)
+suspend fun updateParamEnabled(toolName: String, paramName: String, enabled: Boolean)
+```
+
+**DoD:**
+- [ ] Interface compiles
+
+---
+
+### Task 2.3 — Implement persistence in SettingsRepositoryImpl
+
+**Action — `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/data/repository/SettingsRepositoryImpl.kt` modify:**
+
+Add DataStore key in companion object:
+```kotlin
+private val TOOL_PERMISSIONS_KEY = stringPreferencesKey("tool_permissions")
+```
+
+In the `serverConfig` Flow mapping, read and parse:
+```kotlin
+val toolPermissionsConfig = ToolPermissionsConfig.fromJsonOrDefault(prefs[TOOL_PERMISSIONS_KEY])
+```
+Add `toolPermissionsConfig = toolPermissionsConfig` to the `ServerConfig(...)` constructor call.
+
+Implement the three update methods:
+```kotlin
+override suspend fun updateToolPermissionsConfig(config: ToolPermissionsConfig) {
+    dataStore.edit { prefs ->
+        prefs[TOOL_PERMISSIONS_KEY] = config.toJson()
+    }
+}
+
+override suspend fun updateToolEnabled(toolName: String, enabled: Boolean) {
+    dataStore.edit { prefs ->
+        val current = ToolPermissionsConfig.fromJsonOrDefault(prefs[TOOL_PERMISSIONS_KEY])
+        val updated =
+            if (enabled) {
+                current.copy(disabledTools = current.disabledTools - toolName)
+            } else {
+                current.copy(disabledTools = current.disabledTools + toolName)
+            }
+        prefs[TOOL_PERMISSIONS_KEY] = updated.toJson()
+    }
+}
+
+override suspend fun updateParamEnabled(toolName: String, paramName: String, enabled: Boolean) {
+    dataStore.edit { prefs ->
+        val current = ToolPermissionsConfig.fromJsonOrDefault(prefs[TOOL_PERMISSIONS_KEY])
+        val currentParams = current.disabledParams[toolName] ?: emptySet()
+        val newParams = if (enabled) currentParams - paramName else currentParams + paramName
+        val newDisabledParams =
+            if (newParams.isEmpty()) {
+                current.disabledParams - toolName
+            } else {
+                current.disabledParams + (toolName to newParams)
+            }
+        prefs[TOOL_PERMISSIONS_KEY] = current.copy(disabledParams = newDisabledParams).toJson()
+    }
+}
+```
+
+**DoD:**
+- [ ] Round-trip: write then read `updateToolPermissionsConfig` recovers config
+- [ ] `updateToolEnabled(tool, false)` → tool in `disabledTools`
+- [ ] `updateParamEnabled(tool, param, false)` → param in `disabledParams[tool]`
+- [ ] `updateParamEnabled(tool, param, true)` on last disabled param → key removed from `disabledParams`
+
+---
+
+### Task 2.4 — SettingsRepositoryImpl tests
+
+**Action — existing `SettingsRepositoryImplTest.kt` modify (add test cases):**
+
+| Test | Verifies |
+|------|----------|
+| `updateToolPermissionsConfig with disabled tools persists` | `getServerConfig().first()` reflects disabled tools |
+| `updateToolPermissionsConfig with disabled params persists` | Subsequent read reflects disabled params |
+| `empty config round-trip` | Write `ToolPermissionsConfig()` → read → all sets empty |
+| `corrupt JSON in DataStore falls back to default` | Invalid JSON stored directly → `serverConfig` emits `ToolPermissionsConfig()` |
+| `updateToolEnabled toggle on then off` | `false` then `true` → tool not in `disabledTools` |
+| `updateParamEnabled toggle removes empty key` | `false` then `true` → param removed; key removed from `disabledParams` |
+
+**DoD:**
+- [ ] All new test cases pass
+
+---
+
+### Task 2.5 — ServerConfigTest: add toolPermissionsConfig default test
+
+**Action — existing `ServerConfigTest.kt` modify (add test case in `DefaultValues` nested class):**
+
+| Test | Verifies |
+|------|----------|
+| `default toolPermissionsConfig has empty sets` | `ServerConfig().toolPermissionsConfig == ToolPermissionsConfig()` with empty `disabledTools` and `disabledParams` |
+
+**DoD:**
+- [ ] Test passes
+
+---
+
+## User Story 3 — ADB configurability
+
+Extend `AdbConfigHandler` to accept `tool_permissions` JSON string extra.
+
+**Acceptance criteria:**
+- [ ] `adb shell am broadcast -a ...ADB_CONFIGURE --es tool_permissions '<json>'` updates tool permissions in DataStore
+- [ ] Invalid JSON is rejected with a warning log; existing permissions unchanged
+- [ ] Empty or absent extra is a no-op
+
+### Task 3.1 — Extend AdbConfigHandler
+
+**Action — `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/mcp/AdbConfigHandler.kt` modify:**
+
+Add constant to companion object:
+```kotlin
+internal const val EXTRA_TOOL_PERMISSIONS = "tool_permissions"
+```
+
+Add call in `handleConfigure` after the last existing `apply*` call:
+```kotlin
+applyToolPermissions(intent)
+```
+
+Add implementation:
+```kotlin
+private suspend fun applyToolPermissions(intent: Intent) {
+    val value = intent.getStringExtra(EXTRA_TOOL_PERMISSIONS) ?: return
+    val config = ToolPermissionsConfig.fromJson(value)
+    if (config == null) {
+        Log.w(TAG, "Ignoring invalid tool_permissions JSON")
+        return
+    }
+    settingsRepository.updateToolPermissionsConfig(config)
+    Log.i(
+        TAG,
+        "Tool permissions updated: ${config.disabledTools.size} tools disabled, " +
+            "${config.disabledParams.size} param overrides",
+    )
+}
+```
+
+**DoD:**
+- [ ] `AdbConfigHandler` compiles
+
+---
+
+### Task 3.2 — AdbConfigHandlerTest updates
+
+**Action — existing `AdbConfigHandlerTest.kt` modify (add test cases):**
+
+| Test | Verifies |
+|------|----------|
+| `valid JSON with disabledTools updates config` | `settingsRepository.updateToolPermissionsConfig` called with correct config |
+| `valid JSON with disabledParams updates config` | Correct config passed to repository |
+| `invalid JSON does not update config` | `updateToolPermissionsConfig` NOT called, no exception |
+| `absent tool_permissions extra is no-op` | `updateToolPermissionsConfig` NOT called |
+| `noExtras test includes tool permissions` | Existing `noExtras` test also verifies `updateToolPermissionsConfig` not called |
+
+**DoD:**
+- [ ] All new test cases pass
+- [ ] Existing `noExtras` test updated and still passes
+
+---
+
+## User Story 4 — Tool registration with permissions
+
+Guard tool registrations with `ToolPermissionsConfig`. Conditionally omit configurable parameters from schemas AND enforce defaults at execution time.
+
+**Acceptance criteria:**
+- [ ] Disabled tools not registered (not visible to MCP clients after server restart)
+- [ ] `include_screenshot` absent from `get_screen_state` schema when disabled; execution-time default forced to `false`
+- [ ] `audio` absent from `save_camera_video` schema when disabled; execution-time default forced to `false`
+- [ ] Enabled tools with enabled params are unaffected
+- [ ] All existing integration tests still pass (McpIntegrationTestHelper updated with default `perms`)
+
+### Task 4.1 — Update McpServerService.registerAllTools
+
+**Action — `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/mcp/McpServerService.kt` modify:**
+
+In `startServer()`, pass perms:
+```kotlin
+registerAllTools(sdkServer, toolNamePrefix, config.toolPermissionsConfig)
+```
+
+Update `registerAllTools` signature and all 12 call sites:
+```kotlin
+private fun registerAllTools(
+    server: Server,
+    toolNamePrefix: String,
+    perms: ToolPermissionsConfig,
+) {
+    registerScreenIntrospectionTools(
+        server,
+        treeParser,
+        accessibilityServiceProvider,
+        screenCaptureProvider,
+        compactTreeFormatter,
+        screenshotAnnotator,
+        screenshotEncoder,
+        nodeCache,
+        toolNamePrefix,
+        perms,
+    )
+    registerSystemActionTools(server, actionExecutor, accessibilityServiceProvider, toolNamePrefix, perms)
+    registerTouchActionTools(server, actionExecutor, toolNamePrefix, perms)
+    registerGestureTools(server, actionExecutor, toolNamePrefix, perms)
+    registerElementActionTools(
+        server,
+        treeParser,
+        elementFinder,
+        actionExecutor,
+        accessibilityServiceProvider,
+        nodeCache,
+        toolNamePrefix,
+        perms,
+    )
+    registerTextInputTools(
+        server,
+        treeParser,
+        actionExecutor,
+        accessibilityServiceProvider,
+        typeInputController,
+        nodeCache,
+        toolNamePrefix,
+        perms,
+    )
+    registerUtilityTools(server, treeParser, elementFinder, accessibilityServiceProvider, nodeCache, toolNamePrefix, perms)
+    registerFileTools(server, storageLocationProvider, fileOperationProvider, toolNamePrefix, perms)
+    registerAppManagementTools(server, appManager, toolNamePrefix, perms)
+    registerCameraTools(server, cameraProvider, fileOperationProvider, toolNamePrefix, perms)
+    registerIntentTools(server, intentDispatcher, toolNamePrefix, perms)
+    registerNotificationTools(server, notificationProvider, toolNamePrefix, perms)
+}
+```
+
+**DoD:**
+- [ ] `McpServerService` compiles
+
+---
+
+### Task 4.2 — Add permission guards to all 12 category registration functions
+
+**Action — modify each `register*Tools` top-level function in its respective file:**
+
+Add `perms: ToolPermissionsConfig` as last parameter. Wrap each `.register(server, toolNamePrefix)` call with `if (perms.isToolEnabled(ToolClass.TOOL_NAME))`.
+
+Files (all 12 get the `if` guard in this task; Tasks 4.3/4.4 then modify `GetScreenStateHandler` and `SaveCameraVideoHandler` `register()` calls to add param flags):
+- `registerScreenIntrospectionTools`
+- `registerSystemActionTools`
+- `registerTouchActionTools`
+- `registerGestureTools`
+- `registerElementActionTools`
+- `registerTextInputTools`
+- `registerUtilityTools`
+- `registerFileTools`
+- `registerAppManagementTools`
+- `registerCameraTools`
+- `registerIntentTools`
+- `registerNotificationTools`
+
+Standard pattern:
+```kotlin
+fun registerTouchActionTools(
+    server: Server,
+    actionExecutor: ActionExecutor,
+    toolNamePrefix: String,
+    perms: ToolPermissionsConfig,
+) {
+    if (perms.isToolEnabled(TapTool.TOOL_NAME)) TapTool(actionExecutor).register(server, toolNamePrefix)
+    if (perms.isToolEnabled(LongPressTool.TOOL_NAME)) LongPressTool(actionExecutor).register(server, toolNamePrefix)
+    // ... same for all tools in this category
+}
+```
+
+**DoD:**
+- [ ] All 12 functions accept `perms: ToolPermissionsConfig`
+- [ ] All 12 files compile
+
+---
+
+### Task 4.3 — Modify GetScreenStateHandler (conditional schema + execution enforcement)
+
+**Action — `ScreenIntrospectionTools.kt` modify (`GetScreenStateHandler` class):**
+
+Add field:
+```kotlin
+@Volatile private var includeScreenshotEnabled: Boolean = true
+```
+
+Change `register()` to accept flag, conditionally build `ToolSchema`:
+```kotlin
+fun register(
+    server: Server,
+    toolNamePrefix: String,
+    includeScreenshotParamEnabled: Boolean = true,
+) {
+    includeScreenshotEnabled = includeScreenshotParamEnabled
+    server.addTool(
+        name = "$toolNamePrefix$TOOL_NAME",
+        description = "...", // unchanged
+        inputSchema =
+            ToolSchema(
+                properties =
+                    buildJsonObject {
+                        if (includeScreenshotParamEnabled) {
+                            putJsonObject("include_screenshot") {
+                                put("type", "boolean")
+                                put("description", "...") // keep existing description
+                                put("default", false)
+                            }
+                        }
+                    },
+                required = emptyList(),
+            ),
+    ) { request -> execute(request.arguments) }
+}
+```
+
+In `execute()`, enforce disabled default:
+```kotlin
+val includeScreenshot =
+    if (includeScreenshotEnabled) {
+        arguments?.get("include_screenshot")?.jsonPrimitive?.booleanOrNull ?: false
+    } else {
+        false
+    }
+```
+
+Update `registerScreenIntrospectionTools` call site:
+```kotlin
+if (perms.isToolEnabled(GetScreenStateHandler.TOOL_NAME)) {
+    GetScreenStateHandler(
+        treeParser,
+        accessibilityServiceProvider,
+        screenCaptureProvider,
+        compactTreeFormatter,
+        screenshotAnnotator,
+        screenshotEncoder,
+        nodeCache,
+    ).register(
+        server,
+        toolNamePrefix,
+        includeScreenshotParamEnabled = perms.isParamEnabled(GetScreenStateHandler.TOOL_NAME, "include_screenshot"),
+    )
+}
+```
+
+**DoD:**
+- [ ] Schema omits `include_screenshot` when disabled; includes when enabled
+- [ ] Execution forces `false` when disabled regardless of client input
+
+---
+
+### Task 4.4 — Modify SaveCameraVideoHandler (conditional schema + execution enforcement)
+
+**Action — `CameraTools.kt` modify (`SaveCameraVideoHandler` class):**
+
+Add field:
+```kotlin
+@Volatile private var audioParamEnabled: Boolean = true
+```
+
+Change `register()` to accept flag, conditionally include `audio` in `ToolSchema`. All existing properties unchanged; only `audio` is conditional:
+```kotlin
+fun register(
+    server: Server,
+    toolNamePrefix: String,
+    audioParamEnabled: Boolean = true,
+) {
+    this.audioParamEnabled = audioParamEnabled
+    server.addTool(
+        name = "$toolNamePrefix$TOOL_NAME",
+        description = "...", // unchanged
+        inputSchema =
+            ToolSchema(
+                properties =
+                    buildJsonObject {
+                        putJsonObject("camera_id") { /* unchanged */ }
+                        putJsonObject("location_id") { /* unchanged */ }
+                        putJsonObject("path") { /* unchanged */ }
+                        putJsonObject("duration") { /* unchanged */ }
+                        putJsonObject("resolution") { /* unchanged */ }
+                        if (audioParamEnabled) {
+                            putJsonObject("audio") { /* keep existing content */ }
+                        }
+                        putJsonObject("flash_mode") { /* unchanged */ }
+                    },
+                required = listOf("camera_id", "location_id", "path", "duration"),
+            ),
+    ) { request -> execute(request.arguments) }
+}
+```
+
+In `execute()`, enforce disabled default:
+```kotlin
+val audio =
+    if (audioParamEnabled) {
+        McpToolUtils.optionalBoolean(arguments, "audio", true)
+    } else {
+        false
+    }
+```
+
+Update `registerCameraTools` call site:
+```kotlin
+if (perms.isToolEnabled(SaveCameraVideoHandler.TOOL_NAME)) {
+    SaveCameraVideoHandler(cameraProvider, fileOperationProvider).register(
+        server,
+        toolNamePrefix,
+        audioParamEnabled = perms.isParamEnabled(SaveCameraVideoHandler.TOOL_NAME, "audio"),
+    )
+}
+```
+
+**DoD:**
+- [ ] Schema omits `audio` when disabled; includes when enabled
+- [ ] Execution forces `false` when disabled regardless of client input
+
+---
+
+### Task 4.5 — Update McpIntegrationTestHelper
+
+**Action — `app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/McpIntegrationTestHelper.kt` modify:**
+
+Add `perms: ToolPermissionsConfig = ToolPermissionsConfig()` parameter with default to `registerAllTools`, `createSdkServer`, `withTestApplication`, and `withRawTestApplication`. Pass through call chain:
+
+```kotlin
+fun registerAllTools(
+    server: Server,
+    deps: MockDependencies,
+    deviceSlug: String = "",
+    perms: ToolPermissionsConfig = ToolPermissionsConfig(),
+) {
+    val toolNamePrefix = McpToolUtils.buildToolNamePrefix(deviceSlug)
+    registerScreenIntrospectionTools(server, deps.treeParser, ..., toolNamePrefix, perms)
+    // ... all 12 functions with perms as last argument
+}
+
+fun createSdkServer(
+    deps: MockDependencies,
+    deviceSlug: String = "",
+    perms: ToolPermissionsConfig = ToolPermissionsConfig(),
+): Server {
+    // ...
+    registerAllTools(server, deps, deviceSlug, perms)
+    return server
+}
+
+suspend fun withTestApplication(
+    deps: MockDependencies = createMockDependencies(),
+    deviceSlug: String = "",
+    perms: ToolPermissionsConfig = ToolPermissionsConfig(),
+    testBlock: suspend (client: Client, deps: MockDependencies) -> Unit,
+) {
+    val sdkServer = createSdkServer(deps, deviceSlug, perms)
+    // ... rest unchanged
+}
+
+suspend fun withRawTestApplication(
+    deps: MockDependencies = createMockDependencies(),
+    deviceSlug: String = "",
+    perms: ToolPermissionsConfig = ToolPermissionsConfig(),
+    testBlock: suspend ApplicationTestBuilder.(MockDependencies) -> Unit,
+) {
+    val sdkServer = createSdkServer(deps, deviceSlug, perms)
+    // ... rest unchanged
+}
+```
+
+**DoD:**
+- [ ] All existing integration tests compile and pass without modification
+- [ ] `perms` parameter available for new permission tests
+
+---
+
+### Task 4.6 — Integration tests for tool registration with permissions
+
+**Action — `app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/ToolPermissionsIntegrationTest.kt` create:**
+
+**Setup**: `McpIntegrationTestHelper.withTestApplication(perms = ...)` with custom `ToolPermissionsConfig`
+
+| Test | Verifies | Setup |
+|------|----------|-------|
+| `disabled tool absent from tool list` | `listTools()` excludes `tap`, includes `long_press` | `disabledTools = setOf("tap")` |
+| `all tools disabled returns empty tool list` | `listTools()` returns empty | `disabledTools = setOf(<all 53 tool names>)`. **Setup**: derive names from `TOOL_NAME` constants across all handler classes |
+| `include_screenshot absent from schema when disabled` | `get_screen_state` schema has no `include_screenshot` property | `disabledParams = mapOf("get_screen_state" to setOf("include_screenshot"))` |
+| `audio absent from schema when disabled` | `save_camera_video` schema has no `audio` property | `disabledParams = mapOf("save_camera_video" to setOf("audio"))` |
+| `disabled tool call returns error` | `callTool("tap", ...)` returns unknown tool error | `disabledTools = setOf("tap")` |
+| `include_screenshot enforced at execution time` | `callTool("get_screen_state", {"include_screenshot": true})` → `screenCaptureProvider.takeScreenshot()` NOT called | `disabledParams = mapOf("get_screen_state" to setOf("include_screenshot"))`; mock `screenCaptureProvider` |
+| `audio enforced at execution time` | `callTool("save_camera_video", {"audio": true, ...})` → video recorded with `audio=false` | `disabledParams = mapOf("save_camera_video" to setOf("audio"))`; mock `cameraProvider`, verify `audio` arg is `false` |
+
+**DoD:**
+- [ ] All 7 integration tests pass
+
+---
+
+## User Story 5 — MCP Tools settings UI (replaces Plan 33 placeholder)
+
+Replace placeholder `McpToolsSettingsScreen` with full tool permissions UI. All switches disabled when server is running.
+
+**Acceptance criteria:**
+- [ ] All 53 tools displayed in 12 categories with section headers
+- [ ] Each tool has a `Switch`; toggling updates permissions immediately
+- [ ] `get_screen_state` shows `include_screenshot` sub-row when tool enabled; hidden when disabled
+- [ ] `save_camera_video` shows `audio` sub-row when tool enabled; hidden when disabled
+- [ ] All switches disabled (state still displayed) when `serverStatus is Running || Starting`
+- [ ] Static info text: "Changes take effect on server restart"
+- [ ] **Manual QA**: Verify visual layout, spacing, and dark mode rendering on device/emulator
+
+### Task 5.1 — Add updateToolEnabled/updateParamEnabled to MainViewModel
+
+**Action — `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/viewmodels/MainViewModel.kt` modify:**
+
+```kotlin
+val toolPermissionsConfig: StateFlow<ToolPermissionsConfig> =
+    settingsRepository.serverConfig
+        .map { it.toolPermissionsConfig }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ToolPermissionsConfig())
+
+fun updateToolEnabled(toolName: String, enabled: Boolean) {
+    viewModelScope.launch {
+        settingsRepository.updateToolEnabled(toolName, enabled)
+    }
+}
+
+fun updateParamEnabled(toolName: String, paramName: String, enabled: Boolean) {
+    viewModelScope.launch {
+        settingsRepository.updateParamEnabled(toolName, paramName, enabled)
+    }
+}
+```
+
+**DoD:**
+- [ ] Compiles
+
+---
+
+### Task 5.2 — MainViewModelTest updates
+
+**Action — existing `MainViewModelTest.kt` modify (add test cases):**
+
+| Test | Verifies |
+|------|----------|
+| `updateToolEnabled false delegates to repository` | `settingsRepository.updateToolEnabled(toolName, false)` called |
+| `updateToolEnabled true delegates to repository` | `settingsRepository.updateToolEnabled(toolName, true)` called |
+| `updateParamEnabled delegates to repository` | `settingsRepository.updateParamEnabled(toolName, paramName, false)` called |
+| `toolPermissionsConfig emits updated config` | StateFlow emits updated config when repository emits new `serverConfig` |
+
+**DoD:**
+- [ ] All new test cases pass
+
+---
+
+### Task 5.3 — Implement full McpToolsSettingsScreen (replace placeholder)
+
+**Action — `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/settings/McpToolsSettingsScreen.kt` modify (replace entire content):**
+
+Top-level constants:
+```kotlin
+private data class ParamEntry(val paramName: String, val displayName: String)
+private data class ToolEntry(val toolName: String, val displayName: String, val params: List<ParamEntry> = emptyList())
+private data class ToolCategory(val header: String, val tools: List<ToolEntry>)
+
+private val ALL_TOOL_CATEGORIES: List<ToolCategory> = listOf(
+    ToolCategory("Screen", listOf(
+        ToolEntry("get_screen_state", "Get screen state", listOf(ParamEntry("include_screenshot", "Include screenshot"))),
+    )),
+    ToolCategory("System", listOf(
+        ToolEntry("press_back", "Press Back"),
+        ToolEntry("press_home", "Press Home"),
+        ToolEntry("press_recents", "Press Recents"),
+        ToolEntry("open_notifications", "Open Notifications"),
+        ToolEntry("open_quick_settings", "Open Quick Settings"),
+        ToolEntry("get_device_logs", "Get Device Logs"),
+    )),
+    ToolCategory("Touch", listOf(
+        ToolEntry("tap", "Tap"),
+        ToolEntry("long_press", "Long Press"),
+        ToolEntry("double_tap", "Double Tap"),
+        ToolEntry("swipe", "Swipe"),
+        ToolEntry("scroll", "Scroll"),
+    )),
+    ToolCategory("Gestures", listOf(
+        ToolEntry("pinch", "Pinch"),
+        ToolEntry("custom_gesture", "Custom Gesture"),
+    )),
+    ToolCategory("Element Actions", listOf(
+        ToolEntry("find_elements", "Find Elements"),
+        ToolEntry("click_element", "Click Element"),
+        ToolEntry("long_click_element", "Long Click Element"),
+        ToolEntry("scroll_to_element", "Scroll to Element"),
+    )),
+    ToolCategory("Text Input", listOf(
+        ToolEntry("type_append_text", "Type Append Text"),
+        ToolEntry("type_insert_text", "Type Insert Text"),
+        ToolEntry("type_replace_text", "Type Replace Text"),
+        ToolEntry("type_clear_text", "Type Clear Text"),
+        ToolEntry("press_key", "Press Key"),
+    )),
+    ToolCategory("Utility", listOf(
+        ToolEntry("get_clipboard", "Get Clipboard"),
+        ToolEntry("set_clipboard", "Set Clipboard"),
+        ToolEntry("wait_for_element", "Wait for Element"),
+        ToolEntry("wait_for_idle", "Wait for Idle"),
+        ToolEntry("get_element_details", "Get Element Details"),
+    )),
+    ToolCategory("File Operations", listOf(
+        ToolEntry("list_storage_locations", "List Storage Locations"),
+        ToolEntry("list_files", "List Files"),
+        ToolEntry("read_file", "Read File"),
+        ToolEntry("write_file", "Write File"),
+        ToolEntry("append_file", "Append File"),
+        ToolEntry("file_replace", "File Replace"),
+        ToolEntry("download_from_url", "Download from URL"),
+        ToolEntry("delete_file", "Delete File"),
+    )),
+    ToolCategory("App Management", listOf(
+        ToolEntry("open_app", "Open App"),
+        ToolEntry("list_apps", "List Apps"),
+        ToolEntry("close_app", "Close App"),
+    )),
+    ToolCategory("Camera", listOf(
+        ToolEntry("list_cameras", "List Cameras"),
+        ToolEntry("list_camera_photo_resolutions", "List Camera Photo Resolutions"),
+        ToolEntry("list_camera_video_resolutions", "List Camera Video Resolutions"),
+        ToolEntry("take_camera_photo", "Take Camera Photo"),
+        ToolEntry("save_camera_photo", "Save Camera Photo"),
+        ToolEntry("save_camera_video", "Save Camera Video", listOf(ParamEntry("audio", "Include audio"))),
+    )),
+    ToolCategory("Intent", listOf(
+        ToolEntry("send_intent", "Send Intent"),
+        ToolEntry("open_uri", "Open URI"),
+    )),
+    ToolCategory("Notifications", listOf(
+        ToolEntry("notification_list", "Notification List"),
+        ToolEntry("notification_open", "Notification Open"),
+        ToolEntry("notification_dismiss", "Notification Dismiss"),
+        ToolEntry("notification_snooze", "Notification Snooze"),
+        ToolEntry("notification_action", "Notification Action"),
+        ToolEntry("notification_reply", "Notification Reply"),
+    )),
+)
+```
+
+Composable:
+```kotlin
+@Composable
+fun McpToolsSettingsScreen(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: MainViewModel = hiltViewModel(),
+) {
+    val serverStatus by viewModel.serverStatus.collectAsStateWithLifecycle()
+    val perms by viewModel.toolPermissionsConfig.collectAsStateWithLifecycle()
+    val isEnabled = serverStatus !is ServerStatus.Running && serverStatus !is ServerStatus.Starting
+
+    Column(modifier = modifier.fillMaxSize()) {
+        TopAppBar(
+            title = { Text("MCP Tools") },
+            navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null) } },
+            windowInsets = WindowInsets(0),
+        )
+        LazyColumn(modifier = Modifier.weight(1f)) {
+            item {
+                Text(
+                    text = "Changes take effect on server restart",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                )
+            }
+            ALL_TOOL_CATEGORIES.forEach { category ->
+                item(key = "header_${category.header}") {
+                    Text(
+                        text = category.header,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.padding(horizontal = 16.dp, top = 16.dp, bottom = 4.dp),
+                    )
+                }
+                items(category.tools, key = { it.toolName }) { tool ->
+                    val toolEnabled = perms.isToolEnabled(tool.toolName)
+                    ListItem(
+                        headlineContent = { Text(tool.displayName) },
+                        trailingContent = {
+                            Switch(
+                                checked = toolEnabled,
+                                onCheckedChange = { viewModel.updateToolEnabled(tool.toolName, it) },
+                                enabled = isEnabled,
+                            )
+                        },
+                    )
+                    if (toolEnabled) {
+                        tool.params.forEach { param ->
+                            ListItem(
+                                headlineContent = { Text(param.displayName) },
+                                modifier = Modifier.padding(start = 32.dp),
+                                trailingContent = {
+                                    Switch(
+                                        checked = perms.isParamEnabled(tool.toolName, param.paramName),
+                                        onCheckedChange = { viewModel.updateParamEnabled(tool.toolName, param.paramName, it) },
+                                        enabled = isEnabled,
+                                    )
+                                },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+**DoD:**
+- [ ] All 53 tools visible in correct categories
+- [ ] Toggles call correct ViewModel methods
+- [ ] All switches disabled when server running
+
+---
+
+## User Story 6 — Quality gates and end-to-end verification
+
+**Acceptance criteria:**
+- [ ] `make lint` passes with zero warnings/errors
+- [ ] `make test-unit` passes (all tests green, including new ones)
+- [ ] `./gradlew build` succeeds with no warnings
+- [ ] **Manual QA**: disable `tap` via UI → restart server → MCP client cannot call `tap` (unknown tool)
+- [ ] **Manual QA**: disable `include_screenshot` via UI → restart server → `get_screen_state` schema has no `include_screenshot` field
+- [ ] **Manual QA**: ADB `--es tool_permissions '{"disabledTools":["tap"]}'` → UI shows `tap` toggled off
+- [ ] **Manual QA**: re-enable tool via UI → restart server → tool accessible again
+
+### Task 6.1 — Run quality gates
+
+```bash
+make lint-fix
+make lint
+make test-unit
+./gradlew build
+```
+
+Fix any failures before proceeding.
+
+**DoD:**
+- [ ] Lint: zero errors/warnings
+- [ ] Tests: all passing
+- [ ] Build: success
+
+---
+
+### Task 6.2 — Spawn code-reviewer
+
+After quality gates pass, spawn `code-reviewer` subagent in plan compliance mode to verify the entire implementation matches this plan. Fix all reported issues and re-run until clean.
+
+**DoD:**
+- [ ] `code-reviewer` reports no issues
+
+---
+
+## Review Findings
+
+_Reserved for findings from `plan-reviewer` and `code-reviewer`._
+
+### Original review findings (addressed in revision 1)
+
+**Critical — Fixed:**
+- T34-1: `SaveCameraVideoTool` → `SaveCameraVideoHandler` — fixed in Tasks 4.4 and 4.2
+- A33-3: `registerFileOperationTools` → `registerFileTools` — fixed in Task 4.2
+- A34-1/2: Architecture mismatch (dropping dep params, using injected fields) — fixed: Tasks 4.1/4.2 keep ALL existing dep params + add `perms` as last param; top-level functions create instances inline
+- 34-15: Architectural mismatch with injected tool fields — fixed: plan now uses the correct top-level function pattern
+- 34-18: `McpIntegrationTestHelper` not updated — fixed: Task 4.5 added
+- 34-24: All existing integration tests would break — fixed: Task 4.5 adds default `perms = ToolPermissionsConfig()`
+
+**Warnings/Info — Fixed:**
+- INPUT-3: Disabled params enforced only at schema level — fixed: Tasks 4.3/4.4 add execution-time enforcement
+- Race condition in `updateToolEnabled`/`updateParamEnabled` — fixed: atomic `dataStore.edit {}` in repository
+- JSON duplication — fixed: `toJson()`/`fromJson()`/`fromJsonOrDefault()` on `ToolPermissionsConfig` companion
+- `Tool.Input` vs `ToolSchema` — fixed: Tasks 4.3/4.4 use `ToolSchema`
+- Missing `ServerConfigTest` for new field — fixed: Task 2.5
+- Missing `noExtras` AdbHandler test update — fixed: Task 3.2
+- Missing all-tools-disabled integration test — fixed: Task 4.6
+- Top-level tool list constant — fixed: Task 5.3
+
+### Revision 2 review findings (rule alignment)
+
+**Critical — Fixed:**
+- S-4: Task 6.2 referenced non-existent `plan-implementation-reviewer` → changed to `code-reviewer` in plan compliance mode
+- A-1: Incorrect import `kotlinx.serialization.json.mapValues` → removed; added `kotlinx.serialization.json.add` (needed for `JsonArrayBuilder.add(String)` extension)
+
+**Warnings — Fixed:**
+- S-2, S-3, Q-3, Q-4, Q-5, Q-6: Test tasks used full code / bullet lists / comment pseudo-code → all converted to compressed table format
+- S-5: Review Findings referenced non-existent subagents → fixed
+- Q-1: Missing `audio` execution-time enforcement test → added Test 7 in Task 4.6
+- A-2, A-3: Mutable `var` fields without `@Volatile` → changed to `@Volatile private var`
+
+**Info — Fixed:**
+- S-6 through S-10, V-1 through V-21: Verbose prose, redundant DoD, redundant notes, preamble code duplication, step descriptions restating code → all trimmed per anti-verbosity rules
+- P-2: `LazyColumn` `items()` lacked `key` parameter → added `key = { it.toolName }` and `key = "header_${category.header}"`
+- Q-7: UI acceptance criteria not mapped → added "Manual QA" labels to US5 and US6
+
+### Revision 3 review findings (verification pass)
+
+**Warnings — Fixed:**
+- S-NEW-1: Task 4.2 ambiguous about special-case handlers → clarified that all 12 get basic `if` guard in Task 4.2; Tasks 4.3/4.4 then modify `register()` calls to add param flags
+- Q-NEW-1/Q-NEW-2: `catch (_: Exception)` in `fromJson()` would trigger detekt `TooGenericExceptionCaught` and `SwallowedException` → replaced with specific exception types (`SerializationException`, `IllegalArgumentException`, `IllegalStateException`)
+
+**Info — Fixed:**
+- S-NEW-2: Task 4.5 abbreviated code omitted `server` as first arg → fixed
+- Q-NEW-3: All-tools-disabled test fragile without derivation strategy → added setup note to derive names from `TOOL_NAME` constants
+
+### Revision 4 review findings (final pass)
+
+**Warnings — Fixed:**
+- Q-3: Missing `fromJson` test for empty JSON object `"{}"` → added test row in Task 1.2
+- Q-4: Missing explicit `toJson` test for empty config → added test row in Task 1.2


### PR DESCRIPTION
## Summary

Add two new implementation plans:

- **Plan 33** — UI reorganization: restructures the settings UI from a single-screen layout into a multi-screen navigation architecture with dedicated screens for each settings category
- **Plan 34** — MCP tool permissions: adds per-tool enable/disable and per-parameter enable/disable configuration, persisted in DataStore and configurable via ADB

## Changes

- `docs/plans/33_ui_reorganization_20260303181848.md` — new plan file
- `docs/plans/34_tool_permissions_20260303181848.md` — new plan file (reviewed through 4 revision passes)

## Testing

- Plan 34 reviewed by `plan-reviewer` subagent across 4 passes (0 CRITICAL, 0 WARNING, 0 INFO remaining)
- Both plans follow the required structure: user stories → tasks → actions with compressed test tables