### PR TITLE
feat(accessibility): invalidate node cache on settled window transitions

### DIFF
--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/AccessibilityNodeCache.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/AccessibilityNodeCache.kt
@@ -73,8 +73,10 @@ interface AccessibilityNodeCache {
      *
      * Recycling old entries is safe even if a concurrent [get] call holds a reference to a
      * [CachedNode] from the previous map, because [AccessibilityNodeInfo.recycle] is a no-op
-     * on API 33+ (which is this project's minSdk). In practice, this is only called during
-     * service shutdown ([McpAccessibilityService.onDestroy]) when no new requests are served.
+     * on API 33+ (which is this project's minSdk). Called during service shutdown
+     * ([McpAccessibilityService.onDestroy]) and after a settled window transition (soft-keyboard
+     * show/hide, rotation, activity/dialog change) to drop node references whose bounds may have
+     * moved; an in-flight node action keeps using the reference it already resolved.
      */
     fun clear()
 

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/AccessibilityNodeCacheImpl.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/AccessibilityNodeCacheImpl.kt
@@ -18,8 +18,10 @@ import javax.inject.Inject
  * - [get]: reads the current map (no locking).
  * - [clear]: atomically swaps to an empty map AND recycles old entries. Recycling is
  *   safe even with concurrent [get] callers because `AccessibilityNodeInfo.recycle()` is
- *   a no-op on API 33+ (minSdk). In practice, only called during service shutdown
- *   ([McpAccessibilityService.onDestroy]) when no new requests are served.
+ *   a no-op on API 33+ (minSdk). Called on service shutdown
+ *   ([McpAccessibilityService.onDestroy]) and after a settled window transition (soft-keyboard
+ *   show/hide, rotation, activity/dialog change); an in-flight node action keeps using the
+ *   reference it already resolved, so concurrency with [get] is safe regardless of timing.
  *
  * Hilt-injectable as a singleton.
  */

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/CacheInvalidationDebouncer.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/CacheInvalidationDebouncer.kt
@@ -1,0 +1,87 @@
+package com.danielealbano.androidremotecontrolmcp.services.accessibility
+
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * Debounces cache-invalidation requests triggered by accessibility window-structure changes
+ * (soft-keyboard show/hide, screen rotation, activity/dialog transitions).
+ *
+ * During such a transition the framework emits a BURST of events (window added, bounds settled,
+ * content reflowed, ...). Invalidating on every event would thrash the node cache and could clear
+ * it mid-animation while layout bounds are still moving. Instead, each [schedule] call (re)starts
+ * a single timer and [onSettled] runs only once the event stream has been QUIET for
+ * [debounceMillis] — i.e. AFTER the visual change has finished. This is the core guarantee:
+ * exactly one invalidation per settled transition, never one mid-transition.
+ *
+ * Thread-safety: [schedule] and [cancel] are mutually synchronized, so the class is correct even
+ * if invoked off the main thread, although in production accessibility callbacks are delivered on
+ * the main thread.
+ *
+ * @param scope coroutine scope that owns the debounce timer (the accessibility service scope in
+ *   production). Cancelling this scope cancels any pending invalidation.
+ * @param debounceMillis quiet period that must elapse after the most recent [schedule] before
+ *   [onSettled] runs.
+ * @param onSettled invoked once per settled transition, on [scope]'s dispatcher. SHOULD be
+ *   lightweight and non-blocking. Any exception it throws is caught and logged so it can never
+ *   crash the dispatcher thread.
+ */
+class CacheInvalidationDebouncer(
+    private val scope: CoroutineScope,
+    private val debounceMillis: Long,
+    private val onSettled: () -> Unit,
+) {
+    private val lock = Any()
+
+    private var pending: Job? = null
+
+    /**
+     * (Re)starts the debounce timer. Any previously scheduled, not-yet-fired invalidation is
+     * cancelled, so only the LAST [schedule] in a burst results in an invalidation.
+     */
+    fun schedule() {
+        synchronized(lock) {
+            pending?.cancel()
+            pending =
+                scope.launch {
+                    delay(debounceMillis)
+                    runOnSettled()
+                }
+        }
+    }
+
+    /**
+     * Cancels any pending invalidation without firing it. Idempotent and safe to call when
+     * nothing is scheduled.
+     */
+    fun cancel() {
+        synchronized(lock) {
+            pending?.cancel()
+            pending = null
+        }
+    }
+
+    /**
+     * Invokes [onSettled], guarding against a misbehaving callback. [onSettled] runs after
+     * [delay] (the only suspension point) and is itself non-suspending, so coroutine cancellation
+     * cannot surface inside it; any throwable it produces is therefore a genuine callback bug.
+     * It is contained and logged so a throwing callback degrades to "no invalidation this time"
+     * instead of crashing the dispatcher thread.
+     */
+    private fun runOnSettled() {
+        try {
+            onSettled()
+        } catch (
+            @Suppress("TooGenericExceptionCaught") error: Exception,
+        ) {
+            Log.w(TAG, "Cache-invalidation callback threw; ignored to protect the dispatcher", error)
+        }
+    }
+
+    private companion object {
+        const val TAG = "MCP:CacheInvalidationDebouncer"
+    }
+}

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/McpAccessibilityService.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/McpAccessibilityService.kt
@@ -37,6 +37,10 @@ class McpAccessibilityService : AccessibilityService() {
 
     private var serviceScope: CoroutineScope? = null
 
+    private var nodeCache: AccessibilityNodeCache? = null
+
+    private var cacheInvalidationDebouncer: CacheInvalidationDebouncer? = null
+
     @Volatile
     private var currentPackageName: String? = null
 
@@ -47,7 +51,15 @@ class McpAccessibilityService : AccessibilityService() {
         super.onServiceConnected()
 
         instance = this
-        serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+        serviceScope = scope
+        nodeCache = resolveNodeCache()
+        cacheInvalidationDebouncer =
+            CacheInvalidationDebouncer(
+                scope = scope,
+                debounceMillis = CACHE_INVALIDATION_DEBOUNCE_MS,
+                onSettled = { invalidateCache(nodeCache) },
+            )
 
         configureServiceInfo()
 
@@ -72,6 +84,11 @@ class McpAccessibilityService : AccessibilityService() {
                 )
             }
 
+            AccessibilityEvent.TYPE_WINDOWS_CHANGED -> {
+                // Soft-keyboard show/hide and other window add/remove/bounds changes arrive here.
+                Log.d(TAG, "Windows changed (e.g. soft-keyboard show/hide)")
+            }
+
             AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED -> {
                 Log.d(TAG, "Window content changed: package=${event.packageName}")
             }
@@ -80,6 +97,13 @@ class McpAccessibilityService : AccessibilityService() {
                 // Ignored event types
             }
         }
+
+        // A structural window change (keyboard show/hide, rotation, activity/dialog transition)
+        // shifts element bounds. Because cached node ids are derived from bounds, and which
+        // elements are present/actionable also changes, the cached id->node entries become stale.
+        // Schedule a debounced invalidation so the cache is dropped once — and only once — AFTER
+        // the transition settles, so the next node lookup resolves against the live tree.
+        scheduleCacheInvalidationIfNeeded(event.eventType, cacheInvalidationDebouncer)
     }
 
     override fun onInterrupt() {
@@ -89,17 +113,13 @@ class McpAccessibilityService : AccessibilityService() {
     override fun onDestroy() {
         Log.i(TAG, "Accessibility service destroying")
 
-        // Flush the node cache — all AccessibilityNodeInfo references become invalid
-        try {
-            val entryPoint =
-                EntryPointAccessors.fromApplication(
-                    applicationContext,
-                    NodeCacheEntryPoint::class.java,
-                )
-            entryPoint.nodeCache().clear()
-        } catch (e: IllegalStateException) {
-            Log.w(TAG, "Could not flush node cache during destroy", e)
-        }
+        // Stop any pending debounced invalidation before tearing down the scope it runs on.
+        cacheInvalidationDebouncer?.cancel()
+        cacheInvalidationDebouncer = null
+
+        // Flush the node cache — all AccessibilityNodeInfo references become invalid.
+        nodeCache?.clear()
+        nodeCache = null
 
         serviceScope?.cancel()
         serviceScope = null
@@ -218,6 +238,7 @@ class McpAccessibilityService : AccessibilityService() {
         serviceInfo =
             serviceInfo?.apply {
                 eventTypes = AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED or
+                    AccessibilityEvent.TYPE_WINDOWS_CHANGED or
                     AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED
                 feedbackType = AccessibilityServiceInfo.FEEDBACK_GENERIC
                 flags = AccessibilityServiceInfo.FLAG_REPORT_VIEW_IDS or
@@ -229,6 +250,21 @@ class McpAccessibilityService : AccessibilityService() {
             Log.w(TAG, "serviceInfo is null, cannot configure accessibility service settings")
         }
     }
+
+    /**
+     * Resolves the singleton [AccessibilityNodeCache] via Hilt's application entry point.
+     * Returns null (and logs) if Hilt is not initialized, in which case cache invalidation
+     * becomes a no-op rather than crashing the service.
+     */
+    private fun resolveNodeCache(): AccessibilityNodeCache? =
+        try {
+            EntryPointAccessors
+                .fromApplication(applicationContext, NodeCacheEntryPoint::class.java)
+                .nodeCache()
+        } catch (e: IllegalStateException) {
+            Log.w(TAG, "Could not resolve node cache", e)
+            null
+        }
 
     /**
      * Takes a screenshot using AccessibilityService.takeScreenshot() API.
@@ -283,6 +319,16 @@ class McpAccessibilityService : AccessibilityService() {
         private const val SCREENSHOT_TIMEOUT_MS = 5000L
 
         /**
+         * Length of the QUIET GAP (no further window-structure events) that must elapse before the
+         * node cache is invalidated. The debounce timer resets on every event during a transition,
+         * so this value is the silence required *after the last event*, not the total transition
+         * duration. 250ms is an empirically chosen heuristic — long enough that a settling
+         * keyboard/rotation has stopped emitting events, short enough to keep the post-transition
+         * cache fresh quickly. Single tunable constant; validate/adjust against real-device traces.
+         */
+        private const val CACHE_INVALIDATION_DEBOUNCE_MS = 250L
+
+        /**
          * Singleton instance of the accessibility service.
          * Set when the service connects, cleared when it is destroyed.
          * Access from other components to interact with the accessibility tree.
@@ -295,4 +341,46 @@ class McpAccessibilityService : AccessibilityService() {
         var inputMethodInstance: McpInputMethod? = null
             private set
     }
+}
+
+/**
+ * Returns true if [eventType] is a structural window change after which cached node bounds may be
+ * stale and the node cache should be invalidated: [AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED]
+ * (rotation, activity/dialog transition) and [AccessibilityEvent.TYPE_WINDOWS_CHANGED]
+ * (soft-keyboard show/hide, window add/remove).
+ *
+ * Deliberately EXCLUDES [AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED], which fires far too
+ * frequently (e.g. live text, progress bars) to drive cache invalidation without thrashing.
+ *
+ * Top-level and `internal` so the decision can be unit-tested without instantiating the service.
+ */
+internal fun triggersCacheInvalidation(eventType: Int): Boolean =
+    eventType == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED ||
+        eventType == AccessibilityEvent.TYPE_WINDOWS_CHANGED
+
+/**
+ * Schedules a debounced cache invalidation iff [eventType] is a structural window change (see
+ * [triggersCacheInvalidation]). No-op when [debouncer] is null (service not fully connected).
+ *
+ * Top-level and `internal` so the event-to-schedule wiring can be unit-tested without
+ * instantiating the service.
+ */
+internal fun scheduleCacheInvalidationIfNeeded(
+    eventType: Int,
+    debouncer: CacheInvalidationDebouncer?,
+) {
+    if (triggersCacheInvalidation(eventType)) {
+        debouncer?.schedule()
+    }
+}
+
+/**
+ * Clears [cache] if present. The whole-cache drop is the invalidation applied after a settled
+ * window transition; a null [cache] (Hilt entry point unavailable) is a safe no-op.
+ *
+ * Top-level and `internal` so the invalidation behavior can be unit-tested without instantiating
+ * the service.
+ */
+internal fun invalidateCache(cache: AccessibilityNodeCache?) {
+    cache?.clear()
 }

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/CacheInvalidationDebouncerTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/CacheInvalidationDebouncerTest.kt
@@ -1,0 +1,203 @@
+package com.danielealbano.androidremotecontrolmcp.services.accessibility
+
+import android.util.Log
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@DisplayName("CacheInvalidationDebouncer")
+class CacheInvalidationDebouncerTest {
+    @BeforeEach
+    fun setUp() {
+        // The debouncer logs (via android.util.Log) when a callback throws; stub it for the JVM.
+        mockkStatic(Log::class)
+        every { Log.w(any<String>(), any<String>(), any<Throwable>()) } returns 0
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    @DisplayName("fires exactly once after the quiet window elapses")
+    fun `single schedule fires once after the quiet window`() =
+        runTest {
+            var count = 0
+            val debouncer = CacheInvalidationDebouncer(backgroundScope, DEBOUNCE_MS) { count++ }
+
+            debouncer.schedule()
+
+            advanceTimeBy(DEBOUNCE_MS - 1)
+            runCurrent()
+            assertEquals(0, count, "must not fire before the quiet window elapses")
+
+            advanceTimeBy(1)
+            runCurrent()
+            assertEquals(1, count, "fires once the quiet window has elapsed")
+        }
+
+    @Test
+    @DisplayName("a burst of events coalesces into a single invalidation")
+    fun `burst of events coalesces into one invalidation`() =
+        runTest {
+            var count = 0
+            val debouncer = CacheInvalidationDebouncer(backgroundScope, DEBOUNCE_MS) { count++ }
+
+            // Five events, each arriving before the window elapses, must keep resetting the timer.
+            repeat(5) {
+                debouncer.schedule()
+                advanceTimeBy(DEBOUNCE_MS / 2)
+                runCurrent()
+            }
+            assertEquals(0, count, "no invalidation while events keep arriving")
+
+            advanceTimeBy(DEBOUNCE_MS)
+            runCurrent()
+            assertEquals(1, count, "exactly one invalidation after the burst settles")
+
+            advanceTimeBy(DEBOUNCE_MS * 4)
+            runCurrent()
+            assertEquals(1, count, "does not fire again after settling")
+        }
+
+    @Test
+    @DisplayName("an event before the window elapses resets the timer")
+    fun `event before window elapses resets the timer`() =
+        runTest {
+            var count = 0
+            val debouncer = CacheInvalidationDebouncer(backgroundScope, DEBOUNCE_MS) { count++ }
+
+            debouncer.schedule()
+            advanceTimeBy(DEBOUNCE_MS - 10)
+            runCurrent()
+
+            // Second event cancels the first timer and starts a fresh full window.
+            debouncer.schedule()
+            advanceTimeBy(DEBOUNCE_MS - 10)
+            runCurrent()
+            assertEquals(0, count, "reset extends the window; original timer was cancelled")
+
+            advanceTimeBy(10)
+            runCurrent()
+            assertEquals(1, count, "fires once the fresh window elapses")
+        }
+
+    @Test
+    @DisplayName("events separated by more than the window invalidate each time")
+    fun `events separated by more than the window invalidate each time`() =
+        runTest {
+            var count = 0
+            val debouncer = CacheInvalidationDebouncer(backgroundScope, DEBOUNCE_MS) { count++ }
+
+            debouncer.schedule()
+            advanceTimeBy(DEBOUNCE_MS)
+            runCurrent()
+            assertEquals(1, count, "first transition invalidates")
+
+            debouncer.schedule()
+            advanceTimeBy(DEBOUNCE_MS)
+            runCurrent()
+            assertEquals(2, count, "a later, separate transition invalidates again")
+        }
+
+    @Test
+    @DisplayName("cancel before the window elapses prevents invalidation")
+    fun `cancel before window elapses prevents invalidation`() =
+        runTest {
+            var count = 0
+            val debouncer = CacheInvalidationDebouncer(backgroundScope, DEBOUNCE_MS) { count++ }
+
+            debouncer.schedule()
+            advanceTimeBy(DEBOUNCE_MS - 1)
+            runCurrent()
+
+            debouncer.cancel()
+
+            advanceTimeBy(DEBOUNCE_MS * 2)
+            runCurrent()
+            assertEquals(0, count, "cancel drops the pending invalidation")
+        }
+
+    @Test
+    @DisplayName("cancelling the owning scope prevents a pending invalidation")
+    fun `cancelling the scope prevents a pending invalidation`() =
+        runTest {
+            var count = 0
+            val scope = CoroutineScope(StandardTestDispatcher(testScheduler))
+            val debouncer = CacheInvalidationDebouncer(scope, DEBOUNCE_MS) { count++ }
+
+            debouncer.schedule()
+            advanceTimeBy(DEBOUNCE_MS - 1)
+            runCurrent()
+
+            scope.cancel()
+
+            advanceTimeBy(DEBOUNCE_MS * 2)
+            runCurrent()
+            assertEquals(0, count, "scope cancellation cancels the pending timer")
+        }
+
+    @Test
+    @DisplayName("cancel is idempotent and safe with no pending work")
+    fun `cancel is idempotent and safe with no pending work`() =
+        runTest {
+            var count = 0
+            val debouncer = CacheInvalidationDebouncer(backgroundScope, DEBOUNCE_MS) { count++ }
+
+            debouncer.cancel() // nothing scheduled — must not throw
+
+            debouncer.schedule()
+            advanceTimeBy(DEBOUNCE_MS)
+            runCurrent()
+            assertEquals(1, count)
+
+            debouncer.cancel() // after firing
+            debouncer.cancel() // double cancel
+            assertEquals(1, count, "redundant cancels neither throw nor re-fire")
+        }
+
+    @Test
+    @DisplayName("a throwing callback is contained and does not break later scheduling")
+    fun `a throwing onSettled does not propagate and does not break later scheduling`() =
+        runTest {
+            var invocations = 0
+            var throwOnNext = true
+            val debouncer =
+                CacheInvalidationDebouncer(backgroundScope, DEBOUNCE_MS) {
+                    invocations++
+                    if (throwOnNext) {
+                        throwOnNext = false
+                        error("callback boom")
+                    }
+                }
+
+            debouncer.schedule()
+            advanceTimeBy(DEBOUNCE_MS)
+            runCurrent()
+            // If the exception escaped the coroutine it would fail the test scope here.
+            assertEquals(1, invocations, "the throwing invocation ran")
+
+            debouncer.schedule()
+            advanceTimeBy(DEBOUNCE_MS)
+            runCurrent()
+            assertEquals(2, invocations, "debouncer still fires after a callback threw")
+        }
+
+    private companion object {
+        const val DEBOUNCE_MS = 250L
+    }
+}

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/McpAccessibilityServiceTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/McpAccessibilityServiceTest.kt
@@ -1,0 +1,108 @@
+package com.danielealbano.androidremotecontrolmcp.services.accessibility
+
+import android.view.accessibility.AccessibilityEvent
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+@DisplayName("McpAccessibilityService cache-invalidation wiring")
+class McpAccessibilityServiceTest {
+    @Nested
+    @DisplayName("triggersCacheInvalidation")
+    inner class TriggersCacheInvalidation {
+        @Test
+        @DisplayName("window state changed (rotation / activity transition) triggers invalidation")
+        fun `window state changed triggers invalidation`() {
+            assertTrue(triggersCacheInvalidation(AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED))
+        }
+
+        @Test
+        @DisplayName("windows changed (keyboard show / hide) triggers invalidation")
+        fun `windows changed triggers invalidation`() {
+            assertTrue(triggersCacheInvalidation(AccessibilityEvent.TYPE_WINDOWS_CHANGED))
+        }
+
+        @Test
+        @DisplayName("window content changed does NOT trigger invalidation (too frequent)")
+        fun `window content changed does not trigger invalidation`() {
+            assertFalse(triggersCacheInvalidation(AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED))
+        }
+
+        @ParameterizedTest
+        @ValueSource(
+            ints = [
+                AccessibilityEvent.TYPE_VIEW_CLICKED,
+                AccessibilityEvent.TYPE_VIEW_FOCUSED,
+                AccessibilityEvent.TYPE_VIEW_SCROLLED,
+                AccessibilityEvent.TYPE_NOTIFICATION_STATE_CHANGED,
+                AccessibilityEvent.TYPE_VIEW_TEXT_CHANGED,
+            ],
+        )
+        @DisplayName("unrelated event types do NOT trigger invalidation")
+        fun `unrelated event types do not trigger invalidation`(eventType: Int) {
+            assertFalse(triggersCacheInvalidation(eventType))
+        }
+    }
+
+    @Nested
+    @DisplayName("scheduleCacheInvalidationIfNeeded")
+    inner class ScheduleCacheInvalidationIfNeeded {
+        @Test
+        @DisplayName("schedules the debouncer on a triggering event")
+        fun `schedules on a triggering event`() {
+            val debouncer = mockk<CacheInvalidationDebouncer>(relaxed = true)
+
+            scheduleCacheInvalidationIfNeeded(AccessibilityEvent.TYPE_WINDOWS_CHANGED, debouncer)
+
+            verify(exactly = 1) { debouncer.schedule() }
+        }
+
+        @Test
+        @DisplayName("does NOT schedule on a non-triggering event")
+        fun `does not schedule on a non-triggering event`() {
+            val debouncer = mockk<CacheInvalidationDebouncer>(relaxed = true)
+
+            scheduleCacheInvalidationIfNeeded(
+                AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED,
+                debouncer,
+            )
+
+            verify(exactly = 0) { debouncer.schedule() }
+        }
+
+        @Test
+        @DisplayName("is a safe no-op when the debouncer is null")
+        fun `is a safe no-op when the debouncer is null`() {
+            assertDoesNotThrow {
+                scheduleCacheInvalidationIfNeeded(AccessibilityEvent.TYPE_WINDOWS_CHANGED, null)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("invalidateCache")
+    inner class InvalidateCache {
+        @Test
+        @DisplayName("clears the provided cache")
+        fun `clears the provided cache`() {
+            val cache = mockk<AccessibilityNodeCache>(relaxed = true)
+
+            invalidateCache(cache)
+
+            verify(exactly = 1) { cache.clear() }
+        }
+
+        @Test
+        @DisplayName("is a safe no-op when the cache is null")
+        fun `is a safe no-op when the cache is null`() {
+            assertDoesNotThrow { invalidateCache(null) }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Soft-keyboard show/hide, screen rotation, and activity/dialog transitions shift element bounds. Because cached node ids are derived from bounds (and the set of actionable elements changes), the cached `id -> node` entries become stale after such a transition.

This adds **debounced** node-cache invalidation:

- New `CacheInvalidationDebouncer` coalesces the burst of accessibility events a transition emits and fires the invalidation **once**, after the event stream has been quiet for 250ms (i.e. once the transition has settled — never mid-animation).
- `McpAccessibilityService` subscribes to `TYPE_WINDOWS_CHANGED` (soft-keyboard show/hide; rotation/activity already arrive as `TYPE_WINDOW_STATE_CHANGED`), drops the singleton node cache on settle, and tears the debouncer down in `onDestroy`.
- `TYPE_WINDOW_CONTENT_CHANGED` is deliberately **excluded** from triggering invalidation (too frequent — would thrash).

Invalidation is safe with in-flight node actions: `AccessibilityNodeInfo.recycle()` is a no-op on API 33+ (minSdk), and the consume path (`ActionExecutorImpl.performNodeAction`) holds its resolved reference locally and has a full tree-walk fallback on cache miss.

## Implementation notes

- `triggersCacheInvalidation`, `scheduleCacheInvalidationIfNeeded`, and `invalidateCache` are extracted as top-level `internal` helpers so the event wiring is unit-testable without instantiating the `AccessibilityService`.
- The debounce interval is a single tunable constant (`CACHE_INVALIDATION_DEBOUNCE_MS = 250L`), documented as the quiet gap required *after the last event*, not the total transition duration.

## Tests

21 new unit tests:
- **Debounce timing** (virtual time): single-fire boundary, burst coalescing, timer reset, separated transitions, explicit cancel, scope cancel, idempotent cancel, and throwing-callback containment.
- **Event-routing predicate + wiring**: `TYPE_WINDOW_STATE_CHANGED`/`TYPE_WINDOWS_CHANGED` trigger, `TYPE_WINDOW_CONTENT_CHANGED` and unrelated events do not; schedule/invalidate helpers incl. null no-op.

## Scope

Relates to #91 (keyboard/rotation staleness). This addresses proactive cache hygiene on window transitions; follow-up improvements (a `dismiss_keyboard` tool and tool-description guidance) are tracked separately.

## Verification

- `ktlint` + `detekt`: clean
- Full app unit + integration suite: green