### PR TITLE
fix: about screen crash due to unsupported mipmap adaptive icon

### DIFF
--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/AboutScreen.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/AboutScreen.kt
@@ -5,8 +5,10 @@ package com.danielealbano.androidremotecontrolmcp.ui.screens
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -16,6 +18,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
@@ -32,7 +35,9 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -69,11 +74,20 @@ fun AboutScreen(modifier: Modifier = Modifier) {
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Center,
             ) {
-                Image(
-                    painter = painterResource(id = R.mipmap.ic_launcher),
-                    contentDescription = stringResource(R.string.app_name),
-                    modifier = Modifier.size(72.dp),
-                )
+                Box(
+                    modifier =
+                        Modifier
+                            .size(72.dp)
+                            .clip(CircleShape)
+                            .background(colorResource(R.color.ic_launcher_background)),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Image(
+                        painter = painterResource(id = R.drawable.ic_launcher_foreground),
+                        contentDescription = stringResource(R.string.app_name),
+                        modifier = Modifier.size(72.dp),
+                    )
+                }
                 Spacer(Modifier.height(12.dp))
                 Text(
                     text = stringResource(R.string.app_name),


### PR DESCRIPTION
## Summary
- Fixed crash when opening the About screen caused by `painterResource()` being called with `R.mipmap.ic_launcher` (an adaptive icon XML), which is not supported by Compose's `painterResource()`
- Replaced with `R.drawable.ic_launcher_foreground` rendered inside a circular `Box` with the `ic_launcher_background` color, matching the app's launcher icon appearance

## Test plan
- [x] Verified the About screen no longer crashes on the emulator
- [x] Verified the app icon displays correctly (white phone icon on dark green circular background)
- [x] Verified ktlint passes with no warnings or errors
- [x] Verified the debug APK builds successfully