### PR TITLE
feat(accessibility): collapse WebView nodes in get_screen_state

### DIFF
--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/ScreenIntrospectionTools.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/ScreenIntrospectionTools.kt
@@ -15,6 +15,7 @@ import com.danielealbano.androidremotecontrolmcp.services.accessibility.MultiWin
 import com.danielealbano.androidremotecontrolmcp.services.accessibility.ScreenInfo
 import com.danielealbano.androidremotecontrolmcp.services.accessibility.ScreenStateSnapshot
 import com.danielealbano.androidremotecontrolmcp.services.accessibility.ScreenStateSnapshotCache
+import com.danielealbano.androidremotecontrolmcp.services.accessibility.WebViewNodeMerger
 import com.danielealbano.androidremotecontrolmcp.services.accessibility.WindowData
 import com.danielealbano.androidremotecontrolmcp.services.accessibility.countKeptNodes
 import com.danielealbano.androidremotecontrolmcp.services.accessibility.formatMultiWindowPage
@@ -60,6 +61,7 @@ class GetScreenStateHandler
         private val screenshotEncoder: ScreenshotEncoder,
         private val nodeCache: AccessibilityNodeCache,
         private val screenStateSnapshotCache: ScreenStateSnapshotCache,
+        private val webViewNodeMerger: WebViewNodeMerger,
     ) {
         @Volatile private var includeScreenshotEnabled: Boolean = true
 
@@ -88,7 +90,10 @@ class GetScreenStateHandler
             }
 
         private suspend fun handleFreshRequest(includeScreenshot: Boolean): CallToolResult {
-            val result = getFreshWindows(treeParser, accessibilityServiceProvider, nodeCache)
+            // The node cache (used by element/action tools) is populated by getFreshWindows from the
+            // original tree; the merge only collapses the tree shown to the LLM. Merged anchors keep
+            // their original ids, so taps still resolve.
+            val result = webViewNodeMerger.merge(getFreshWindows(treeParser, accessibilityServiceProvider, nodeCache))
             val screenInfo = accessibilityServiceProvider.getScreenInfo()
             val totalKept = compactTreeFormatter.countKeptNodes(result)
             val totalPages = ceilDiv(totalKept, CompactTreeFormatter.PAGE_SIZE)
@@ -346,6 +351,7 @@ fun registerScreenIntrospectionTools(
     screenshotEncoder: ScreenshotEncoder,
     nodeCache: AccessibilityNodeCache,
     screenStateSnapshotCache: ScreenStateSnapshotCache,
+    webViewNodeMerger: WebViewNodeMerger,
     toolNamePrefix: String,
     perms: ToolPermissionsConfig,
 ) {
@@ -359,6 +365,7 @@ fun registerScreenIntrospectionTools(
             screenshotEncoder,
             nodeCache,
             screenStateSnapshotCache,
+            webViewNodeMerger,
         ).register(
             server,
             toolNamePrefix,

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/AccessibilityTreeParser.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/AccessibilityTreeParser.kt
@@ -37,6 +37,10 @@ data class BoundsData(
  * @property editable Whether the node is an editable text field.
  * @property enabled Whether the node is enabled.
  * @property visible Whether the node is visible to the user.
+ * @property webRole Chromium DOM role from `getExtras()` (e.g., "link", "heading", "article"),
+ *   populated by Chrome and the Android System WebView on every web accessibility node. Null for
+ *   native and Compose nodes. Used to scope WebView node collapsing to web content only.
+ * @property targetUrl Target URL from `getExtras()` for links and images, or null when absent.
  * @property children The child nodes of this node.
  */
 @Serializable
@@ -54,6 +58,8 @@ data class AccessibilityNodeData(
     val editable: Boolean = false,
     val enabled: Boolean = false,
     val visible: Boolean = false,
+    val webRole: String? = null,
+    val targetUrl: String? = null,
     val children: List<AccessibilityNodeData> = emptyList(),
 )
 
@@ -188,6 +194,12 @@ class AccessibilityTreeParser
             val enabled = node.isEnabled
             val visible = isNodeVisible(node)
 
+            // Chromium (Chrome + Android System WebView) populates these extras on every web node.
+            // They are absent on native/Compose nodes, so webRole/targetUrl stay null there.
+            val extras = node.extras
+            val webRole = extras?.getString(EXTRA_KEY_CHROME_ROLE)?.takeIf(String::isNotEmpty)
+            val targetUrl = extras?.getString(EXTRA_KEY_TARGET_URL)?.takeIf(String::isNotEmpty)
+
             // Max depth protection: return current node as leaf without recursing into children
             if (depth >= MAX_TREE_DEPTH) {
                 Log.w(TAG, "Maximum tree depth ($MAX_TREE_DEPTH) reached, truncating subtree")
@@ -207,6 +219,8 @@ class AccessibilityTreeParser
                         editable = editable,
                         enabled = enabled,
                         visible = visible,
+                        webRole = webRole,
+                        targetUrl = targetUrl,
                         children = emptyList(),
                     )
 
@@ -268,6 +282,8 @@ class AccessibilityTreeParser
                     editable = editable,
                     enabled = enabled,
                     visible = visible,
+                    webRole = webRole,
+                    targetUrl = targetUrl,
                     children = children,
                 )
 
@@ -318,6 +334,12 @@ class AccessibilityTreeParser
             private const val ROOT_PARENT_ID = "root"
             private const val HASH_RADIX = 16
             internal const val MAX_TREE_DEPTH = 100
+
+            /** `getExtras()` key holding the Chromium DOM role on web accessibility nodes. */
+            private const val EXTRA_KEY_CHROME_ROLE = "AccessibilityNodeInfo.chromeRole"
+
+            /** `getExtras()` key holding the target URL for web links and images. */
+            private const val EXTRA_KEY_TARGET_URL = "AccessibilityNodeInfo.targetUrl"
 
             /**
              * Extra data key added by Compose's AccessibilityNodeProvider to every

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/CompactTreeFormatter.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/CompactTreeFormatter.kt
@@ -111,8 +111,12 @@ class CompactTreeFormatter
         ) {
             val id = node.id
             val className = simplifyClassName(node.className)
-            val text = sanitizeText(node.text)
-            val desc = sanitizeText(node.contentDescription)
+            // Merged WebView nodes carry content collapsed from many DOM nodes that exists ONLY in
+            // this output (get_node_details reads the original, un-merged node cache). Truncating it
+            // would lose text, so web nodes are never truncated.
+            val truncate = node.webRole == null
+            val text = sanitizeText(node.text, truncate)
+            val desc = sanitizeText(node.contentDescription, truncate)
             val resId = sanitizeResourceId(node.resourceId)
             val bounds =
                 "${node.bounds.left},${node.bounds.top}," +
@@ -225,9 +229,14 @@ class CompactTreeFormatter
          * 1. Replaces tabs, newlines, carriage returns with spaces.
          * 2. Trims whitespace.
          * 3. Returns "-" if null, empty, or whitespace-only after sanitization.
-         * 4. Truncates to [MAX_TEXT_LENGTH] characters with [TRUNCATION_SUFFIX] if exceeded.
+         * 4. Truncates to [MAX_TEXT_LENGTH] characters with [TRUNCATION_SUFFIX] if exceeded,
+         *    UNLESS [truncate] is false (used for merged WebView nodes whose collapsed content
+         *    exists only in this output and must not be lost).
          */
-        internal fun sanitizeText(text: String?): String {
+        internal fun sanitizeText(
+            text: String?,
+            truncate: Boolean = true,
+        ): String {
             val sanitized =
                 text
                     ?.replace('\t', ' ')
@@ -240,7 +249,7 @@ class CompactTreeFormatter
                     NULL_VALUE
                 }
 
-                sanitized.length > MAX_TEXT_LENGTH -> {
+                truncate && sanitized.length > MAX_TEXT_LENGTH -> {
                     sanitized.substring(0, MAX_TEXT_LENGTH) + TRUNCATION_SUFFIX
                 }
 

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/WebViewNodeMerger.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/WebViewNodeMerger.kt
@@ -1,0 +1,260 @@
+package com.danielealbano.androidremotecontrolmcp.services.accessibility
+
+import javax.inject.Inject
+
+/**
+ * Collapses Chromium WebView accessibility subtrees into a far smaller tree WITHOUT losing any
+ * text content or any interactive (tap) target.
+ *
+ * WebViews expose one accessibility node per DOM element, which explodes the node count on
+ * content-heavy pages (a single article list can be thousands of nodes). Chrome and the Android
+ * System WebView populate [AccessibilityNodeData.webRole] (the Chromium DOM role) on every web
+ * node, which lets us scope this collapsing strictly to web content — native and Compose subtrees
+ * (where `webRole` is null) are returned untouched, by reference.
+ *
+ * ## Algorithm (single bottom-up pass = fixpoint)
+ *
+ * Within a web subtree, each node is classified and processed after its children:
+ * - **Anchor** — an interactive node (clickable / long-clickable / editable / scrollable). Always
+ *   kept (it is a tap target). Its text becomes its accessible name plus any descendant content
+ *   not already present in that name. Keeps its original id and bounds, so element actions still
+ *   resolve it.
+ * - **Block** — a semantic block role ([BLOCK_ROLES]: article, listItem, section, figure, …).
+ *   Kept when it carries any content, holding the merged markdown of its non-block descendants.
+ *   Empty blocks are dropped and their kept descendants bubble up.
+ * - **Plain** — everything else (staticText, heading, image, paragraph, genericContainer, …). The
+ *   node itself is removed; its content bubbles up (as markdown) into the nearest kept ancestor and
+ *   its kept descendants are re-parented to that ancestor.
+ *
+ * ## Markdown annotation
+ *
+ * Non-interactive content is annotated with minimal markdown so structure survives the collapse:
+ * `# ` for headings, `- ` for list items, `![alt](url)` for images, `[text](url)` for links. This
+ * is intentionally NOT a full HTML→Markdown conversion.
+ *
+ * ## Invariants (verified by tests)
+ * - **No text is ever dropped**: every text/contentDescription token (and every image URL) present
+ *   in the input survives somewhere in the output.
+ * - **No two interactive nodes are merged together**: every tap target keeps its own node.
+ * - Native / Compose subtrees are returned unchanged (same instances).
+ *
+ * This runs only on the `get_screen_state` output. The node cache used by element/action tools is
+ * populated separately from the original (un-merged) tree, and merged anchors keep their original
+ * ids, so taps and look-ups are unaffected.
+ */
+class WebViewNodeMerger
+    @Inject
+    constructor() {
+        /**
+         * Returns a copy of [result] with every Chromium WebView subtree collapsed. Windows and
+         * native subtrees with no web nodes are returned by reference (no allocation).
+         */
+        fun merge(result: MultiWindowResult): MultiWindowResult {
+            val windows = result.windows
+            var changed = false
+            val newWindows =
+                windows.map { window ->
+                    val newTree = transform(window.tree)
+                    if (newTree !== window.tree) {
+                        changed = true
+                        window.copy(tree = newTree)
+                    } else {
+                        window
+                    }
+                }
+            return if (changed) result.copy(windows = newWindows) else result
+        }
+
+        /**
+         * Walks the native tree until a web-area entry node ([AccessibilityNodeData.webRole] set on a
+         * node whose ancestors are native) is reached, then collapses that subtree via [mergeWebArea].
+         * Native nodes are rebuilt only along paths that actually contain a web area; subtrees with no
+         * web content are returned by reference.
+         */
+        private fun transform(node: AccessibilityNodeData): AccessibilityNodeData {
+            if (node.webRole != null) {
+                return mergeWebArea(node)
+            }
+            // Rebuild native nodes only when a descendant web area was actually collapsed; otherwise
+            // return the same instance (an empty child list maps to no change automatically).
+            var changed = false
+            val newChildren =
+                node.children.map { child ->
+                    val newChild = transform(child)
+                    if (newChild !== child) changed = true
+                    newChild
+                }
+            return if (changed) node.copy(children = newChildren) else node
+        }
+
+        /**
+         * Collapses the web subtree rooted at [webRoot]. The root is retained as the container for the
+         * web area (preserving its position, id and bounds in the overall tree); its kept descendants
+         * become its children and any leftover bubbled-up content is folded into its text so nothing
+         * is lost.
+         */
+        private fun mergeWebArea(webRoot: AccessibilityNodeData): AccessibilityNodeData {
+            val keptChildren = ArrayList<AccessibilityNodeData>()
+            val looseParts = ArrayList<String>()
+            looseParts.add(ownContent(webRoot))
+            for (child in webRoot.children) {
+                val out = walk(child)
+                keptChildren.addAll(out.kept)
+                if (out.looseMarkdown.isNotEmpty()) looseParts.add(out.looseMarkdown)
+            }
+            val containerText = dedupJoin(looseParts)
+            return webRoot.copy(
+                text = containerText.ifEmpty { null },
+                contentDescription = null,
+                children = keptChildren,
+            )
+        }
+
+        /**
+         * Result of collapsing one subtree: the kept nodes to attach to the nearest kept ancestor
+         * (each a fully-collapsed subtree), plus any markdown content that must bubble further up.
+         */
+        private data class WalkOut(
+            val kept: List<AccessibilityNodeData>,
+            val looseMarkdown: String,
+        )
+
+        private fun walk(node: AccessibilityNodeData): WalkOut {
+            val childKept = ArrayList<AccessibilityNodeData>()
+            val childMarkdown = ArrayList<String>()
+            for (child in node.children) {
+                val out = walk(child)
+                childKept.addAll(out.kept)
+                if (out.looseMarkdown.isNotEmpty()) childMarkdown.add(out.looseMarkdown)
+            }
+
+            return when {
+                isInteractive(node) -> {
+                    // Use the role-aware ownContent so an image/link tap target keeps its targetUrl
+                    // (the TSV output carries no URL column, so a plain name would lose it entirely);
+                    // fall back to the plain name for other interactive roles.
+                    val name = ownContent(node).ifEmpty { rawContent(node) }
+                    val text = dedupJoin(listOf(name) + childMarkdown)
+                    val anchor =
+                        node.copy(
+                            text = text.ifEmpty { null },
+                            contentDescription = null,
+                            children = childKept,
+                        )
+                    WalkOut(listOf(anchor), "")
+                }
+
+                node.webRole in BLOCK_ROLES -> {
+                    val text = dedupJoin(listOf(ownContent(node)) + childMarkdown)
+                    if (text.isEmpty()) {
+                        // Empty structural block: drop it, pass its kept descendants upward.
+                        WalkOut(childKept, "")
+                    } else {
+                        val block =
+                            node.copy(
+                                text = text,
+                                contentDescription = null,
+                                children = childKept,
+                            )
+                        WalkOut(listOf(block), "")
+                    }
+                }
+
+                else -> {
+                    // Plain node: remove it; bubble its content up and re-parent its kept descendants.
+                    WalkOut(childKept, dedupJoin(listOf(ownContent(node)) + childMarkdown))
+                }
+            }
+        }
+
+        /** Whether a node is a tap target that must be preserved as its own node. */
+        private fun isInteractive(node: AccessibilityNodeData): Boolean =
+            node.clickable || node.longClickable || node.editable || node.scrollable
+
+        /**
+         * The node's own text/contentDescription, combined so neither is ever dropped (with redundant
+         * token-subset duplicates removed). No markdown decoration — used for interactive accessible
+         * names and as the raw basis for [ownContent].
+         */
+        private fun rawContent(node: AccessibilityNodeData): String =
+            dedupJoin(listOf(node.text.orEmpty().trim(), node.contentDescription.orEmpty().trim()))
+
+        /**
+         * The node's own content as minimal markdown, based on its [AccessibilityNodeData.webRole].
+         * Always preserves every text/contentDescription token; adds the URL for images and links.
+         */
+        private fun ownContent(node: AccessibilityNodeData): String {
+            val base = rawContent(node)
+            val url = node.targetUrl.orEmpty().trim()
+            return when (node.webRole) {
+                ROLE_IMAGE -> if (base.isNotEmpty() || url.isNotEmpty()) "![$base]($url)" else ""
+                ROLE_HEADING -> if (base.isNotEmpty()) "# $base" else ""
+                ROLE_LIST_ITEM -> if (base.isNotEmpty()) "- $base" else ""
+                ROLE_LINK -> if (url.isNotEmpty()) "[$base]($url)" else base
+                else -> base
+            }
+        }
+
+        /**
+         * Joins non-empty [parts] with spaces, skipping any part whose tokens are already entirely
+         * present in earlier parts (Chromium frequently duplicates child text onto a parent's
+         * accessible name). A part is dropped ONLY when every one of its tokens — including
+         * single-character tokens such as digits — is already present, so it can never discard new
+         * content (the worst case is keeping a near-duplicate, never losing text).
+         */
+        private fun dedupJoin(parts: List<String>): String {
+            val seen = HashSet<String>()
+            val out = ArrayList<String>()
+            for (part in parts) {
+                if (part.isEmpty()) continue
+                val partTokens = tokens(part)
+                val isNewContent = partTokens.isEmpty() || !seen.containsAll(partTokens)
+                if (isNewContent) {
+                    seen.addAll(partTokens)
+                    out.add(part)
+                }
+            }
+            return out.joinToString(" ").trim()
+        }
+
+        /**
+         * Lowercased content tokens used for redundancy detection. A token is either a word/url run
+         * (`[\w/.:-]+`, so URLs and markdown stay intact while `![ ]( )#` act as separators) OR any
+         * other single non-whitespace glyph (`+`, `%`, `$`, `★`, emoji, …). Including those glyphs —
+         * and single-character word tokens like a lone digit — ensures [dedupJoin] can NEVER hide
+         * visible content from its subset check and silently drop it.
+         */
+        private fun tokens(text: String): Set<String> =
+            TOKEN_REGEX
+                .findAll(text.lowercase())
+                .map { it.value }
+                .toSet()
+
+        companion object {
+            private const val ROLE_IMAGE = "image"
+            private const val ROLE_HEADING = "heading"
+            private const val ROLE_LIST_ITEM = "listItem"
+            private const val ROLE_LINK = "link"
+
+            /** Chromium DOM roles treated as content blocks: kept (when non-empty) to preserve structure. */
+            private val BLOCK_ROLES =
+                setOf(
+                    "article",
+                    "listItem",
+                    "list",
+                    "region",
+                    "section",
+                    "sectionWithoutName",
+                    "navigation",
+                    "header",
+                    "footer",
+                    "main",
+                    "complementary",
+                    "banner",
+                    "figure",
+                    "figcaption",
+                )
+
+            private val TOKEN_REGEX = Regex("[\\w/.:-]+|\\S")
+        }
+    }

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/mcp/McpServerService.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/mcp/McpServerService.kt
@@ -38,6 +38,7 @@ import com.danielealbano.androidremotecontrolmcp.services.accessibility.CompactT
 import com.danielealbano.androidremotecontrolmcp.services.accessibility.ElementFinder
 import com.danielealbano.androidremotecontrolmcp.services.accessibility.ScreenStateSnapshotCache
 import com.danielealbano.androidremotecontrolmcp.services.accessibility.TypeInputController
+import com.danielealbano.androidremotecontrolmcp.services.accessibility.WebViewNodeMerger
 import com.danielealbano.androidremotecontrolmcp.services.apps.AppManager
 import com.danielealbano.androidremotecontrolmcp.services.camera.CameraProvider
 import com.danielealbano.androidremotecontrolmcp.services.intents.IntentDispatcher
@@ -119,6 +120,8 @@ class McpServerService : Service() {
     @Inject lateinit var nodeCache: AccessibilityNodeCache
 
     @Inject lateinit var screenStateSnapshotCache: ScreenStateSnapshotCache
+
+    @Inject lateinit var webViewNodeMerger: WebViewNodeMerger
 
     @Inject lateinit var cameraProvider: CameraProvider
 
@@ -297,6 +300,7 @@ class McpServerService : Service() {
             screenshotEncoder,
             nodeCache,
             screenStateSnapshotCache,
+            webViewNodeMerger,
             toolNamePrefix,
             perms,
         )

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/McpIntegrationTestHelper.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/McpIntegrationTestHelper.kt
@@ -30,6 +30,7 @@ import com.danielealbano.androidremotecontrolmcp.services.accessibility.ScreenIn
 import com.danielealbano.androidremotecontrolmcp.services.accessibility.ScreenStateSnapshotCache
 import com.danielealbano.androidremotecontrolmcp.services.accessibility.ScreenStateSnapshotCacheImpl
 import com.danielealbano.androidremotecontrolmcp.services.accessibility.TypeInputController
+import com.danielealbano.androidremotecontrolmcp.services.accessibility.WebViewNodeMerger
 import com.danielealbano.androidremotecontrolmcp.services.apps.AppManager
 import com.danielealbano.androidremotecontrolmcp.services.camera.CameraProvider
 import com.danielealbano.androidremotecontrolmcp.services.intents.IntentDispatcher
@@ -166,6 +167,7 @@ object McpIntegrationTestHelper {
             deps.screenshotEncoder,
             deps.nodeCache,
             deps.screenStateSnapshotCache,
+            WebViewNodeMerger(),
             toolNamePrefix,
             perms,
         )

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/ScreenIntrospectionToolsTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/ScreenIntrospectionToolsTest.kt
@@ -14,6 +14,7 @@ import com.danielealbano.androidremotecontrolmcp.services.accessibility.CompactT
 import com.danielealbano.androidremotecontrolmcp.services.accessibility.PaginationTestTrees
 import com.danielealbano.androidremotecontrolmcp.services.accessibility.ScreenInfo
 import com.danielealbano.androidremotecontrolmcp.services.accessibility.ScreenStateSnapshotCacheImpl
+import com.danielealbano.androidremotecontrolmcp.services.accessibility.WebViewNodeMerger
 import com.danielealbano.androidremotecontrolmcp.services.screencapture.ScreenCaptureProvider
 import com.danielealbano.androidremotecontrolmcp.services.screencapture.ScreenshotAnnotator
 import com.danielealbano.androidremotecontrolmcp.services.screencapture.ScreenshotEncoder
@@ -164,6 +165,7 @@ class ScreenIntrospectionToolsTest {
                     mockScreenshotEncoder,
                     mockNodeCache,
                     ScreenStateSnapshotCacheImpl(),
+                    WebViewNodeMerger(),
                 )
         }
 
@@ -440,6 +442,7 @@ class ScreenIntrospectionToolsTest {
                     mockScreenshotEncoder,
                     mockNodeCache,
                     realCache,
+                    WebViewNodeMerger(),
                 )
         }
 

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/CompactTreeFormatterTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/CompactTreeFormatterTest.kt
@@ -514,6 +514,36 @@ class CompactTreeFormatterTest {
             val result = formatter.sanitizeText(text)
             assertEquals("a".repeat(100) + "...truncated", result)
         }
+
+        @Test
+        @DisplayName("does not truncate when truncate=false (merged WebView content)")
+        fun doesNotTruncateWhenTruncateFalse() {
+            val longText = "a".repeat(150)
+            assertEquals(longText, formatter.sanitizeText(longText, truncate = false))
+        }
+
+        @Test
+        @DisplayName("appendElementRow does not truncate web nodes but truncates native nodes")
+        fun appendElementRowSkipsTruncationForWebNodes() {
+            val longText = "b".repeat(150)
+            val webNode =
+                AccessibilityNodeData(
+                    id = "w",
+                    bounds = BoundsData(0, 0, 1, 1),
+                    text = longText,
+                    webRole = "article",
+                )
+            val nativeNode =
+                AccessibilityNodeData(
+                    id = "n",
+                    bounds = BoundsData(0, 0, 1, 1),
+                    text = longText,
+                )
+            val webRow = StringBuilder().also { formatter.appendElementRow(it, webNode) }.toString()
+            val nativeRow = StringBuilder().also { formatter.appendElementRow(it, nativeNode) }.toString()
+            assertTrue(webRow.contains(longText), "web node text must not be truncated")
+            assertTrue(nativeRow.contains("...truncated"), "native node text must still truncate")
+        }
     }
 
     // ─────────────────────────────────────────────────────────────────────

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/WebViewNodeMergerTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/WebViewNodeMergerTest.kt
@@ -1,0 +1,435 @@
+package com.danielealbano.androidremotecontrolmcp.services.accessibility
+
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("WebViewNodeMerger")
+class WebViewNodeMergerTest {
+    private val merger = WebViewNodeMerger()
+    private val json = Json { ignoreUnknownKeys = true }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    // Mirrors the production tokenizer (word/url runs OR any single non-whitespace glyph) so the
+    // content-preservation assertions cannot miss a dropped digit, lone letter or glyph (★/+/%/$).
+    private val tokenRegex = Regex("[\\w/.:-]+|\\S")
+
+    private fun tokens(text: String?): Set<String> =
+        tokenRegex
+            .findAll(text.orEmpty().lowercase())
+            .map { it.value }
+            .toSet()
+
+    private val baseNode =
+        AccessibilityNodeData(id = "n", bounds = BoundsData(0, 0, 1, 1), enabled = true, visible = true)
+
+    private fun node(
+        id: String,
+        webRole: String? = null,
+        text: String? = null,
+        desc: String? = null,
+        children: List<AccessibilityNodeData> = emptyList(),
+    ): AccessibilityNodeData =
+        baseNode.copy(
+            id = id,
+            text = text,
+            contentDescription = desc,
+            webRole = webRole,
+            children = children,
+        )
+
+    /** Marks a node as a clickable tap target. */
+    private fun clickable(node: AccessibilityNodeData): AccessibilityNodeData = node.copy(clickable = true)
+
+    private fun result(tree: AccessibilityNodeData): MultiWindowResult =
+        MultiWindowResult(
+            windows = listOf(WindowData(windowId = 1, windowType = "APPLICATION", tree = tree)),
+        )
+
+    private fun mergedTree(tree: AccessibilityNodeData): AccessibilityNodeData {
+        val merged = merger.merge(result(tree))
+        return merged.windows[0].tree
+    }
+
+    private fun flatten(node: AccessibilityNodeData): List<AccessibilityNodeData> {
+        val descendants = node.children.flatMap { flatten(it) }
+        return listOf(node) + descendants
+    }
+
+    /** Content that MUST survive: every text/contentDescription token + every image/link target URL. */
+    private fun requiredTokens(node: AccessibilityNodeData): Set<String> {
+        val out = HashSet<String>()
+        for (n in flatten(node)) {
+            out.addAll(tokens(n.text))
+            out.addAll(tokens(n.contentDescription))
+            if (n.webRole == "image" || n.webRole == "link") out.addAll(tokens(n.targetUrl))
+        }
+        return out
+    }
+
+    /**
+     * Content the TSV formatter actually EMITS: the `text` and `desc` columns only. `targetUrl` is
+     * NOT a TSV column, so reading it here would mask a URL that the merge failed to fold into `text`.
+     */
+    private fun emittedTokens(node: AccessibilityNodeData): Set<String> {
+        val out = HashSet<String>()
+        for (n in flatten(node)) {
+            out.addAll(tokens(n.text))
+            out.addAll(tokens(n.contentDescription))
+        }
+        return out
+    }
+
+    private fun keptCount(node: AccessibilityNodeData): Int {
+        val formatter = CompactTreeFormatter()
+        return flatten(node).count { formatter.shouldKeepNode(it) }
+    }
+
+    private fun loadFixture(): AccessibilityNodeData {
+        val text =
+            this::class.java.getResource("/webview/webview_tree_fixture.json")!!.readText()
+        return json.decodeFromString(AccessibilityNodeData.serializer(), text)
+    }
+
+    // ── fixture-driven invariants ────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("realistic fixture")
+    inner class FixtureTests {
+        private val input = loadFixture()
+        private val output = mergedTree(input)
+
+        @Test
+        @DisplayName("emits every input text/desc/url token in the formatter-visible output")
+        fun losesNoContent() {
+            // before = what MUST survive (incl. URLs); after = what the TSV columns actually emit.
+            val before = requiredTokens(input)
+            val after = emittedTokens(output)
+            val lost = before - after
+            assertTrue(lost.isEmpty(), "content tokens dropped by merge: $lost")
+        }
+
+        @Test
+        @DisplayName("reduces node count by at least 25%")
+        fun reducesNodeCount() {
+            val before = keptCount(input)
+            val after = keptCount(output)
+            assertTrue(after < before, "expected fewer kept nodes ($after) than baseline ($before)")
+            val reduction = (before - after).toDouble() / before
+            assertTrue(reduction >= 0.25, "reduction $reduction below 25% (before=$before after=$after)")
+        }
+
+        @Test
+        @DisplayName("preserves every interactive node with its id")
+        fun preservesInteractiveNodes() {
+            val interactiveIn =
+                flatten(input)
+                    .filter { it.clickable || it.longClickable || it.editable || it.scrollable }
+                    .map { it.id }
+                    .toSet()
+            val idsOut = flatten(output).map { it.id }.toSet()
+            assertTrue(
+                idsOut.containsAll(interactiveIn),
+                "missing interactive node ids: ${interactiveIn - idsOut}",
+            )
+        }
+
+        @Test
+        @DisplayName("annotates headings, list items and images with markdown")
+        fun emitsMarkdown() {
+            val allText = flatten(output).joinToString("\n") { it.text.orEmpty() }
+            assertTrue(allText.contains("# Global Markets Rally"), "missing heading markdown")
+            assertTrue(allText.contains("- Team Alpha wins the final"), "missing list-item markdown")
+            assertTrue(allText.contains("![Markets chart]"), "missing image markdown")
+        }
+
+        @Test
+        @DisplayName("leaves native subtree nodes untouched by reference")
+        fun nativePassthrough() {
+            val nativeIn = flatten(input).first { it.id == "native_toolbar" }
+            val nativeOut = flatten(output).first { it.id == "native_toolbar" }
+            assertSame(nativeIn, nativeOut, "native node should not be copied")
+        }
+    }
+
+    // ── per-branch behaviour ─────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("returns the same result instance when there are no web nodes")
+    fun noWebNodesReturnsSameInstance() {
+        val native =
+            node(
+                "root",
+                children =
+                    listOf(
+                        node("a", text = "Hello"),
+                        clickable(node("b", text = "World")),
+                    ),
+            )
+        val input = result(native)
+        assertSame(input, merger.merge(input))
+    }
+
+    @Test
+    @DisplayName("absorbs redundant child text into a clickable without duplicating it")
+    fun dedupAbsorbIntoAnchor() {
+        val web =
+            webArea(
+                clickable(
+                    node(
+                        "link",
+                        webRole = "link",
+                        desc = "Buy now",
+                        children = listOf(node("t", webRole = "staticText", text = "Buy now")),
+                    ),
+                ),
+            )
+        val anchor = mergedWeb(web).children.single()
+        assertEquals("link", anchor.id)
+        assertEquals("Buy now", anchor.text)
+        assertTrue(anchor.children.isEmpty(), "redundant child should be absorbed, not kept")
+    }
+
+    @Test
+    @DisplayName("absorbs non-redundant child content into a clickable")
+    fun absorbExtraChildContent() {
+        val web =
+            webArea(
+                clickable(
+                    node(
+                        "link",
+                        webRole = "link",
+                        desc = "Title",
+                        children = listOf(node("t", webRole = "staticText", text = "Extra detail")),
+                    ),
+                ),
+            )
+        val text =
+            mergedWeb(web)
+                .children
+                .single()
+                .text
+                .orEmpty()
+        assertTrue(text.contains("Title"), "lost link name")
+        assertTrue(text.contains("Extra detail"), "lost child content")
+    }
+
+    @Test
+    @DisplayName("annotates a heading with leading '# '")
+    fun headingMarkdown() {
+        val web = webArea(node("h", webRole = "heading", text = "Hi there"))
+        assertTrue(mergedWeb(web).text!!.contains("# Hi there"))
+    }
+
+    @Test
+    @DisplayName("annotates an image with '![alt](url)'")
+    fun imageMarkdown() {
+        val image =
+            baseNode.copy(
+                id = "img",
+                webRole = "image",
+                contentDescription = "Cat",
+                targetUrl = "https://e.example/c.png",
+            )
+        assertTrue(mergedWeb(webArea(image)).text!!.contains("![Cat](https://e.example/c.png)"))
+    }
+
+    @Test
+    @DisplayName("annotates a list item with leading '- '")
+    fun listItemMarkdown() {
+        val web =
+            webArea(
+                node(
+                    "list",
+                    webRole = "list",
+                    children = listOf(node("li", webRole = "listItem", text = "One")),
+                ),
+            )
+        val merged = mergedWeb(web)
+        val allText = (listOf(merged) + merged.children).joinToString("\n") { it.text.orEmpty() }
+        assertTrue(allText.contains("- One"), "missing list-item markdown in: $allText")
+    }
+
+    @Test
+    @DisplayName("annotates a non-interactive link with '[text](url)'")
+    fun nonInteractiveLinkMarkdown() {
+        val link =
+            baseNode.copy(id = "l", webRole = "link", text = "Docs", targetUrl = "https://e.example/d")
+        assertTrue(mergedWeb(webArea(link)).text!!.contains("[Docs](https://e.example/d)"))
+    }
+
+    @Test
+    @DisplayName("never drops single-character content (e.g. a lone digit) during dedup")
+    fun keepsSingleCharContent() {
+        // Heading "Match result" + child "Match result 3": the digit "3" is a single-char token
+        // whose siblings ("match", "result") are already seen — it must NOT be dropped.
+        val web =
+            webArea(
+                node(
+                    "article",
+                    webRole = "article",
+                    children =
+                        listOf(
+                            node("h", webRole = "heading", text = "Match result"),
+                            node("s", webRole = "staticText", text = "Match result 3"),
+                        ),
+                ),
+            )
+        val allText = flatten(mergedWeb(web)).joinToString(" ") { it.text.orEmpty() }
+        assertTrue(allText.contains("3"), "lone digit content must not be dropped: $allText")
+    }
+
+    @Test
+    @DisplayName("preserves a link URL even when the link has no accessible name")
+    fun nonInteractiveLinkUrlWithoutName() {
+        val link = baseNode.copy(id = "l", webRole = "link", targetUrl = "https://e.example/x")
+        assertTrue(mergedWeb(webArea(link)).text!!.contains("https://e.example/x"))
+    }
+
+    @Test
+    @DisplayName("preserves the targetUrl of a CLICKABLE image (named tap target)")
+    fun clickableImageKeepsUrl() {
+        val image =
+            baseNode.copy(
+                id = "img",
+                webRole = "image",
+                contentDescription = "Chart",
+                targetUrl = "https://e.example/chart.png",
+                clickable = true,
+            )
+        val anchor = mergedWeb(webArea(image)).children.single()
+        assertEquals("img", anchor.id)
+        assertTrue(anchor.text!!.contains("https://e.example/chart.png"), "clickable image lost its url")
+    }
+
+    @Test
+    @DisplayName("preserves the targetUrl of a CLICKABLE named link")
+    fun clickableLinkKeepsUrl() {
+        val link =
+            baseNode.copy(
+                id = "lnk",
+                webRole = "link",
+                contentDescription = "Open report",
+                targetUrl = "https://e.example/report",
+                clickable = true,
+            )
+        val anchor = mergedWeb(webArea(link)).children.single()
+        val text = anchor.text.orEmpty()
+        assertTrue(text.contains("Open report"), "clickable link lost its name")
+        assertTrue(text.contains("https://e.example/report"), "clickable link lost its url")
+    }
+
+    @Test
+    @DisplayName("never drops a non-word glyph (★) whose word tokens are already present")
+    fun keepsGlyphContent() {
+        // Parent "5 stars" + child "5★": the word token "5" is duplicated, but the ★ glyph is new
+        // visible content and must survive.
+        val web =
+            webArea(
+                node(
+                    "article",
+                    webRole = "article",
+                    children =
+                        listOf(
+                            node("h", webRole = "heading", text = "5 stars"),
+                            node("s", webRole = "staticText", text = "5★"),
+                        ),
+                ),
+            )
+        val allText = flatten(mergedWeb(web)).joinToString(" ") { it.text.orEmpty() }
+        assertTrue(allText.contains("★"), "glyph content must not be dropped: $allText")
+    }
+
+    @Test
+    @DisplayName("drops an empty structural block, keeping no node and no content")
+    fun emptyBlockDropped() {
+        val web =
+            webArea(
+                node(
+                    "article",
+                    webRole = "article",
+                    children = listOf(node("g", webRole = "genericContainer")),
+                ),
+            )
+        val merged = mergedWeb(web)
+        assertTrue(merged.children.isEmpty(), "empty block should not be kept")
+        assertNull(merged.text, "no content expected")
+    }
+
+    @Test
+    @DisplayName("never merges two clickables together")
+    fun twoClickablesKeptSeparate() {
+        val web =
+            webArea(
+                node(
+                    "article",
+                    webRole = "article",
+                    children =
+                        listOf(
+                            clickable(node("l1", webRole = "link", desc = "First")),
+                            clickable(node("l2", webRole = "link", desc = "Second")),
+                        ),
+                ),
+            )
+        val ids = flatten(mergedWeb(web)).map { it.id }
+        assertTrue(ids.contains("l1") && ids.contains("l2"), "both tap targets must survive: $ids")
+    }
+
+    @Test
+    @DisplayName("keeps an anchor's original id and bounds")
+    fun anchorKeepsIdAndBounds() {
+        val link =
+            AccessibilityNodeData(
+                id = "link42",
+                bounds = BoundsData(10, 20, 30, 40),
+                webRole = "link",
+                contentDescription = "Open",
+                clickable = true,
+                enabled = true,
+                visible = true,
+            )
+        val anchor = mergedWeb(webArea(link)).children.single()
+        assertEquals("link42", anchor.id)
+        assertEquals(BoundsData(10, 20, 30, 40), anchor.bounds)
+        assertTrue(anchor.clickable)
+    }
+
+    @Test
+    @DisplayName("returns scrollable web nodes as preserved anchors")
+    fun scrollableIsAnchor() {
+        val scroller =
+            baseNode.copy(
+                id = "scroller",
+                webRole = "genericContainer",
+                scrollable = true,
+                children = listOf(node("t", webRole = "staticText", text = "Inside")),
+            )
+        val ids = flatten(mergedWeb(webArea(scroller))).map { it.id }
+        assertTrue(ids.contains("scroller"), "scrollable node must be preserved")
+    }
+
+    // ── small-tree helpers ───────────────────────────────────────────────────
+
+    /** Wraps [children] under a rootWebArea web entry, itself under a native host. */
+    private fun webArea(vararg children: AccessibilityNodeData): AccessibilityNodeData =
+        node(
+            "host",
+            children =
+                listOf(
+                    node("webroot", webRole = "rootWebArea", children = children.toList()),
+                ),
+        )
+
+    /** Merges [tree] and returns the collapsed rootWebArea node. */
+    private fun mergedWeb(tree: AccessibilityNodeData): AccessibilityNodeData {
+        val merged = mergedTree(tree)
+        return flatten(merged).first { it.id == "webroot" }
+    }
+}

--- a/app/src/test/resources/webview/webview_tree_fixture.json
+++ b/app/src/test/resources/webview/webview_tree_fixture.json
@@ -1,0 +1,270 @@
+{
+  "id": "win_root",
+  "className": "android.widget.FrameLayout",
+  "bounds": { "left": 0, "top": 0, "right": 1080, "bottom": 2400 },
+  "enabled": true,
+  "visible": true,
+  "children": [
+    {
+      "id": "native_toolbar",
+      "className": "android.widget.TextView",
+      "text": "Example News",
+      "bounds": { "left": 0, "top": 0, "right": 1080, "bottom": 140 },
+      "enabled": true,
+      "visible": true
+    },
+    {
+      "id": "webview_host",
+      "className": "android.webkit.WebView",
+      "bounds": { "left": 0, "top": 140, "right": 1080, "bottom": 2400 },
+      "enabled": true,
+      "visible": true,
+      "children": [
+        {
+          "id": "web_root",
+          "className": "android.view.View",
+          "bounds": { "left": 0, "top": 140, "right": 1080, "bottom": 2400 },
+          "enabled": true,
+          "visible": true,
+          "webRole": "rootWebArea",
+          "children": [
+            {
+              "id": "web_nav",
+              "className": "android.view.View",
+              "bounds": { "left": 0, "top": 140, "right": 1080, "bottom": 200 },
+              "enabled": true,
+              "visible": true,
+              "webRole": "navigation",
+              "children": [
+                {
+                  "id": "nav_link_home",
+                  "className": "android.view.View",
+                  "contentDescription": "Home",
+                  "bounds": { "left": 10, "top": 150, "right": 200, "bottom": 195 },
+                  "clickable": true,
+                  "enabled": true,
+                  "visible": true,
+                  "webRole": "link",
+                  "targetUrl": "https://news.example/home"
+                }
+              ]
+            },
+            {
+              "id": "article_1",
+              "className": "android.view.View",
+              "bounds": { "left": 0, "top": 200, "right": 1080, "bottom": 1000 },
+              "enabled": true,
+              "visible": true,
+              "webRole": "article",
+              "children": [
+                {
+                  "id": "a1_heading",
+                  "className": "android.view.View",
+                  "text": "Global Markets Rally",
+                  "bounds": { "left": 20, "top": 210, "right": 1060, "bottom": 270 },
+                  "enabled": true,
+                  "visible": true,
+                  "webRole": "heading"
+                },
+                {
+                  "id": "a1_link",
+                  "className": "android.view.View",
+                  "contentDescription": "Global Markets Rally full story",
+                  "bounds": { "left": 20, "top": 280, "right": 1060, "bottom": 700 },
+                  "clickable": true,
+                  "enabled": true,
+                  "visible": true,
+                  "webRole": "link",
+                  "targetUrl": "https://news.example/markets",
+                  "children": [
+                    {
+                      "id": "a1_link_text",
+                      "className": "android.view.View",
+                      "text": "Global Markets Rally full story",
+                      "bounds": { "left": 20, "top": 280, "right": 1060, "bottom": 340 },
+                      "enabled": true,
+                      "visible": true,
+                      "webRole": "staticText"
+                    },
+                    {
+                      "id": "a1_link_image",
+                      "className": "android.view.View",
+                      "contentDescription": "Markets chart",
+                      "bounds": { "left": 20, "top": 350, "right": 1060, "bottom": 700 },
+                      "enabled": true,
+                      "visible": true,
+                      "webRole": "image",
+                      "targetUrl": "https://img.example/markets.png"
+                    }
+                  ]
+                },
+                {
+                  "id": "a1_para",
+                  "className": "android.view.View",
+                  "bounds": { "left": 20, "top": 710, "right": 1060, "bottom": 990 },
+                  "enabled": true,
+                  "visible": true,
+                  "webRole": "paragraph",
+                  "children": [
+                    {
+                      "id": "a1_para_text",
+                      "className": "android.view.View",
+                      "text": "Investors responded positively to the new monetary policy announcement.",
+                      "bounds": { "left": 20, "top": 710, "right": 1060, "bottom": 990 },
+                      "enabled": true,
+                      "visible": true,
+                      "webRole": "staticText"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "article_2",
+              "className": "android.view.View",
+              "bounds": { "left": 0, "top": 1000, "right": 1080, "bottom": 1700 },
+              "enabled": true,
+              "visible": true,
+              "webRole": "article",
+              "children": [
+                {
+                  "id": "a2_heading",
+                  "className": "android.view.View",
+                  "text": "Sports Update",
+                  "bounds": { "left": 20, "top": 1010, "right": 1060, "bottom": 1070 },
+                  "enabled": true,
+                  "visible": true,
+                  "webRole": "heading"
+                },
+                {
+                  "id": "a2_list",
+                  "className": "android.view.View",
+                  "bounds": { "left": 20, "top": 1080, "right": 1060, "bottom": 1400 },
+                  "enabled": true,
+                  "visible": true,
+                  "webRole": "list",
+                  "children": [
+                    {
+                      "id": "a2_item_1",
+                      "className": "android.view.View",
+                      "text": "Team Alpha wins the final",
+                      "bounds": { "left": 30, "top": 1090, "right": 1050, "bottom": 1240 },
+                      "enabled": true,
+                      "visible": true,
+                      "webRole": "listItem"
+                    },
+                    {
+                      "id": "a2_item_2",
+                      "className": "android.view.View",
+                      "text": "Team Beta advances to the playoffs",
+                      "bounds": { "left": 30, "top": 1250, "right": 1050, "bottom": 1400 },
+                      "enabled": true,
+                      "visible": true,
+                      "webRole": "listItem"
+                    }
+                  ]
+                },
+                {
+                  "id": "a2_link",
+                  "className": "android.view.View",
+                  "contentDescription": "Sports Update full story",
+                  "bounds": { "left": 20, "top": 1410, "right": 1060, "bottom": 1470 },
+                  "clickable": true,
+                  "enabled": true,
+                  "visible": true,
+                  "webRole": "link",
+                  "targetUrl": "https://news.example/sports"
+                }
+              ]
+            },
+            {
+              "id": "article_3",
+              "className": "android.view.View",
+              "bounds": { "left": 0, "top": 1500, "right": 1080, "bottom": 1700 },
+              "enabled": true,
+              "visible": true,
+              "webRole": "article",
+              "children": [
+                {
+                  "id": "a3_heading",
+                  "className": "android.view.View",
+                  "text": "Match result",
+                  "bounds": { "left": 20, "top": 1510, "right": 1060, "bottom": 1560 },
+                  "enabled": true,
+                  "visible": true,
+                  "webRole": "heading"
+                },
+                {
+                  "id": "a3_score",
+                  "className": "android.view.View",
+                  "text": "Match result 3",
+                  "bounds": { "left": 20, "top": 1570, "right": 1060, "bottom": 1690 },
+                  "enabled": true,
+                  "visible": true,
+                  "webRole": "staticText"
+                }
+              ]
+            },
+            {
+              "id": "web_footer_container",
+              "className": "android.view.View",
+              "bounds": { "left": 0, "top": 1700, "right": 1080, "bottom": 1900 },
+              "enabled": true,
+              "visible": true,
+              "webRole": "genericContainer",
+              "children": [
+                {
+                  "id": "footer_text",
+                  "className": "android.view.View",
+                  "text": "All content is provided for informational purposes only.",
+                  "bounds": { "left": 20, "top": 1710, "right": 1060, "bottom": 1880 },
+                  "enabled": true,
+                  "visible": true,
+                  "webRole": "staticText"
+                }
+              ]
+            },
+            {
+              "id": "empty_section",
+              "className": "android.view.View",
+              "bounds": { "left": 0, "top": 1900, "right": 1080, "bottom": 1950 },
+              "enabled": true,
+              "visible": true,
+              "webRole": "section",
+              "children": [
+                {
+                  "id": "empty_generic",
+                  "className": "android.view.View",
+                  "bounds": { "left": 0, "top": 1900, "right": 1080, "bottom": 1950 },
+                  "enabled": true,
+                  "visible": true,
+                  "webRole": "genericContainer"
+                }
+              ]
+            },
+            {
+              "id": "banner_image",
+              "className": "android.view.View",
+              "contentDescription": "Promotional banner",
+              "bounds": { "left": 0, "top": 1950, "right": 1080, "bottom": 2200 },
+              "enabled": true,
+              "visible": true,
+              "webRole": "image",
+              "targetUrl": "https://img.example/banner.png"
+            },
+            {
+              "id": "subscribe_button",
+              "className": "android.view.View",
+              "text": "Subscribe",
+              "bounds": { "left": 400, "top": 2220, "right": 680, "bottom": 2300 },
+              "clickable": true,
+              "enabled": true,
+              "visible": true,
+              "webRole": "button"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/compose-test-app/src/main/kotlin/com/danielealbano/composetestapp/WebViewActivity.kt
+++ b/compose-test-app/src/main/kotlin/com/danielealbano/composetestapp/WebViewActivity.kt
@@ -23,6 +23,11 @@ import androidx.activity.ComponentActivity
  * When launched with the string extra `content=heavy`, it instead loads a large,
  * content-heavy page (hundreds of articles with headings, paragraphs, links, list
  * items and images) used to exercise WebView node collapsing in E2E tests.
+ *
+ * This activity is `singleTop`, so a relaunch reuses the same instance and fires
+ * [onNewIntent] rather than [onCreate]. Both route through [applyIntent] so the
+ * displayed page is always determined by the latest intent — a simple-page launch
+ * after a heavy-page launch reliably shows the simple page again.
  */
 class WebViewActivity : ComponentActivity() {
 
@@ -31,32 +36,51 @@ class WebViewActivity : ComponentActivity() {
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val heavy = intent?.getStringExtra(EXTRA_CONTENT) == CONTENT_HEAVY
-        Log.i(TAG, "onCreate called, heavy=$heavy")
-
+        Log.i(TAG, "onCreate called")
         webView = WebView(this).apply {
             settings.javaScriptEnabled = true
             webViewClient = WebViewClient()
-            if (heavy) {
-                loadDataWithBaseURL(null, buildHeavyHtml(), "text/html", "UTF-8", null)
-            } else {
-                loadData(
-                    """
-                    <html>
-                    <body style="display:flex;justify-content:center;align-items:center;height:100vh;margin:0;">
-                        <span id="counter" style="font-size:48px;">Number: 0</span>
-                    </body>
-                    </html>
-                    """.trimIndent(),
-                    "text/html",
-                    "UTF-8",
-                )
-            }
         }
         setContentView(webView)
+        applyIntent(intent)
+    }
 
-        if (!heavy) {
-            handleNumberIntent(intent)
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        Log.i(TAG, "onNewIntent called, extras=${intent.extras}")
+        applyIntent(intent)
+    }
+
+    /**
+     * Routes an intent: a `number` extra updates the counter in place via JavaScript (no reload);
+     * otherwise the page is (re)loaded — the heavy page when `content=heavy`, the simple counter
+     * page otherwise.
+     */
+    private fun applyIntent(intent: Intent?) {
+        when {
+            intent?.hasExtra(EXTRA_NUMBER) == true -> updateNumber(intent.getIntExtra(EXTRA_NUMBER, 0))
+            intent?.getStringExtra(EXTRA_CONTENT) == CONTENT_HEAVY -> loadHeavyPage()
+            else -> loadSimplePage()
+        }
+    }
+
+    private fun loadSimplePage() {
+        Log.i(TAG, "loading simple counter page")
+        webView?.loadData(SIMPLE_HTML, "text/html", "UTF-8")
+    }
+
+    private fun loadHeavyPage() {
+        Log.i(TAG, "loading heavy page")
+        webView?.loadDataWithBaseURL(null, buildHeavyHtml(), "text/html", "UTF-8", null)
+    }
+
+    private fun updateNumber(newNumber: Int) {
+        Log.i(TAG, "updating WebView to number=$newNumber")
+        webView?.evaluateJavascript(
+            "document.getElementById('counter').textContent = 'Number: $newNumber';",
+        ) { result ->
+            Log.i(TAG, "evaluateJavascript result=$result")
         }
     }
 
@@ -81,26 +105,6 @@ class WebViewActivity : ComponentActivity() {
         return "<html><body>$body</body></html>"
     }
 
-    override fun onNewIntent(intent: Intent) {
-        super.onNewIntent(intent)
-        Log.i(TAG, "onNewIntent called, extras=${intent.extras}")
-        handleNumberIntent(intent)
-    }
-
-    private fun handleNumberIntent(intent: Intent?) {
-        if (intent?.hasExtra(EXTRA_NUMBER) == true) {
-            val newNumber = intent.getIntExtra(EXTRA_NUMBER, 0)
-            Log.i(TAG, "handleNumberIntent: updating WebView to number=$newNumber")
-            webView?.evaluateJavascript(
-                "document.getElementById('counter').textContent = 'Number: $newNumber';",
-            ) { result ->
-                Log.i(TAG, "handleNumberIntent: evaluateJavascript result=$result")
-            }
-        } else {
-            Log.i(TAG, "handleNumberIntent: no '$EXTRA_NUMBER' extra in intent")
-        }
-    }
-
     override fun onDestroy() {
         webView?.destroy()
         webView = null
@@ -113,6 +117,15 @@ class WebViewActivity : ComponentActivity() {
         private const val EXTRA_CONTENT = "content"
         private const val CONTENT_HEAVY = "heavy"
         private const val ARTICLE_COUNT = 200
+
+        private val SIMPLE_HTML =
+            """
+            <html>
+            <body style="display:flex;justify-content:center;align-items:center;height:100vh;margin:0;">
+                <span id="counter" style="font-size:48px;">Number: 0</span>
+            </body>
+            </html>
+            """.trimIndent()
 
         /** 1x1 transparent PNG so each article has a real <img> accessibility node, offline. */
         private const val PIXEL_DATA_URI =

--- a/compose-test-app/src/main/kotlin/com/danielealbano/composetestapp/WebViewActivity.kt
+++ b/compose-test-app/src/main/kotlin/com/danielealbano/composetestapp/WebViewActivity.kt
@@ -19,6 +19,10 @@ import androidx.activity.ComponentActivity
  * The number is updated via evaluateJavascript, which modifies the DOM without
  * reloading the page. WebView virtual accessibility nodes may return stale data
  * if not refreshed during tree traversal.
+ *
+ * When launched with the string extra `content=heavy`, it instead loads a large,
+ * content-heavy page (hundreds of articles with headings, paragraphs, links, list
+ * items and images) used to exercise WebView node collapsing in E2E tests.
  */
 class WebViewActivity : ComponentActivity() {
 
@@ -27,26 +31,54 @@ class WebViewActivity : ComponentActivity() {
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        Log.i(TAG, "onCreate called")
+        val heavy = intent?.getStringExtra(EXTRA_CONTENT) == CONTENT_HEAVY
+        Log.i(TAG, "onCreate called, heavy=$heavy")
 
         webView = WebView(this).apply {
             settings.javaScriptEnabled = true
             webViewClient = WebViewClient()
-            loadData(
-                """
-                <html>
-                <body style="display:flex;justify-content:center;align-items:center;height:100vh;margin:0;">
-                    <span id="counter" style="font-size:48px;">Number: 0</span>
-                </body>
-                </html>
-                """.trimIndent(),
-                "text/html",
-                "UTF-8",
-            )
+            if (heavy) {
+                loadDataWithBaseURL(null, buildHeavyHtml(), "text/html", "UTF-8", null)
+            } else {
+                loadData(
+                    """
+                    <html>
+                    <body style="display:flex;justify-content:center;align-items:center;height:100vh;margin:0;">
+                        <span id="counter" style="font-size:48px;">Number: 0</span>
+                    </body>
+                    </html>
+                    """.trimIndent(),
+                    "text/html",
+                    "UTF-8",
+                )
+            }
         }
         setContentView(webView)
 
-        handleNumberIntent(intent)
+        if (!heavy) {
+            handleNumberIntent(intent)
+        }
+    }
+
+    /**
+     * Builds a large HTML document with [ARTICLE_COUNT] articles, each containing a heading,
+     * two paragraphs, a link, an inline image and a two-item list. This produces well over a
+     * thousand WebView accessibility nodes, exercising the node-collapsing path.
+     */
+    private fun buildHeavyHtml(): String {
+        val body = StringBuilder()
+        body.append("<h1>Daily Digest</h1>")
+        for (i in 1..ARTICLE_COUNT) {
+            body.append("<article>")
+            body.append("<h2>Story number $i headline</h2>")
+            body.append("<p>First paragraph describing the details of story number $i in full.</p>")
+            body.append("<p>Second paragraph with additional context for story number $i.</p>")
+            body.append("<img src=\"$PIXEL_DATA_URI\" alt=\"Illustration for story $i\" width=\"32\" height=\"32\">")
+            body.append("<a href=\"https://example.invalid/story/$i\">Read full story number $i</a>")
+            body.append("<ul><li>Highlight A of story $i</li><li>Highlight B of story $i</li></ul>")
+            body.append("</article>")
+        }
+        return "<html><body>$body</body></html>"
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -78,5 +110,13 @@ class WebViewActivity : ComponentActivity() {
     companion object {
         private const val TAG = "WebViewTestApp"
         private const val EXTRA_NUMBER = "number"
+        private const val EXTRA_CONTENT = "content"
+        private const val CONTENT_HEAVY = "heavy"
+        private const val ARTICLE_COUNT = 200
+
+        /** 1x1 transparent PNG so each article has a real <img> accessibility node, offline. */
+        private const val PIXEL_DATA_URI =
+            "data:image/png;base64," +
+                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
     }
 }

--- a/e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/AndroidContainerSetup.kt
+++ b/e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/AndroidContainerSetup.kt
@@ -429,6 +429,69 @@ object AndroidContainerSetup {
     }
 
     /**
+     * Launch the WebView test activity with the large, content-heavy page
+     * (hundreds of articles) used to exercise WebView node collapsing.
+     */
+    fun launchHeavyWebViewTestApp() {
+        val result = execAdb(
+            "shell", "am", "start", "-W",
+            "--es", "content", "heavy",
+            "-n", "$COMPOSE_TEST_PACKAGE/.WebViewActivity",
+        )
+        println("[E2E Setup] launchHeavyWebViewTestApp result: $result")
+        Thread.sleep(3_000)
+    }
+
+    /**
+     * Counts the accessibility nodes currently on screen via `uiautomator dump`. This is the raw,
+     * un-collapsed node count (every node the platform exposes), used as the baseline against the
+     * collapsed `get_screen_state` output.
+     *
+     * @return the number of `<node` elements in the dump, or 0 if the dump could not be produced.
+     */
+    fun uiAutomatorNodeCount(): Int {
+        execAdb("shell", "uiautomator", "dump", "/sdcard/uidump.xml")
+        val xml = execAdb("shell", "cat", "/sdcard/uidump.xml")
+        return Regex("<node ").findAll(xml).count()
+    }
+
+    /**
+     * Counts on-screen nodes that would survive `get_screen_state`'s keep-filter BEFORE the WebView
+     * merge: a node is kept if it has non-empty text / content-desc / resource-id, or is clickable /
+     * long-clickable / scrollable. Comparing the collapsed `get_screen_state` count against THIS
+     * baseline (rather than the raw total) isolates the merge's contribution from the structural-only
+     * filtering that `get_screen_state` always applies.
+     */
+    fun uiAutomatorKeptNodeCount(): Int {
+        execAdb("shell", "uiautomator", "dump", "/sdcard/uidump.xml")
+        val xml = execAdb("shell", "cat", "/sdcard/uidump.xml")
+        return NODE_TAG_REGEX.findAll(xml).count { match ->
+            val tag = match.value
+            attrNonEmpty(tag, "text") ||
+                attrNonEmpty(tag, "content-desc") ||
+                attrNonEmpty(tag, "resource-id") ||
+                attrTrue(tag, "clickable") ||
+                attrTrue(tag, "long-clickable") ||
+                attrTrue(tag, "scrollable")
+        }
+    }
+
+    private val NODE_TAG_REGEX = Regex("<node\\b[^>]*>")
+
+    private fun attrNonEmpty(
+        tag: String,
+        name: String,
+    ): Boolean {
+        val match = Regex("\\s$name=\"([^\"]*)\"").find(tag) ?: return false
+        return match.groupValues[1].isNotEmpty()
+    }
+
+    private fun attrTrue(
+        tag: String,
+        name: String,
+    ): Boolean = Regex("\\s$name=\"true\"").containsMatchIn(tag)
+
+    /**
      * Send an intent to the WebView test activity to update the displayed number.
      *
      * @param number the number to display

--- a/e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/E2EWebViewNodeReductionTest.kt
+++ b/e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/E2EWebViewNodeReductionTest.kt
@@ -1,0 +1,107 @@
+package com.danielealbano.androidremotecontrolmcp.e2e
+
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * E2E test: WebView node collapsing reduces the node count on a large web page.
+ *
+ * Loads the bundled content-heavy WebView page (hundreds of articles → well over a thousand raw
+ * accessibility nodes), confirms the raw node count (via `uiautomator dump`) exceeds 1000, then
+ * confirms the collapsed `get_screen_state` output reports meaningfully fewer nodes.
+ *
+ * To ISOLATE the merge from the structural-only filtering that `get_screen_state` always applies,
+ * the reduction is measured against the keep-FILTERED baseline (`uiAutomatorKeptNodeCount`) — i.e.
+ * the nodes that would survive filtering BEFORE the merge — not the raw total. As a second,
+ * independent proof that the collapse actually ran (and that Chromium populated `webRole`), it also
+ * asserts the output contains image markdown (`![`), a wrapper produced ONLY by the merge.
+ *
+ * The content-preserving correctness of the collapse is covered exhaustively by
+ * `WebViewNodeMergerTest` (JVM unit tests).
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class E2EWebViewNodeReductionTest {
+
+    private val mcpClient = SharedAndroidContainer.mcpClient
+
+    companion object {
+        private const val TOOL_PREFIX = AndroidContainerSetup.TOOL_NAME_PREFIX
+        private const val MIN_RAW_NODES = 1000
+        private const val MIN_REDUCTION = 0.25
+        private const val SETTLE_ATTEMPTS = 3
+        private const val SETTLE_WAIT_MS = 10_000L
+
+        // Parses the "nodes:<start>-<end>/<total>" pagination marker; total = collapsed node count.
+        private val NODES_TOTAL_REGEX = Regex("""nodes:\d+-\d+/(\d+)""")
+
+        // A collapsed TSV data row: node id (hex hash) followed by the tab column separator.
+        private val TSV_ROW_REGEX = Regex("""(?m)^node_[0-9a-f]+\t""")
+    }
+
+    @BeforeEach
+    fun ensureAccessibility() {
+        SharedAndroidContainer.ensureAccessibilityService()
+    }
+
+    @Test
+    fun `heavy webview page node count is collapsed`() = runBlocking {
+        mcpClient.callTool("${TOOL_PREFIX}press_home")
+        Thread.sleep(1_000)
+
+        AndroidContainerSetup.launchHeavyWebViewTestApp()
+
+        // The web accessibility tree populates asynchronously; wait until it is large enough.
+        var rawNodes = 0
+        repeat(SETTLE_ATTEMPTS) { attempt ->
+            rawNodes = AndroidContainerSetup.uiAutomatorNodeCount()
+            println("[E2E NodeReduction] attempt ${attempt + 1}: raw uiautomator nodes=$rawNodes")
+            if (rawNodes > MIN_RAW_NODES) return@repeat
+            Thread.sleep(SETTLE_WAIT_MS)
+        }
+        assertTrue(
+            rawNodes > MIN_RAW_NODES,
+            "expected > $MIN_RAW_NODES raw nodes after ${SETTLE_ATTEMPTS} attempts, got $rawNodes",
+        )
+
+        // Keep-filtered baseline (nodes surviving filtering BEFORE the merge) isolates the merge.
+        val keptRawNodes = AndroidContainerSetup.uiAutomatorKeptNodeCount()
+        val result = mcpClient.callTool("${TOOL_PREFIX}get_screen_state")
+        val text = (result.content[0] as TextContent).text
+        val mergedNodes = collapsedNodeCount(text)
+        val reduction = (keptRawNodes - mergedNodes).toDouble() / keptRawNodes
+        println(
+            "[E2E NodeReduction] raw=$rawNodes keptRaw=$keptRawNodes merged=$mergedNodes " +
+                "merge-reduction=${"%.1f".format(reduction * 100)}%",
+        )
+
+        assertTrue(mergedNodes > 0, "collapsed node count should be positive (output:\n${text.take(500)})")
+        assertTrue(keptRawNodes > 0, "keep-filtered baseline should be positive")
+        assertTrue(
+            reduction >= MIN_REDUCTION,
+            "expected >= ${(MIN_REDUCTION * 100).toInt()}% merge reduction vs filtered baseline, got " +
+                "${"%.1f".format(reduction * 100)}% (keptRaw=$keptRawNodes merged=$mergedNodes)",
+        )
+        // The "![" image-markdown wrapper is produced ONLY by the WebView collapse, so its presence
+        // proves the merge actually ran (isolating it from the structural-only filtering that
+        // get_screen_state always applies).
+        assertTrue(
+            text.contains("!["),
+            "merged output must contain image markdown (proving the WebView collapse ran); " +
+                "output excerpt:\n${text.take(800)}",
+        )
+    }
+
+    /**
+     * Returns the collapsed node count from a `get_screen_state` response: the pagination total when
+     * the output is paged, otherwise the number of TSV data rows on the single page.
+     */
+    private fun collapsedNodeCount(screenState: String): Int {
+        val paged = NODES_TOTAL_REGEX.find(screenState)?.groupValues?.get(1)?.toIntOrNull()
+        if (paged != null) return paged
+        return TSV_ROW_REGEX.findAll(screenState).count()
+    }
+}


### PR DESCRIPTION
## Summary

WebViews expose one accessibility node per DOM element, which explodes the node count returned by `get_screen_state` on content-heavy pages (a single article list can be thousands of nodes). This adds a content-preserving collapse that cuts the WebView node count at the source while losing **zero text** and keeping **every tap target**.

Chrome and the Android System WebView (both Chromium) populate `getExtras()` with the DOM role (`chromeRole`) and `targetUrl` on every web node — readable for free, no injection, no root. We capture these as `webRole`/`targetUrl` and use them to scope the collapse strictly to web content; native and Compose subtrees are returned unchanged.

## What it does

- **New `WebViewNodeMerger`** — a stateless transform that walks web subtrees bottom-up:
  - interactive nodes (clickable/long-clickable/editable/scrollable) → **anchors**, always kept with their original `id`/`bounds` so taps still resolve;
  - semantic block roles (article, list item, section, figure, …) → **blocks** carrying merged content;
  - everything else (staticText, heading, image, paragraph, generic containers) → **merged upward** with minimal markdown (`# ` heading, `- ` list item, `![alt](url)` image, `[text](url)` link).
- **Invariants:** no text/desc token and no image/link URL is ever dropped (redundancy is removed only when every visible token already appears elsewhere); no two interactive nodes are ever merged.
- The merge runs **only in the `get_screen_state` path**, after the node cache is populated from the original tree, so element/action tools and `get_node_details` are unaffected. Merged web content is exempt from the 100-char TSV truncation because it exists only in this output.

## Testing

- **Unit:** `WebViewNodeMergerTest` (+ anonymized fixture) proves content preservation against the *formatter-emitted* output — including single characters, digits and non-word glyphs (`★`/`+`/`%`), and clickable image/link URL retention — plus tap-target/id/bounds preservation, no-two-clickables-merged, markdown annotation, and native passthrough. Formatter truncation tests added.
- **E2E:** a bundled content-heavy WebView page (`content=heavy`); the test confirms >1000 raw nodes, measures the reduction against a keep-filtered baseline so it isolates the merge, and asserts image markdown is present as an independent proof the collapse ran.
- ktlint + detekt clean; full app unit/integration suite passes; all modules build; e2e compiles.

Relates to #92.