### PR TITLE
feat(tools): add dismiss_keyboard MCP tool and post-typing guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ make clean
 make test-unit
 ```
 
-Runs JUnit 5 unit tests with MockK for mocking. Tests cover accessibility tree parsing, node finding, screenshot encoding, settings repository, network utilities, and all 55 MCP tool handlers.
+Runs JUnit 5 unit tests with MockK for mocking. Tests cover accessibility tree parsing, node finding, screenshot encoding, settings repository, network utilities, and all 56 MCP tool handlers.
 
 ### Integration Tests
 
@@ -158,7 +158,7 @@ graph TB
         subgraph McpServerService["McpServerService (Foreground Service)"]
             McpServer["McpServer (Ktor)"]
             McpServer -->|"Streamable HTTP /mcp"| SDK["SDK Server (MCP Kotlin SDK)"]
-            SDK -->|"55 MCP Tools"| Tools["Tool Handlers"]
+            SDK -->|"56 MCP Tools"| Tools["Tool Handlers"]
             TunnelMgr["TunnelManager (optional)"]
             TunnelMgr -->|"Cloudflare / ngrok"| PublicURL["Public HTTPS URL"]
         end

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The app runs directly on your Android device (or emulator) and exposes an HTTP s
 - Auto-start on boot
 - Remote access tunnels via Cloudflare Quick Tunnels or ngrok (public HTTPS URL)
 
-### 55 MCP Tools across 13 Categories
+### 56 MCP Tools across 13 Categories
 
 Screen introspection, system actions, touch actions, gestures, node actions, text input, utilities, file operations, app management, camera, intents, notifications, and location.
 
@@ -45,7 +45,7 @@ See [docs/MCP_TOOLS.md](docs/MCP_TOOLS.md) for the full tool reference with inpu
 
 | Feature | This project | [mobile-mcp] | [Android-MCP] | [android-mcp-server] | [adb-mcp] | [droidrun-mcp] |
 |---------|:-:|:-:|:-:|:-:|:-:|:-:|
-| MCP tools | 55 | 21 | 11 | 5 | 10 | 11 |
+| MCP tools | 56 | 21 | 11 | 5 | 10 | 11 |
 | Runs on the phone (no ADB) | :white_check_mark: | :x: | :x: | :x: | :x: | :x: |
 | Action latency | 10-100 ms | 1-4 s | 1-4 s | 1-4 s | 1-4 s | 1-4 s |
 | Works over the internet | :white_check_mark: | :x: | :x: | :x: | :x: | :x: |

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/SystemActionTools.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/SystemActionTools.kt
@@ -613,6 +613,70 @@ class GetDeviceLogsHandler
     }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// dismiss_keyboard
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * MCP tool handler for `dismiss_keyboard`.
+ *
+ * Closes the on-screen soft keyboard if one is open. No-op (and never navigates back) when no
+ * keyboard is visible — see [ActionExecutor.dismissKeyboard].
+ *
+ * **Input**: `{}` (no parameters)
+ * **Output**: text `"Keyboard dismissed"` or `"No keyboard was open"`
+ * **Errors**:
+ *   - PermissionDenied if accessibility service is not enabled
+ *   - ActionFailed if dismissing the keyboard failed
+ */
+class DismissKeyboardHandler
+    @Inject
+    constructor(
+        private val actionExecutor: ActionExecutor,
+        private val accessibilityServiceProvider: AccessibilityServiceProvider,
+    ) {
+        @Suppress("UnusedParameter")
+        suspend fun execute(arguments: JsonObject?): CallToolResult {
+            if (!accessibilityServiceProvider.isReady()) {
+                throw McpToolException.PermissionDenied(
+                    "Accessibility service not enabled. Please enable it in Android Settings > Accessibility.",
+                )
+            }
+
+            val dismissed =
+                actionExecutor.dismissKeyboard().getOrElse { exception ->
+                    throw McpToolException.ActionFailed(
+                        "Dismiss keyboard failed: ${exception.message ?: "Unknown error"}",
+                    )
+                }
+
+            return McpToolUtils.textResult(
+                if (dismissed) "Keyboard dismissed" else "No keyboard was open",
+            )
+        }
+
+        fun register(
+            server: Server,
+            toolNamePrefix: String,
+        ) {
+            server.addTool(
+                name = "$toolNamePrefix$TOOL_NAME",
+                description =
+                    "Closes the on-screen keyboard if open; no-op if none (never navigates back). " +
+                        "Use after typing to reveal elements it covers.",
+                inputSchema =
+                    ToolSchema(
+                        properties = buildJsonObject {},
+                        required = listOf(),
+                    ),
+            ) { request -> execute(request.arguments) }
+        }
+
+        companion object {
+            const val TOOL_NAME = "dismiss_keyboard"
+        }
+    }
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Registration function
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -642,6 +706,9 @@ fun registerSystemActionTools(
     }
     if (perms.isToolEnabled(OpenQuickSettingsHandler.TOOL_NAME)) {
         OpenQuickSettingsHandler(actionExecutor, accessibilityServiceProvider).register(server, toolNamePrefix)
+    }
+    if (perms.isToolEnabled(DismissKeyboardHandler.TOOL_NAME)) {
+        DismissKeyboardHandler(actionExecutor, accessibilityServiceProvider).register(server, toolNamePrefix)
     }
     if (perms.isToolEnabled(GetDeviceLogsHandler.TOOL_NAME)) {
         GetDeviceLogsHandler().register(server, toolNamePrefix)

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/TextInputTools.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/TextInputTools.kt
@@ -45,6 +45,24 @@ private const val ADAPTIVE_DELAY_DECREASE_MS = 25
 private const val ADAPTIVE_DELAY_MAX_MS = 2000
 
 /**
+ * Shared guidance appended to every text-entry tool description: entering text leaves the soft
+ * keyboard open, which can cover lower parts of the screen. [toolNamePrefix] is interpolated so
+ * the referenced tool name matches the server's configured prefix.
+ */
+private fun keyboardOverlayHint(toolNamePrefix: String): String =
+    "Typing leaves the keyboard open and may cover elements; " +
+        "call ${toolNamePrefix}dismiss_keyboard before tapping them."
+
+/**
+ * Standard trailing sentence shared by every text-entry tool description: confirms the
+ * verification behavior and appends the [keyboardOverlayHint]. Kept as one helper so the common
+ * tail stays DRY and does not lengthen each `register` function.
+ */
+private fun verificationAndKeyboardHint(toolNamePrefix: String): String =
+    "Returns the field content after the operation for verification. " +
+        keyboardOverlayHint(toolNamePrefix)
+
+/**
  * Mutex serializing all type tool operations.
  * Prevents concurrent MCP requests from interleaving character commits.
  *
@@ -438,7 +456,7 @@ class TypeAppendTextTool
                         "Maximum text length: $MAX_TEXT_LENGTH characters. " +
                         "For text longer than $MAX_TEXT_LENGTH chars, call this tool multiple times — " +
                         "subsequent calls continue typing at the current cursor position. " +
-                        "Returns the field content after the operation for verification.",
+                        verificationAndKeyboardHint(toolNamePrefix),
                 inputSchema =
                     ToolSchema(
                         properties =
@@ -576,7 +594,7 @@ class TypeInsertTextTool
                     "Type text character by character at a specific position in a text field. " +
                         "Uses natural InputConnection typing (indistinguishable from keyboard input). " +
                         "Maximum text length: $MAX_TEXT_LENGTH characters. " +
-                        "Returns the field content after the operation for verification.",
+                        verificationAndKeyboardHint(toolNamePrefix),
                 inputSchema =
                     ToolSchema(
                         properties =
@@ -783,7 +801,7 @@ class TypeReplaceTextTool
                         "character by character via InputConnection. " +
                         "Maximum new_text length: $MAX_TEXT_LENGTH characters. " +
                         "Returns error if search text is not found. " +
-                        "Returns the field content after the operation for verification.",
+                        verificationAndKeyboardHint(toolNamePrefix),
                 inputSchema =
                     ToolSchema(
                         properties =
@@ -938,7 +956,7 @@ class TypeClearTextTool
                 description =
                     "Clear all text from a field naturally using select-all + delete. " +
                         "Uses InputConnection operations (indistinguishable from user action). " +
-                        "Returns the field content after the operation for verification.",
+                        verificationAndKeyboardHint(toolNamePrefix),
                 inputSchema =
                     ToolSchema(
                         properties =

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/ActionExecutor.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/ActionExecutor.kt
@@ -118,6 +118,17 @@ interface ActionExecutor {
 
     suspend fun openQuickSettings(): Result<Unit>
 
+    /**
+     * Dismisses the on-screen soft keyboard if one is currently open.
+     *
+     * Unlike [pressBack], this is a no-op when no input-method window is visible: the back action
+     * is dispatched only when a keyboard was detected, so it is not used to navigate back.
+     *
+     * @return `Result.success(true)` if a keyboard was open and dismissed,
+     *   `Result.success(false)` if no keyboard was open, or `Result.failure` on error.
+     */
+    suspend fun dismissKeyboard(): Result<Boolean>
+
     suspend fun pinch(
         centerX: Float,
         centerY: Float,

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/ActionExecutorImpl.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/ActionExecutorImpl.kt
@@ -443,6 +443,54 @@ class ActionExecutorImpl
                 "openQuickSettings",
             )
 
+        /**
+         * Dismisses the soft keyboard if an input-method window is currently shown.
+         *
+         * Detects the keyboard via [McpAccessibilityService.getAccessibilityWindows] (an
+         * INPUT_METHOD-type window exists only while the IME is visible) and, if present, sends
+         * GLOBAL_ACTION_BACK — which the system routes to closing the IME first. When no keyboard
+         * is open it returns `false` without performing any action; BACK is dispatched only when
+         * an IME window was detected, so it is not used to navigate back.
+         */
+        override suspend fun dismissKeyboard(): Result<Boolean> {
+            val service =
+                McpAccessibilityService.instance
+                    ?: return Result.failure(
+                        IllegalStateException("Accessibility service is not available"),
+                    )
+
+            val windows = service.getAccessibilityWindows()
+            val keyboardOpen =
+                try {
+                    windows.any {
+                        it.type == android.view.accessibility.AccessibilityWindowInfo.TYPE_INPUT_METHOD
+                    }
+                } finally {
+                    // Recycle all AccessibilityWindowInfo objects for consistency
+                    for (w in windows) {
+                        @Suppress("DEPRECATION")
+                        w.recycle()
+                    }
+                }
+
+            return when {
+                !keyboardOpen -> {
+                    Log.d(TAG, "dismissKeyboard: no input-method window open, nothing to dismiss")
+                    Result.success(false)
+                }
+
+                // A keyboard was detected just above, so BACK closes the IME rather than navigating
+                // back. Reuse the shared helper for uniform success/failure logging, mapping its
+                // Unit success to `true`.
+                else -> {
+                    performGlobalAction(
+                        android.accessibilityservice.AccessibilityService.GLOBAL_ACTION_BACK,
+                        "dismissKeyboard",
+                    ).map { true }
+                }
+            }
+        }
+
         // ─────────────────────────────────────────────────────────────────────────
         // Advanced Gestures
         // ─────────────────────────────────────────────────────────────────────────

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/settings/McpToolsSettingsScreen.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/settings/McpToolsSettingsScreen.kt
@@ -65,6 +65,7 @@ private val ALL_TOOL_CATEGORIES: List<ToolCategory> =
                 ToolEntry("press_recents", "Press Recents"),
                 ToolEntry("open_notifications", "Open Notifications"),
                 ToolEntry("open_quick_settings", "Open Quick Settings"),
+                ToolEntry("dismiss_keyboard", "Dismiss Keyboard"),
                 ToolEntry("get_device_logs", "Get Device Logs"),
             ),
         ),

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/AuthIntegrationTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/AuthIntegrationTest.kt
@@ -106,6 +106,6 @@ class AuthIntegrationTest {
         }
 
     companion object {
-        private const val EXPECTED_TOOL_COUNT = 55
+        private const val EXPECTED_TOOL_COUNT = 56
     }
 }

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/McpProtocolIntegrationTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/McpProtocolIntegrationTest.kt
@@ -35,7 +35,7 @@ class McpProtocolIntegrationTest {
         }
 
     @Test
-    fun `listTools returns all 54 registered tools`() =
+    fun `listTools returns all 56 registered tools`() =
         runTest {
             McpIntegrationTestHelper.withTestApplication { client, _ ->
                 val result = client.listTools()
@@ -135,7 +135,7 @@ class McpProtocolIntegrationTest {
         }
 
     companion object {
-        private const val EXPECTED_TOOL_COUNT = 55
+        private const val EXPECTED_TOOL_COUNT = 56
 
         private val EXPECTED_TOOL_NAMES =
             setOf(
@@ -162,6 +162,7 @@ class McpProtocolIntegrationTest {
                 "android_press_recents",
                 "android_open_notifications",
                 "android_open_quick_settings",
+                "android_dismiss_keyboard",
                 "android_get_device_logs",
                 // Text input
                 "android_type_append_text",

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/SystemActionIntegrationTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/SystemActionIntegrationTest.kt
@@ -52,4 +52,34 @@ class SystemActionIntegrationTest {
                 assertTrue(text.contains("executed successfully"))
             }
         }
+
+    @Test
+    fun `dismiss_keyboard reports dismissal when a keyboard was open`() =
+        runTest {
+            val deps = McpIntegrationTestHelper.createMockDependencies()
+            every { deps.accessibilityServiceProvider.isReady() } returns true
+            coEvery { deps.actionExecutor.dismissKeyboard() } returns Result.success(true)
+
+            McpIntegrationTestHelper.withTestApplication(deps) { client, _ ->
+                val result = client.callTool(name = "android_dismiss_keyboard", arguments = emptyMap())
+                assertNotEquals(true, result.isError)
+                val text = (result.content[0] as TextContent).text
+                assertTrue(text.contains("Keyboard dismissed"))
+            }
+        }
+
+    @Test
+    fun `dismiss_keyboard reports no-op when no keyboard was open`() =
+        runTest {
+            val deps = McpIntegrationTestHelper.createMockDependencies()
+            every { deps.accessibilityServiceProvider.isReady() } returns true
+            coEvery { deps.actionExecutor.dismissKeyboard() } returns Result.success(false)
+
+            McpIntegrationTestHelper.withTestApplication(deps) { client, _ ->
+                val result = client.callTool(name = "android_dismiss_keyboard", arguments = emptyMap())
+                assertNotEquals(true, result.isError)
+                val text = (result.content[0] as TextContent).text
+                assertTrue(text.contains("No keyboard was open"))
+            }
+        }
 }

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/ToolPermissionsIntegrationTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/ToolPermissionsIntegrationTest.kt
@@ -275,6 +275,7 @@ class ToolPermissionsIntegrationTest {
                 "press_recents",
                 "open_notifications",
                 "open_quick_settings",
+                "dismiss_keyboard",
                 "get_device_logs",
                 "pinch",
                 "custom_gesture",

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/SystemActionToolsTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/SystemActionToolsTest.kt
@@ -613,4 +613,64 @@ class SystemActionToolsTest {
                 assertTrue(exception.message!!.contains("ISO 8601"))
             }
     }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // dismiss_keyboard
+    // ─────────────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("DismissKeyboardHandler")
+    inner class DismissKeyboardTests {
+        private lateinit var handler: DismissKeyboardHandler
+
+        @BeforeEach
+        fun setUp() {
+            handler = DismissKeyboardHandler(mockActionExecutor, mockAccessibilityServiceProvider)
+        }
+
+        @Test
+        @DisplayName("returns 'Keyboard dismissed' when a keyboard was open")
+        fun returnsDismissedWhenKeyboardOpen() =
+            runTest {
+                coEvery { mockActionExecutor.dismissKeyboard() } returns Result.success(true)
+
+                val result = handler.execute(null)
+
+                coVerify(exactly = 1) { mockActionExecutor.dismissKeyboard() }
+                assertTextContentResponse(result, "Keyboard dismissed")
+            }
+
+        @Test
+        @DisplayName("returns 'No keyboard was open' when none was open")
+        fun returnsNoOpWhenKeyboardClosed() =
+            runTest {
+                coEvery { mockActionExecutor.dismissKeyboard() } returns Result.success(false)
+
+                val result = handler.execute(null)
+
+                assertTextContentResponse(result, "No keyboard was open")
+            }
+
+        @Test
+        @DisplayName("throws PermissionDenied when service not available")
+        fun throwsPermissionDeniedWhenServiceNotReady() =
+            runTest {
+                every { mockAccessibilityServiceProvider.isReady() } returns false
+                assertThrows<McpToolException.PermissionDenied> { handler.execute(null) }
+            }
+
+        @Test
+        @DisplayName("throws ActionFailed when dismissing fails")
+        fun throwsActionFailedWhenDismissFails() =
+            runTest {
+                coEvery { mockActionExecutor.dismissKeyboard() } returns
+                    Result.failure(RuntimeException("Failed to dismiss keyboard"))
+
+                val exception =
+                    assertThrows<McpToolException.ActionFailed> {
+                        handler.execute(null)
+                    }
+                assertTrue(exception.message!!.contains("Failed to dismiss keyboard"))
+            }
+    }
 }

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/ActionExecutorImplTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/ActionExecutorImplTest.kt
@@ -13,6 +13,7 @@ import io.mockk.spyk
 import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -241,6 +242,102 @@ class ActionExecutorImplTest {
 
                 // Assert
                 assertTrue(result.isFailure)
+            }
+    }
+
+    @Nested
+    @DisplayName("Dismiss keyboard")
+    inner class DismissKeyboard {
+        private fun imeWindow(): AccessibilityWindowInfo =
+            mockk<AccessibilityWindowInfo>(relaxed = true) {
+                every { type } returns AccessibilityWindowInfo.TYPE_INPUT_METHOD
+            }
+
+        private fun appWindow(): AccessibilityWindowInfo =
+            mockk<AccessibilityWindowInfo>(relaxed = true) {
+                every { type } returns AccessibilityWindowInfo.TYPE_APPLICATION
+            }
+
+        @Test
+        @DisplayName("returns failure when service is not available")
+        fun returnsFailureWhenServiceNotAvailable() =
+            runTest {
+                // Arrange: instance left null
+
+                // Act
+                val result = executor.dismissKeyboard()
+
+                // Assert
+                assertTrue(result.isFailure)
+            }
+
+        @Test
+        @DisplayName("dismisses via GLOBAL_ACTION_BACK when an input-method window is open")
+        fun dismissesWhenKeyboardOpen() =
+            runTest {
+                // Arrange
+                setServiceInstance(mockService)
+                every { mockService.getAccessibilityWindows() } returns listOf(appWindow(), imeWindow())
+                every { mockService.performGlobalAction(AccessibilityService.GLOBAL_ACTION_BACK) } returns true
+
+                // Act
+                val result = executor.dismissKeyboard()
+
+                // Assert
+                assertTrue(result.isSuccess)
+                assertEquals(true, result.getOrNull())
+                verify { mockService.performGlobalAction(AccessibilityService.GLOBAL_ACTION_BACK) }
+            }
+
+        @Test
+        @DisplayName("is a no-op (no back) when no input-method window is open")
+        fun noOpWhenKeyboardClosed() =
+            runTest {
+                // Arrange
+                setServiceInstance(mockService)
+                every { mockService.getAccessibilityWindows() } returns listOf(appWindow())
+
+                // Act
+                val result = executor.dismissKeyboard()
+
+                // Assert
+                assertTrue(result.isSuccess)
+                assertEquals(false, result.getOrNull())
+                verify(exactly = 0) { mockService.performGlobalAction(any()) }
+            }
+
+        @Test
+        @DisplayName("returns failure when GLOBAL_ACTION_BACK fails while a keyboard is open")
+        fun returnsFailureWhenBackFails() =
+            runTest {
+                // Arrange
+                setServiceInstance(mockService)
+                every { mockService.getAccessibilityWindows() } returns listOf(imeWindow())
+                every { mockService.performGlobalAction(AccessibilityService.GLOBAL_ACTION_BACK) } returns false
+
+                // Act
+                val result = executor.dismissKeyboard()
+
+                // Assert
+                assertTrue(result.isFailure)
+            }
+
+        @Test
+        @DisplayName("recycles the queried window objects")
+        @Suppress("DEPRECATION")
+        fun recyclesQueriedWindows() =
+            runTest {
+                // Arrange
+                setServiceInstance(mockService)
+                val window = imeWindow()
+                every { mockService.getAccessibilityWindows() } returns listOf(window)
+                every { mockService.performGlobalAction(AccessibilityService.GLOBAL_ACTION_BACK) } returns true
+
+                // Act
+                executor.dismissKeyboard()
+
+                // Assert
+                verify { window.recycle() }
             }
     }
 

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -33,12 +33,12 @@ This document provides a comprehensive reference for all MCP tools available in 
 
 ## Overview
 
-The MCP server exposes 55 tools via the JSON-RPC 2.0 protocol, organized into 13 categories:
+The MCP server exposes 56 tools via the JSON-RPC 2.0 protocol, organized into 13 categories:
 
 | Category | Tools | Plan |
 |----------|-------|------|
 | Screen Introspection | `android_get_screen_state` | 7, 15 |
-| System Actions | `android_press_back`, `android_press_home`, `android_press_recents`, `android_open_notifications`, `android_open_quick_settings`, `android_get_device_logs` | 7 |
+| System Actions | `android_press_back`, `android_press_home`, `android_press_recents`, `android_open_notifications`, `android_open_quick_settings`, `android_dismiss_keyboard`, `android_get_device_logs` | 7 |
 | Touch Actions | `android_tap`, `android_long_press`, `android_double_tap`, `android_swipe`, `android_scroll` | 8 |
 | Gestures | `android_pinch`, `android_custom_gesture` | 8 |
 | Node Actions | `android_find_nodes`, `android_click_node`, `android_long_click_node`, `android_tap_node`, `android_scroll_to_node` | 9, 35 |
@@ -580,6 +580,56 @@ Opens the quick settings panel.
 **Error Cases**:
 - **Permission denied**: Accessibility service not enabled
 - **Action failed**: Action execution failed
+
+---
+
+### `android_dismiss_keyboard`
+
+Closes the on-screen soft keyboard if one is open. No-op (and never navigates back) when no keyboard is visible — unlike `android_press_back`, which would navigate back if no keyboard were shown. Useful after typing to reveal buttons or fields the keyboard may be covering.
+
+**Input Schema**:
+```json
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}
+```
+
+**Request Example**:
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "method": "tools/call",
+  "params": {
+    "name": "android_dismiss_keyboard",
+    "arguments": {}
+  }
+}
+```
+
+**Response Example (Success)**:
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "Keyboard dismissed"
+      }
+    ]
+  }
+}
+```
+
+When no keyboard was open, the response text is `"No keyboard was open"`.
+
+**Error Cases**:
+- **Permission denied**: Accessibility service not enabled
+- **Action failed**: Dismissing the keyboard failed
 
 ---
 

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -191,7 +191,7 @@ Tool errors are returned as `CallToolResult(isError = true)` with an error messa
 
 ## MCP Tools Specification
 
-The MCP server exposes 55 tools across 13 categories. For full JSON-RPC schemas, detailed usage examples, and implementation notes, see [MCP_TOOLS.md](MCP_TOOLS.md).
+The MCP server exposes 56 tools across 13 categories. For full JSON-RPC schemas, detailed usage examples, and implementation notes, see [MCP_TOOLS.md](MCP_TOOLS.md).
 
 > **Tool Naming Convention**: All tool names are prefixed with `android_` by default (e.g., `android_tap`, `android_find_nodes`). When a device slug is configured (e.g., `pixel7`), the prefix becomes `android_pixel7_` (e.g., `android_pixel7_tap`). See [MCP_TOOLS.md](MCP_TOOLS.md) for details.
 
@@ -238,7 +238,7 @@ The MCP server exposes 55 tools across 13 categories. For full JSON-RPC schemas,
 | `android_type_clear_text` | Clear all text from field via select-all + delete | `node_id` (string) | — |
 | `android_press_key` | Press a specific key | `key` (string: ENTER/BACK/DEL/HOME/TAB/SPACE) | — |
 
-### 5. System Action Tools (6 tools)
+### 5. System Action Tools (7 tools)
 
 | Tool | Description | Parameters |
 |------|-------------|------------|
@@ -247,6 +247,7 @@ The MCP server exposes 55 tools across 13 categories. For full JSON-RPC schemas,
 | `android_press_recents` | Open recent apps | None |
 | `android_open_notifications` | Pull down notification shade | None |
 | `android_open_quick_settings` | Open quick settings panel | None |
+| `android_dismiss_keyboard` | Dismiss the on-screen soft keyboard if open | None |
 | `android_get_device_logs` | Retrieve filtered logcat logs | `last_lines` (int, 1-1000, default 100), `since`/`until` (ISO 8601 timestamp), `tag` (string), `level` (string: V/D/I/W/E/F, default D), `package_name` (string) — all optional |
 
 ### 6. Gesture Tools (2 tools)
@@ -762,7 +763,7 @@ All common development tasks are accessible via `make <target>`. Run `make help`
 
 - **[TOOLS.md](TOOLS.md)** — Git branching conventions, commit format, PR creation, GitHub CLI commands, and local CI testing with `act`
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** — Detailed application architecture: component interactions, service lifecycle diagrams, threading model, inter-service communication patterns
-- **[MCP_TOOLS.md](MCP_TOOLS.md)** — Full MCP tools documentation with JSON-RPC schemas, usage examples, error codes, and implementation notes for all 53 tools
+- **[MCP_TOOLS.md](MCP_TOOLS.md)** — Full MCP tools documentation with JSON-RPC schemas, usage examples, error codes, and implementation notes for all 56 tools
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a dedicated **`android_dismiss_keyboard`** MCP tool (System Actions category) that closes the on-screen soft keyboard, plus guidance on the text-entry tools so agents dismiss the keyboard before tapping elements it may be covering.

### Why a dedicated tool (not just `press_back`)
`press_back` is blunt: `GLOBAL_ACTION_BACK` closes the keyboard **only if one is open** — otherwise it navigates back and can pull the agent off the screen. `dismiss_keyboard` first checks for a visible `INPUT_METHOD` window via `getAccessibilityWindows()` and dispatches `GLOBAL_ACTION_BACK` **only when a keyboard is open**, so it is a safe no-op that never navigates back when none is shown.

- Returns `"Keyboard dismissed"` when a keyboard was open, `"No keyboard was open"` otherwise.
- Recycles the queried `AccessibilityWindowInfo` objects (matching the codebase convention).
- Action-only output (server-generated text), so no untrusted-content warning needed.

### Post-typing guidance
A shared hint is appended to `type_append_text`, `type_insert_text`, `type_replace_text`, and `type_clear_text`:
> Typing leaves the keyboard open and may cover elements; call `<prefix>dismiss_keyboard` before tapping them.

## Wiring
- Registered in `registerSystemActionTools`, gated by per-tool permissions (enabled by default).
- Added to the MCP Tools settings screen toggle list.
- Relates to #91 (keyboard overlay) — pairs with the merged node-cache-invalidation change.

## Docs
Tool count updated 55 → 56 across `README.md`, `CONTRIBUTING.md`, `docs/PROJECT.md`, and `docs/MCP_TOOLS.md` (incl. a new tool reference section).

## Tests
- `ActionExecutorImpl.dismissKeyboard`: keyboard open → BACK + `true`; closed → no-op `false` with `verify(exactly=0)`; service unavailable → failure; BACK fails → failure; window recycling verified.
- `DismissKeyboardHandler`: dismissed / no-op / permission-denied / action-failed.
- Integration: tool dispatched over the full MCP stack (dismissed + no-op).
- Tool-count expectations updated to 56.

## Verification
- `ktlint` + `detekt`: clean
- Full app unit + integration suite: green