### PR TITLE
fix(deps): pin Netty native transports to 4.2.15.Final

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -219,9 +219,11 @@ dependencies {
     implementation(libs.ktor.client.okhttp)
     implementation(libs.ktor.client.content.negotiation)
 
-    // Force patched Netty to fix CVE-2026-33870 (HTTP Request Smuggling)
-    // and CVE-2026-33871 (HTTP/2 CONTINUATION Frame Flood DoS).
-    // Ktor 3.4.2 ships netty 4.2.9 which is vulnerable.
+    // Force patched Netty: Ktor's server engine ships netty 4.2.9, which is vulnerable.
+    // Covers the HTTP Request Smuggling / HTTP/2 CONTINUATION-flood CVEs (CVE-2026-33870,
+    // CVE-2026-33871) plus the native-transport advisories that the engine also pulls onto the
+    // release classpath: epoll DoS (GHSA-rwm7-x88c-3g2p) and the epoll/kqueue fd leak
+    // (GHSA-w573-9ffj-6ff9). All netty modules are pinned to the same version to avoid skew.
     constraints {
         implementation("io.netty:netty-codec-http:4.2.15.Final")
         implementation("io.netty:netty-codec-http2:4.2.15.Final")
@@ -234,6 +236,9 @@ dependencies {
         implementation("io.netty:netty-resolver:4.2.15.Final")
         implementation("io.netty:netty-transport-native-unix-common:4.2.15.Final")
         implementation("io.netty:netty-transport-classes-epoll:4.2.15.Final")
+        implementation("io.netty:netty-transport-native-epoll:4.2.15.Final")
+        implementation("io.netty:netty-transport-classes-kqueue:4.2.15.Final")
+        implementation("io.netty:netty-transport-native-kqueue:4.2.15.Final")
     }
 
     // Certificate generation (Bouncy Castle for self-signed cert with SAN support)


### PR DESCRIPTION
## Summary

Closes a real shipping vulnerability missed by the #105 Netty pin: `netty-transport-native-epoll` and `netty-transport-native-kqueue` were still resolving to the Ktor-requested **4.2.9.Final** in the **release** runtime classpath, because the constraint block pinned `netty-transport-classes-epoll` but not the `native-*` transport modules.

These are flagged by Dependabot:
- **#46 / #51** `netty-transport-native-epoll` — epoll DoS (GHSA-rwm7-x88c-3g2p) and epoll/kqueue fd leak (GHSA-w573-9ffj-6ff9)
- **#52** `netty-transport-native-kqueue` — epoll/kqueue fd leak (GHSA-w573-9ffj-6ff9)

## Change

Pin `netty-transport-native-epoll`, `netty-transport-native-kqueue`, and `netty-transport-classes-kqueue` (for kqueue-pair alignment) to `4.2.15.Final`, matching the rest of the Netty modules so every Netty artifact on the release classpath is the same patched version.

## Verification

- `dependencyInsight` on `releaseRuntimeClasspath` confirms all three now resolve to **4.2.15.Final** (was 4.2.9).
- `:app:testDebugUnitTest` + `:app:assembleDebug` + ktlint/detekt all pass locally.

## Context

This was found while auditing the open Dependabot alerts one-by-one. The other 18 open alerts are AGP-internal test-platform transitives (grpc-netty → Netty 4.1.x in the `_internal-unified-test-platform-*` configs) and a stale BouncyCastle 1.79 entry — none present in any shipped/run classpath — and are being dismissed separately. These three were the only ones actually on the release classpath.

Note: as with other dependency PRs, CI's Unit & Integration check passes here (branch PR, secrets available).