### PR TITLE
fix(a11y): declare isAccessibilityTool to read protected app content

### DIFF
--- a/app/src/main/res/xml/accessibility_service_config.xml
+++ b/app/src/main/res/xml/accessibility_service_config.xml
@@ -7,5 +7,6 @@
     android:canRetrieveWindowContent="true"
     android:canTakeScreenshot="true"
     android:description="@string/accessibility_service_description"
+    android:isAccessibilityTool="true"
     android:notificationTimeout="100"
     android:settingsActivity="com.danielealbano.androidremotecontrolmcp.ui.MainActivity" />

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -370,6 +370,12 @@ The MCP server exposes 56 tools across 13 categories. For full JSON-RPC schemas,
 - All node operations MUST happen on main thread
 - Use `performAction()` for element actions, `performGlobalAction()` for system actions, `dispatchGesture()` for complex touch sequences (API 24+)
 
+### `isAccessibilityTool` and `accessibilityDataSensitive` (Android 14+ / API 34)
+
+- `accessibility_service_config.xml` declares `android:isAccessibilityTool="true"`. On API 34+, apps can mark UI subtrees `accessibilityDataSensitive`; those nodes are delivered **only** to services that declare `isAccessibilityTool="true"` (and to the system `UiAutomation`). Without the flag, such subtrees are silently filtered out of the tree we receive — e.g. the GitHub app renders as an empty `main_activity_container` in `get_screen_state`/`find_nodes` even though the content is fully present in the framework tree (confirmed via `uiautomator dump`). The flag is what lets this tool introspect and control apps that mark their content sensitive.
+- **Security implication**: this intentionally bypasses the `accessibilityDataSensitive` anti-scraping protection that security-conscious apps (banking, password managers) rely on. This is acceptable for a user-installed, user-enabled remote-control tool, but is a deliberate trade-off that MUST stay documented.
+- **Google Play implication (deferred)**: Play considers only genuine assistive tools eligible to declare `isAccessibilityTool`; declaring it on a remote-control app risks rejection. Current distribution is sideload / GitHub Releases / F-Droid, where the manifest is never reviewed, so the flag is fine. If Play distribution is pursued later, split into per-distribution build variants — a `play` flavor overriding `accessibility_service_config.xml` **without** the flag (plus the required prominent disclosure/consent flow), keeping the flag only in the sideload/F-Droid variant.
+
 ### Permission Handling
 
 - **Accessibility**: User must enable manually in Settings (provide deep link). Also provides screenshot capture via `takeScreenshot()` API (Android 11+)


### PR DESCRIPTION
## Summary

Android 14+ (API 34) lets apps mark UI subtrees `accessibilityDataSensitive`. Such nodes are delivered **only** to accessibility services that declare `android:isAccessibilityTool="true"` (and to the system `UiAutomation`). Our service did not declare it, so those subtrees were silently filtered out of the tree we receive.

Observed impact: the **GitHub app** rendered as an empty `main_activity_container` in `get_screen_state` / `find_nodes` — no header, no issue list, no bottom nav — even though the content was fully present in the framework tree (confirmed by comparing against `uiautomator dump`, which uses `UiAutomation` and saw all 144 nodes). Node-based tools were unusable on such apps.

## Root cause

Not a traversal, cache, or formatter bug in this app (all ruled out via instrumentation: `main_activity_container` reported `childCount=0` to our connection, `2` after the fix). The framework filters `accessibilityDataSensitive` subtrees from any service without `isAccessibilityTool="true"`.

## Changes

- `app/src/main/res/xml/accessibility_service_config.xml`: add `android:isAccessibilityTool="true"`.
- `docs/PROJECT.md`: document the flag, the `accessibilityDataSensitive` mechanism, the security trade-off (bypasses the anti-scraping protection banking/password apps rely on), and the deferred Google Play build-variant plan.

## Security / distribution notes

- The flag intentionally bypasses `accessibilityDataSensitive`. Acceptable for a user-installed, user-enabled remote-control tool; documented as a deliberate trade-off.
- Google Play deems only genuine assistive tools eligible to declare `isAccessibilityTool`. Current distribution is sideload / GitHub Releases / F-Droid (manifest never reviewed), so this is fine. If Play is pursued later, split into per-distribution build variants (a `play` flavor without the flag + disclosure flow). Captured in PROJECT.md.

## Testing

- Verified end-to-end on a physical Pixel 8 Pro (Android 16): before the change GitHub's content was invisible; after, `find_nodes` locates issue nodes and `get_screen_state` returns the full tree.
- `make lint` passes (ktlint + detekt).
- Manifest-config-only change; no unit-testable logic added.

## Checklist

- [x] Lint passes (`make lint`)
- [x] Verified on-device (Pixel 8 Pro, Android 16)
- [x] Automated tests — N/A (manifest configuration; no testable code path)