### PR TITLE
fix: force commons-lang3 3.18.0 to resolve CVE-2025-48924

### DIFF
--- a/e2e-tests/build.gradle.kts
+++ b/e2e-tests/build.gradle.kts
@@ -26,10 +26,12 @@ dependencies {
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.junit.jupiter)
 
-    // Force patched commons-compress to fix CVE-2024-25710 and CVE-2024-26308.
-    // Testcontainers 1.21.3 ships commons-compress 1.24.0 which is vulnerable.
+    // Force patched transitive dependencies from Testcontainers 1.21.3:
+    // - commons-compress 1.24.0 → 1.27.1 (CVE-2024-25710, CVE-2024-26308)
+    // - commons-lang3 3.16.0 → 3.18.0 (CVE-2025-48924)
     constraints {
         testImplementation("org.apache.commons:commons-compress:1.27.1")
+        testImplementation("org.apache.commons:commons-lang3:3.18.0")
     }
 
     // MCP SDK client (Streamable HTTP transport)


### PR DESCRIPTION
## Summary
- Force **commons-lang3 3.18.0** via Gradle dependency constraint in e2e-tests module to fix CVE-2025-48924 (Uncontrolled Recursion DoS)
- Transitive dep from commons-compress 1.27.1 (itself constrained from testcontainers 1.21.3)

## Dependabot alert addressed
| Alert | Package | CVE | Severity | Action |
|-------|---------|-----|----------|--------|
| #25 | commons-lang3 | CVE-2025-48924 | medium | **Fixed** — constraint to 3.18.0 |

Note: #3 and #4 (commons-compress) are already resolved to 1.27.1 via existing constraint but Dependabot may not detect Gradle constraints — they should auto-close on next scan or can be dismissed.

## Verified
- `commons-lang3:3.16.0 → 3.18.0` (by constraint)
- `commons-compress:1.24.0 → 1.27.1` (existing constraint still active)
- `make lint` passes

## Test plan
- [x] Gradle dependency insight confirms upgraded version
- [x] Lint passes