### PR TITLE
feat: permission warning banner and tunnel subtitle fix

### DIFF
--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/MainScreen.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/MainScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.danielealbano.androidremotecontrolmcp.R
+import com.danielealbano.androidremotecontrolmcp.ui.navigation.SettingsRoute
 import com.danielealbano.androidremotecontrolmcp.ui.navigation.TopLevelRoute
 import com.danielealbano.androidremotecontrolmcp.ui.viewmodels.MainViewModel
 
@@ -32,6 +33,7 @@ fun MainScreen(
     viewModel: MainViewModel = hiltViewModel(),
 ) {
     var selectedTabRoute by rememberSaveable { mutableStateOf(TopLevelRoute.Server.route) }
+    var pendingSettingsRoute by rememberSaveable { mutableStateOf<String?>(null) }
 
     Scaffold(
         bottomBar = {
@@ -52,17 +54,35 @@ fun MainScreen(
         },
     ) { paddingValues ->
         when (selectedTabRoute) {
-            TopLevelRoute.Server.route -> ServerScreen(modifier = Modifier.padding(paddingValues))
+            TopLevelRoute.Server.route ->
+                ServerScreen(
+                    onNavigateToPermissions = {
+                        pendingSettingsRoute = SettingsRoute.Permissions.route
+                        selectedTabRoute = TopLevelRoute.Settings.route
+                    },
+                    modifier = Modifier.padding(paddingValues),
+                    viewModel = viewModel,
+                )
             TopLevelRoute.Settings.route ->
                 SettingsScreen(
                     onRequestNotificationPermission = onRequestNotificationPermission,
                     onRequestCameraPermission = onRequestCameraPermission,
                     onRequestMicrophonePermission = onRequestMicrophonePermission,
+                    pendingRoute = pendingSettingsRoute,
+                    onPendingRouteConsumed = { pendingSettingsRoute = null },
                     modifier = Modifier.padding(paddingValues),
                     viewModel = viewModel,
                 )
             TopLevelRoute.About.route -> AboutScreen(modifier = Modifier.padding(paddingValues))
-            else -> ServerScreen(modifier = Modifier.padding(paddingValues))
+            else ->
+                ServerScreen(
+                    onNavigateToPermissions = {
+                        pendingSettingsRoute = SettingsRoute.Permissions.route
+                        selectedTabRoute = TopLevelRoute.Settings.route
+                    },
+                    modifier = Modifier.padding(paddingValues),
+                    viewModel = viewModel,
+                )
         }
     }
 }

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/ServerScreen.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/ServerScreen.kt
@@ -4,20 +4,30 @@ package com.danielealbano.androidremotecontrolmcp.ui.screens
 
 import android.content.Intent
 import android.widget.Toast
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
@@ -37,6 +47,7 @@ import com.danielealbano.androidremotecontrolmcp.utils.NetworkUtils
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ServerScreen(
+    onNavigateToPermissions: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: MainViewModel = hiltViewModel(),
 ) {
@@ -47,6 +58,19 @@ fun ServerScreen(
     val serverStatus by viewModel.serverStatus.collectAsStateWithLifecycle()
     val serverLogs by viewModel.serverLogs.collectAsStateWithLifecycle()
     val tunnelStatus by viewModel.tunnelStatus.collectAsStateWithLifecycle()
+
+    val isAccessibilityEnabled by viewModel.isAccessibilityEnabled.collectAsStateWithLifecycle()
+    val isNotificationPermissionGranted by viewModel.isNotificationPermissionGranted.collectAsStateWithLifecycle()
+    val isCameraPermissionGranted by viewModel.isCameraPermissionGranted.collectAsStateWithLifecycle()
+    val isMicrophonePermissionGranted by viewModel.isMicrophonePermissionGranted.collectAsStateWithLifecycle()
+    val isNotificationListenerEnabled by viewModel.isNotificationListenerEnabled.collectAsStateWithLifecycle()
+
+    val hasAllPermissions =
+        isAccessibilityEnabled &&
+            isNotificationPermissionGranted &&
+            isCameraPermissionGranted &&
+            isMicrophonePermissionGranted &&
+            isNotificationListenerEnabled
 
     val deviceIp = remember(context) { NetworkUtils.getDeviceIpAddress(context) ?: "N/A" }
     val copiedToClipboardMessage = stringResource(R.string.copied_to_clipboard)
@@ -63,6 +87,11 @@ fun ServerScreen(
                     .verticalScroll(rememberScrollState())
                     .padding(16.dp),
         ) {
+            if (!hasAllPermissions) {
+                PermissionWarningCard(onClick = onNavigateToPermissions)
+                Spacer(Modifier.height(16.dp))
+            }
+
             ServerStatusCard(
                 status = serverStatus,
                 onStartClick = { viewModel.startServer(context) },
@@ -96,6 +125,30 @@ fun ServerScreen(
 
             ServerLogsSection(
                 logs = serverLogs,
+            )
+        }
+    }
+}
+
+@Composable
+private fun PermissionWarningCard(onClick: () -> Unit) {
+    ElevatedCard(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = Icons.Default.Warning,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.error,
+            )
+            Spacer(Modifier.width(12.dp))
+            Text(
+                text = stringResource(R.string.permission_warning_message),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
             )
         }
     }

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/SettingsScreen.kt
@@ -1,8 +1,9 @@
-@file:Suppress("FunctionNaming", "LongMethod")
+@file:Suppress("FunctionNaming", "LongMethod", "LongParameterList")
 
 package com.danielealbano.androidremotecontrolmcp.ui.screens
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.NavHost
@@ -23,10 +24,22 @@ fun SettingsScreen(
     onRequestNotificationPermission: () -> Unit,
     onRequestCameraPermission: () -> Unit,
     onRequestMicrophonePermission: () -> Unit,
+    pendingRoute: String? = null,
+    onPendingRouteConsumed: () -> Unit = {},
     modifier: Modifier = Modifier,
     viewModel: MainViewModel = hiltViewModel(),
 ) {
     val navController = rememberNavController()
+
+    LaunchedEffect(pendingRoute) {
+        if (pendingRoute != null) {
+            navController.navigate(pendingRoute) {
+                launchSingleTop = true
+            }
+            onPendingRouteConsumed()
+        }
+    }
+
     NavHost(
         navController = navController,
         startDestination = SettingsRoute.Index.route,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,7 +24,7 @@
     <string name="settings_security_title">Security</string>
     <string name="settings_security_subtitle">HTTPS, certificate</string>
     <string name="settings_tunnel_title">Tunnel</string>
-    <string name="settings_tunnel_subtitle">Cloudflare, ngrok, downloads</string>
+    <string name="settings_tunnel_subtitle">Cloudflare, ngrok</string>
     <string name="settings_mcp_tools_title">MCP Tools</string>
     <string name="settings_mcp_tools_subtitle">Enable or disable tools</string>
     <string name="settings_mcp_tools_placeholder">Tool permissions — available in next update</string>
@@ -95,6 +95,9 @@
     <string name="permission_camera">Camera</string>
     <string name="permission_microphone">Microphone</string>
     <string name="permission_notification_listener">Notification Listener</string>
+
+    <!-- Permission Warning -->
+    <string name="permission_warning_message">Some permissions are not granted. Tap to review.</string>
 
     <!-- Server Logs -->
     <string name="server_logs_title">Server Logs</string>


### PR DESCRIPTION
## Summary
- Add a permission warning banner on the Server tab that shows when any permission (accessibility, notifications, camera, microphone, notification listener) is not granted. Tapping it navigates directly to Settings → Permissions via cross-tab navigation.
- Fix the Tunnel settings subtitle: removed incorrect "downloads" reference (belongs under Storage).

## Changes
- **ServerScreen**: Added permission state collection, `hasAllPermissions` derived check, and `PermissionWarningCard` composable with `onNavigateToPermissions` callback
- **MainScreen**: Added `pendingSettingsRoute` state for cross-tab navigation (Server → Settings/Permissions)
- **SettingsScreen**: Added `pendingRoute`/`onPendingRouteConsumed` parameters with `LaunchedEffect` for programmatic sub-page navigation
- **strings.xml**: Added `permission_warning_message` string, fixed tunnel subtitle from "Cloudflare, ngrok, downloads" to "Cloudflare, ngrok"

## Test plan
- [x] Lint passes (`make lint`)
- [ ] Verify warning banner appears when permissions are missing
- [ ] Verify tapping the banner navigates to Settings → Permissions
- [ ] Verify banner disappears when all permissions are granted
- [ ] Verify tunnel subtitle no longer mentions "downloads"