### PR TITLE
fix: force patched netty and commons-compress versions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -212,6 +212,23 @@ dependencies {
     implementation(libs.ktor.network.tls.certificates)
     implementation(libs.ktor.serialization.kotlinx.json)
 
+    // Force patched Netty to fix CVE-2026-33870 (HTTP Request Smuggling)
+    // and CVE-2026-33871 (HTTP/2 CONTINUATION Frame Flood DoS).
+    // Ktor 3.4.2 ships netty 4.2.9 which is vulnerable.
+    constraints {
+        implementation("io.netty:netty-codec-http:4.2.11.Final")
+        implementation("io.netty:netty-codec-http2:4.2.11.Final")
+        implementation("io.netty:netty-handler:4.2.11.Final")
+        implementation("io.netty:netty-common:4.2.11.Final")
+        implementation("io.netty:netty-buffer:4.2.11.Final")
+        implementation("io.netty:netty-transport:4.2.11.Final")
+        implementation("io.netty:netty-codec-base:4.2.11.Final")
+        implementation("io.netty:netty-codec-compression:4.2.11.Final")
+        implementation("io.netty:netty-resolver:4.2.11.Final")
+        implementation("io.netty:netty-transport-native-unix-common:4.2.11.Final")
+        implementation("io.netty:netty-transport-classes-epoll:4.2.11.Final")
+    }
+
     // Certificate generation (Bouncy Castle for self-signed cert with SAN support)
     implementation(libs.bouncy.castle.pkix)
     implementation(libs.bouncy.castle.prov)

--- a/e2e-tests/build.gradle.kts
+++ b/e2e-tests/build.gradle.kts
@@ -26,6 +26,12 @@ dependencies {
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.junit.jupiter)
 
+    // Force patched commons-compress to fix CVE-2024-25710 and CVE-2024-26308.
+    // Testcontainers 1.21.3 ships commons-compress 1.24.0 which is vulnerable.
+    constraints {
+        testImplementation("org.apache.commons:commons-compress:1.27.1")
+    }
+
     // MCP SDK client (Streamable HTTP transport)
     testImplementation(libs.mcp.kotlin.sdk.client)
     testImplementation(libs.ktor.client.cio)


### PR DESCRIPTION
## Summary
- Force **netty 4.2.11.Final** via Gradle dependency constraints to fix CVE-2026-33870 (HTTP Request Smuggling) and CVE-2026-33871 (HTTP/2 CONTINUATION Frame Flood DoS) in the runtime APK. Ktor 3.4.2 (latest) still ships netty 4.2.9.
- Force **commons-compress 1.27.1** in e2e-tests module to fix CVE-2024-25710 and CVE-2024-26308. Testcontainers 1.21.3 still ships 1.24.0.

## Dependabot alerts addressed
| Alert | Package | CVE | Severity | Action |
|-------|---------|-----|----------|--------|
| #22 | netty-codec-http | CVE-2026-33870 | high | **Fixed** — constraint to 4.2.11 |
| #24 | netty-codec-http2 | CVE-2026-33871 | high | **Fixed** — constraint to 4.2.11 |
| #3 | commons-compress | CVE-2024-26308 | medium | **Fixed** — constraint to 1.27.1 |
| #4 | commons-compress | CVE-2024-25710 | medium | **Fixed** — constraint to 1.27.1 |

## Verified via Gradle dependency insight
- `io.netty:netty-codec-http2:4.2.9.Final → 4.2.11.Final` (by constraint)
- `io.netty:netty-codec-http:4.2.9.Final → 4.2.11.Final` (by constraint)
- `org.apache.commons:commons-compress:1.24.0 → 1.27.1` (by constraint)

## Test plan
- [x] `make lint` passes
- [x] `make test-unit` passes (pre-existing NgrokTunnelIntegrationTest config failure excluded)
- [x] Gradle dependency insight confirms upgraded versions