### PR TITLE
chore(deps): bump Testcontainers to 2.0.5

### DIFF
--- a/e2e-tests/build.gradle.kts
+++ b/e2e-tests/build.gradle.kts
@@ -22,13 +22,15 @@ dependencies {
     testRuntimeOnly(libs.junit.jupiter.engine)
     testRuntimeOnly(libs.junit.platform.launcher)
 
-    // Testcontainers
+    // Testcontainers (core only; the container lifecycle is managed manually in
+    // SharedAndroidContainer, so the JUnit Jupiter extension artifact is not needed —
+    // and it no longer exists in Testcontainers 2.x).
     testImplementation(libs.testcontainers)
-    testImplementation(libs.testcontainers.junit.jupiter)
 
-    // Force patched transitive dependencies from Testcontainers 1.21.3:
-    // - commons-compress 1.24.0 → 1.27.1 (CVE-2024-25710, CVE-2024-26308)
-    // - commons-lang3 3.16.0 → 3.18.0 (CVE-2025-48924)
+    // Safety floor for patched transitive dependencies pulled via Testcontainers/docker-java
+    // (Testcontainers may already resolve equal or newer versions; these guard against regressions):
+    // - commons-compress ≥ 1.27.1 (CVE-2024-25710, CVE-2024-26308)
+    // - commons-lang3 ≥ 3.18.0 (CVE-2025-48924)
     constraints {
         testImplementation("org.apache.commons:commons-compress:1.27.1")
         testImplementation("org.apache.commons:commons-lang3:3.18.0")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,7 +49,7 @@ accompanist = "0.37.3"
 junit5 = "5.13.4"
 mockk = "1.14.9"
 turbine = "1.2.1"
-testcontainers = "1.21.3"
+testcontainers = "2.0.5"
 
 # AndroidX Test
 test-core = "1.7.0"
@@ -155,7 +155,6 @@ mockk-android = { group = "io.mockk", name = "mockk-android", version.ref = "moc
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 testcontainers = { group = "org.testcontainers", name = "testcontainers", version.ref = "testcontainers" }
-testcontainers-junit-jupiter = { group = "org.testcontainers", name = "junit-jupiter", version.ref = "testcontainers" }
 
 # AndroidX Test
 test-core = { group = "androidx.test", name = "core", version.ref = "test-core" }


### PR DESCRIPTION
## Summary

Bumps **Testcontainers 1.21.3 → 2.0.5** (latest stable) in the `e2e-tests` module. The motivation is the open Dependabot alerts: every remaining Netty 4.1.x / BouncyCastle alert came from `docker-java-transport-zerodep:3.4.2` (pulled transitively by the old Testcontainers), which **shades** those libraries inside itself. Bumping Testcontainers pulls the current **docker-java 3.7.1**, replacing that vulnerable bundle.

## Changes

- `gradle/libs.versions.toml`: `testcontainers` `1.21.3 → 2.0.5`; removed the `testcontainers-junit-jupiter` catalog entry.
- `e2e-tests/build.gradle.kts`: dropped `testImplementation(libs.testcontainers.junit.jupiter)`. Testcontainers 2.x **removed** the `org.testcontainers:junit-jupiter` artifact (it stops at 1.21.4), and the e2e suite manages the container lifecycle manually in `SharedAndroidContainer` (no `@Testcontainers`/`@Container` extension), so it was unused. Only core APIs (`GenericContainer`, `DockerImageName`, `AbstractWaitStrategy`) are used, unchanged in 2.x. Refreshed the commons-constraints comment.

## Verification (local, against podman)

- **Full e2e suite passes** — Calculator, Camera, ComposeRefresh, ErrorHandling, Screenshot, WebViewNodeReduction (59.6% reduction), WebViewRefresh. `BUILD SUCCESSFUL in 4m13s`.
- **`:app` unit + integration tests pass**; **ktlint + detekt clean**.

## Notes

- Like other Dependabot/dep changes, CI's Unit & Integration check will be red **only** if run without the `NGROK_AUTHTOKEN` secret (the `NgrokTunnelIntegrationTest` hard-fails without it); it passes locally with `.env`.
- The 19 shaded Netty/BouncyCastle alerts should clear once Dependabot re-scans `main` after merge.