### PR TITLE
fix: enable CORS for browser-based MCP clients

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -215,6 +215,7 @@ dependencies {
     implementation(libs.ktor.server.core)
     implementation(libs.ktor.server.netty)
     implementation(libs.ktor.server.content.negotiation)
+    implementation(libs.ktor.server.cors)
     implementation(libs.ktor.network.tls.certificates)
     implementation(libs.ktor.serialization.kotlinx.json)
 

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/Cors.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/Cors.kt
@@ -12,6 +12,9 @@ const val MCP_PROTOCOL_VERSION_HEADER = "mcp-protocol-version"
 /** Request/response header carrying the Streamable HTTP session id. */
 const val MCP_SESSION_ID_HEADER = "mcp-session-id"
 
+/** Preflight cache lifetime (1 hour) — avoids re-issuing a preflight for nearly every `/mcp` call. */
+private const val CORS_MAX_AGE_SECONDS = 3600L
+
 /**
  * Installs permissive CORS so browser-based MCP clients (e.g. the MCP Inspector) can complete the
  * OAuth discovery/DCR/authorize flow AND the `/mcp` protocol exchange. Without it the browser's
@@ -20,13 +23,27 @@ const val MCP_SESSION_ID_HEADER = "mcp-session-id"
  * MUST be installed BEFORE [com.danielealbano.androidremotecontrolmcp.mcp.auth.McpAuthPlugin]: that
  * plugin intercepts [io.ktor.server.application.ApplicationCallPipeline.Plugins] and fails closed on
  * any token-less request to `/mcp` — including a preflight `OPTIONS`, which carries no `Authorization`
- * header. Installing CORS first lets it answer and finish the preflight before auth runs.
+ * header. Installing CORS first lets it answer and finish the preflight before auth runs. This ordering
+ * is centralized in [installMcpBasePlugins] so production and tests cannot drift.
  *
  * Any origin is allowed ([anyHost]) — this does NOT weaken auth: `/mcp` still requires the bearer or
  * OAuth token (which a cross-origin page cannot obtain) and the OAuth flow is still gated by the
  * on-device number-match approval. Credentials mode is deliberately NOT enabled (auth travels in the
  * `Authorization` header, not cookies), which is what permits the wildcard origin — the two are
- * mutually exclusive per the CORS spec.
+ * mutually exclusive per the CORS spec. For every non-browser client (Claude.ai backend, `mcp-remote`,
+ * Claude Desktop) there is no `Origin` header, so the CORS plugin is a complete no-op and OAuth /
+ * bearer behavior is byte-identical to before.
+ *
+ * **Trade-off (open mode / DNS rebinding).** The wildcard removes the browser same-origin barrier that
+ * previously blocked a cross-origin `application/json` POST to `/mcp`. With the defaults (loopback
+ * binding + auth enabled) this is fully mitigated — a cross-origin page cannot obtain a token, so
+ * `/mcp` returns 401. But if the user runs in OPEN mode (both `bearer_token_enabled` and
+ * `oauth_enabled` disabled — an explicit, warned-about choice) on a network-reachable binding, a
+ * malicious page in the victim's browser could now drive the tool surface. No `Origin`/`Host`
+ * allowlist is enforced because the device's public host is dynamic (changing IPs, Cloudflare/ngrok
+ * tunnels, `public_url_override`), so any static allowlist would break remote access. Stay on loopback
+ * and keep at least one auth method enabled unless the network is trusted — see PROJECT.md
+ * "Network Security".
  *
  * Response headers are exposed so browser clients can read them via `fetch()` (non-safelisted response
  * headers are hidden from JS otherwise):
@@ -35,7 +52,9 @@ const val MCP_SESSION_ID_HEADER = "mcp-session-id"
  * - `WWW-Authenticate` — carries the RFC 9728 `resource_metadata` pointer on a 401, which is how a
  *   browser MCP client discovers the OAuth authorization server. Not exposing it would defeat the
  *   header the auth plugin sends specifically for this discovery.
- * - [MCP_PROTOCOL_VERSION_HEADER] — the negotiated protocol version the transport may echo back.
+ *
+ * [MCP_PROTOCOL_VERSION_HEADER] is allowed as a REQUEST header (MCP 2025-06-18 clients send it) but is
+ * NOT exposed, because the SDK transport does not emit it as a response header.
  */
 fun Application.configureCors() {
     install(CORS) {
@@ -50,7 +69,7 @@ fun Application.configureCors() {
         allowHeader(MCP_SESSION_ID_HEADER)
         exposeHeader(MCP_SESSION_ID_HEADER)
         exposeHeader(HttpHeaders.WWWAuthenticate)
-        exposeHeader(MCP_PROTOCOL_VERSION_HEADER)
+        maxAgeInSeconds = CORS_MAX_AGE_SECONDS
         // MCP POSTs use `Content-Type: application/json`, a non-simple content type whose preflight
         // Ktor rejects unless explicitly allowed.
         allowNonSimpleContentTypes = true

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/Cors.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/Cors.kt
@@ -1,0 +1,58 @@
+package com.danielealbano.androidremotecontrolmcp.mcp
+
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.plugins.cors.routing.CORS
+
+/** Request header carrying the negotiated MCP protocol version. */
+const val MCP_PROTOCOL_VERSION_HEADER = "mcp-protocol-version"
+
+/** Request/response header carrying the Streamable HTTP session id. */
+const val MCP_SESSION_ID_HEADER = "mcp-session-id"
+
+/**
+ * Installs permissive CORS so browser-based MCP clients (e.g. the MCP Inspector) can complete the
+ * OAuth discovery/DCR/authorize flow AND the `/mcp` protocol exchange. Without it the browser's
+ * preflight `OPTIONS` and cross-origin requests are blocked before reaching any handler.
+ *
+ * MUST be installed BEFORE [com.danielealbano.androidremotecontrolmcp.mcp.auth.McpAuthPlugin]: that
+ * plugin intercepts [io.ktor.server.application.ApplicationCallPipeline.Plugins] and fails closed on
+ * any token-less request to `/mcp` — including a preflight `OPTIONS`, which carries no `Authorization`
+ * header. Installing CORS first lets it answer and finish the preflight before auth runs.
+ *
+ * Any origin is allowed ([anyHost]) — this does NOT weaken auth: `/mcp` still requires the bearer or
+ * OAuth token (which a cross-origin page cannot obtain) and the OAuth flow is still gated by the
+ * on-device number-match approval. Credentials mode is deliberately NOT enabled (auth travels in the
+ * `Authorization` header, not cookies), which is what permits the wildcard origin — the two are
+ * mutually exclusive per the CORS spec.
+ *
+ * Response headers are exposed so browser clients can read them via `fetch()` (non-safelisted response
+ * headers are hidden from JS otherwise):
+ * - [MCP_SESSION_ID_HEADER] — the session id the Streamable HTTP transport returns, replayed on
+ *   follow-up requests.
+ * - `WWW-Authenticate` — carries the RFC 9728 `resource_metadata` pointer on a 401, which is how a
+ *   browser MCP client discovers the OAuth authorization server. Not exposing it would defeat the
+ *   header the auth plugin sends specifically for this discovery.
+ * - [MCP_PROTOCOL_VERSION_HEADER] — the negotiated protocol version the transport may echo back.
+ */
+fun Application.configureCors() {
+    install(CORS) {
+        anyHost()
+        allowMethod(HttpMethod.Get)
+        allowMethod(HttpMethod.Post)
+        allowMethod(HttpMethod.Delete)
+        allowMethod(HttpMethod.Options)
+        allowHeader(HttpHeaders.ContentType)
+        allowHeader(HttpHeaders.Authorization)
+        allowHeader(MCP_PROTOCOL_VERSION_HEADER)
+        allowHeader(MCP_SESSION_ID_HEADER)
+        exposeHeader(MCP_SESSION_ID_HEADER)
+        exposeHeader(HttpHeaders.WWWAuthenticate)
+        exposeHeader(MCP_PROTOCOL_VERSION_HEADER)
+        // MCP POSTs use `Content-Type: application/json`, a non-simple content type whose preflight
+        // Ktor rejects unless explicitly allowed.
+        allowNonSimpleContentTypes = true
+    }
+}

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/McpApplicationPlugins.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/McpApplicationPlugins.kt
@@ -1,0 +1,30 @@
+package com.danielealbano.androidremotecontrolmcp.mcp
+
+import com.danielealbano.androidremotecontrolmcp.mcp.auth.McpAuthConfig
+import com.danielealbano.androidremotecontrolmcp.mcp.auth.McpAuthPlugin
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.modelcontextprotocol.kotlin.sdk.types.McpJson
+
+/**
+ * Installs the MCP application base plugins in the ONE canonical order shared by production
+ * ([McpServer.configureApplication]) and the integration tests:
+ *
+ * 1. [ContentNegotiation] with `json(McpJson)` — required by the SDK Streamable HTTP transport.
+ * 2. [configureCors] — MUST precede auth so token-less browser preflight `OPTIONS` are answered by
+ *    CORS instead of being failed closed (401) by the auth plugin.
+ * 3. [McpAuthPlugin] — combined bearer/OAuth authentication, configured by the caller.
+ *
+ * Centralizing the order here makes the CORS-before-auth invariant impossible to break by reordering
+ * a single caller: every caller (production and tests) goes through this function, and the integration
+ * tests exercise it directly, so a regression in the ordering cannot pass unnoticed.
+ *
+ * @param configureAuth Caller-supplied [McpAuthConfig] block (tokens, OAuth validator, exclusions).
+ */
+fun Application.installMcpBasePlugins(configureAuth: McpAuthConfig.() -> Unit) {
+    install(ContentNegotiation) { json(McpJson) }
+    configureCors()
+    install(McpAuthPlugin, configureAuth)
+}

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/McpServer.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/McpServer.kt
@@ -155,6 +155,11 @@ class McpServer(
             json(McpJson)
         }
 
+        // CORS — MUST be installed before McpAuthPlugin so preflight OPTIONS (which carry no
+        // Authorization header) are answered by CORS instead of being failed closed by auth.
+        // Enables browser MCP clients (e.g. MCP Inspector) to reach the OAuth and /mcp endpoints.
+        configureCors()
+
         // Combined MCP authentication: static bearer OR issued OAuth access token (dual-accept).
         // Excludes /health, the unauthenticated OAuth endpoints, the /.well-known/ namespace, and the
         // /s/ capability route. Exact paths are used for the OAuth endpoints (not prefixes) so sibling

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/McpServer.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/McpServer.kt
@@ -3,7 +3,6 @@ package com.danielealbano.androidremotecontrolmcp.mcp
 import android.util.Log
 import com.danielealbano.androidremotecontrolmcp.BuildConfig
 import com.danielealbano.androidremotecontrolmcp.data.model.ServerConfig
-import com.danielealbano.androidremotecontrolmcp.mcp.auth.McpAuthPlugin
 import com.danielealbano.androidremotecontrolmcp.mcp.oauth.OAuthAccessValidator
 import com.danielealbano.androidremotecontrolmcp.mcp.oauth.OAuthRouteDeps
 import com.danielealbano.androidremotecontrolmcp.mcp.oauth.OAuthServerDeps
@@ -11,20 +10,16 @@ import com.danielealbano.androidremotecontrolmcp.mcp.oauth.installOAuthRoutes
 import com.danielealbano.androidremotecontrolmcp.services.sharing.EphemeralFileLinkService
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
-import io.ktor.serialization.kotlinx.json.json
-import io.ktor.server.application.install
 import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.engine.sslConnector
 import io.ktor.server.netty.Netty
 import io.ktor.server.netty.NettyApplicationEngine
-import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondBytes
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
-import io.modelcontextprotocol.kotlin.sdk.types.McpJson
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import java.security.KeyStore
@@ -149,22 +144,16 @@ class McpServer(
     }
 
     private fun io.ktor.server.application.Application.configureApplication() {
-        // JSON serialization — required by StreamableHttpServerTransport
-        // which uses call.respond(JSONRPCResponse/Error) internally
-        install(ContentNegotiation) {
-            json(McpJson)
-        }
-
-        // CORS — MUST be installed before McpAuthPlugin so preflight OPTIONS (which carry no
-        // Authorization header) are answered by CORS instead of being failed closed by auth.
-        // Enables browser MCP clients (e.g. MCP Inspector) to reach the OAuth and /mcp endpoints.
-        configureCors()
-
+        // Base plugins in the canonical order (ContentNegotiation → CORS → auth). CORS MUST precede
+        // auth so browser preflight OPTIONS (no Authorization header) are answered by CORS instead of
+        // being failed closed by auth. The order lives in installMcpBasePlugins so it stays consistent
+        // between production and the integration tests.
+        //
         // Combined MCP authentication: static bearer OR issued OAuth access token (dual-accept).
         // Excludes /health, the unauthenticated OAuth endpoints, the /.well-known/ namespace, and the
         // /s/ capability route. Exact paths are used for the OAuth endpoints (not prefixes) so sibling
         // routes are not silently exempted.
-        install(McpAuthPlugin) {
+        installMcpBasePlugins {
             bearerTokenEnabled = config.bearerTokenEnabled
             expectedToken = config.bearerToken
             oauthEnabled = config.oauthEnabled

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/McpStreamableHttpExtension.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/McpStreamableHttpExtension.kt
@@ -27,7 +27,6 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 
 private const val TAG = "MCP:StreamableHttp"
-private const val MCP_SESSION_ID_HEADER = "mcp-session-id"
 private const val MAX_SESSIONS = 100
 private const val SESSION_CLEANUP_INTERVAL_MS = 60_000L
 private const val SESSION_IDLE_TIMEOUT_MS = 7L * 24 * 60 * 60 * 1000 // 7 days

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/CorsIntegrationTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/CorsIntegrationTest.kt
@@ -1,0 +1,227 @@
+package com.danielealbano.androidremotecontrolmcp.integration
+
+import com.danielealbano.androidremotecontrolmcp.mcp.auth.McpAuthPlugin
+import com.danielealbano.androidremotecontrolmcp.mcp.configureCors
+import com.danielealbano.androidremotecontrolmcp.mcp.effectiveBaseUrl
+import com.danielealbano.androidremotecontrolmcp.mcp.mcpStreamableHttp
+import com.danielealbano.androidremotecontrolmcp.services.sharing.EphemeralFileLinkService
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.options
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import io.modelcontextprotocol.kotlin.sdk.types.McpJson
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("CORS Integration Tests")
+class CorsIntegrationTest {
+    @BeforeEach
+    fun setUp() {
+        McpIntegrationTestHelper.mockAndroidLog()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        McpIntegrationTestHelper.unmockAndroidLog()
+    }
+
+    /**
+     * Configures a test application mirroring the production plugin ordering in
+     * [com.danielealbano.androidremotecontrolmcp.mcp.McpServer.configureApplication]: ContentNegotiation,
+     * then [configureCors] (BEFORE auth so preflight is not failed closed), then [McpAuthPlugin], a
+     * `/health` and a stand-in `/register` route (both auth-excluded), and `/mcp`.
+     *
+     * NOTE: this replicates the production wiring rather than invoking it (McpServer builds Netty). If
+     * the production ordering or auth-exclusion set changes, this MUST be kept in sync or these tests
+     * stop protecting the real behavior.
+     *
+     * @param oauthEnabled When true, auth emits the RFC 9728 `WWW-Authenticate` discovery header on 401
+     *   (the OAuth token check always denies here — only the 401 header path is under test).
+     */
+    private suspend fun withCorsApp(
+        oauthEnabled: Boolean = false,
+        testBlock: suspend ApplicationTestBuilder.() -> Unit,
+    ) {
+        val deps = McpIntegrationTestHelper.createMockDependencies()
+        val sdkServer = McpIntegrationTestHelper.createSdkServer(deps)
+        testApplication {
+            application {
+                install(ContentNegotiation) { json(McpJson) }
+                configureCors()
+                install(McpAuthPlugin) {
+                    bearerTokenEnabled = true
+                    expectedToken = McpIntegrationTestHelper.TEST_BEARER_TOKEN
+                    this.oauthEnabled = oauthEnabled
+                    validateOAuthToken = { _, _ -> false }
+                    baseUrlOf = { effectiveBaseUrl(it, "") }
+                    excludedPaths = setOf("/health", "/register", "/token", "/authorize", "/authorize/status")
+                    excludedPathPrefixes = setOf(EphemeralFileLinkService.PATH_PREFIX, "/.well-known/")
+                }
+                routing {
+                    get("/health") { call.respondText("{}", ContentType.Application.Json) }
+                    post("/register") { call.respondText("{}", ContentType.Application.Json) }
+                }
+                mcpStreamableHttp { sdkServer }
+            }
+            testBlock()
+        }
+    }
+
+    private fun HttpResponse.allowOrigin(): String? = headers[HttpHeaders.AccessControlAllowOrigin]
+
+    private fun HttpResponse.headerTokens(name: String): List<String> =
+        headers[name]
+            .orEmpty()
+            .split(",")
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+
+    @Test
+    fun `preflight OPTIONS on mcp returns wildcard origin and is not failed closed by auth`() =
+        runTest {
+            withCorsApp {
+                val response =
+                    client.options("/mcp") {
+                        header(HttpHeaders.Origin, "https://inspector.example.com")
+                        header(HttpHeaders.AccessControlRequestMethod, "POST")
+                        header(
+                            HttpHeaders.AccessControlRequestHeaders,
+                            "authorization, content-type, mcp-protocol-version",
+                        )
+                    }
+
+                assertTrue(response.status.value in 200..299, "preflight should succeed, was ${response.status}")
+                assertEquals("*", response.allowOrigin())
+                val allowedHeaders =
+                    response.headerTokens(HttpHeaders.AccessControlAllowHeaders).map { it.lowercase() }
+                listOf("authorization", "content-type", "mcp-protocol-version", "mcp-session-id").forEach {
+                    assertTrue(it in allowedHeaders, "expected '$it' in Allow-Headers, was $allowedHeaders")
+                }
+                // POST/GET are CORS-safelisted ("simple") methods that Ktor does not enumerate — they are
+                // implicitly allowed. DELETE (MCP session termination) is non-simple and MUST be listed.
+                val allowedMethods = response.headerTokens(HttpHeaders.AccessControlAllowMethods)
+                assertTrue("DELETE" in allowedMethods, "expected DELETE in Allow-Methods, was $allowedMethods")
+            }
+        }
+
+    @Test
+    fun `preflight OPTIONS on oauth register endpoint returns wildcard origin`() =
+        runTest {
+            withCorsApp {
+                val response =
+                    client.options("/register") {
+                        header(HttpHeaders.Origin, "https://inspector.example.com")
+                        header(HttpHeaders.AccessControlRequestMethod, "POST")
+                        header(HttpHeaders.AccessControlRequestHeaders, "content-type")
+                    }
+
+                assertTrue(response.status.value in 200..299, "preflight should succeed, was ${response.status}")
+                assertEquals("*", response.allowOrigin())
+            }
+        }
+
+    @Test
+    fun `cross-origin GET exposes mcp-session-id response header to the browser`() =
+        runTest {
+            withCorsApp {
+                val response =
+                    client.get("/health") {
+                        header(HttpHeaders.Origin, "https://inspector.example.com")
+                    }
+
+                assertEquals("*", response.allowOrigin())
+                val exposed = response.headers[HttpHeaders.AccessControlExposeHeaders].orEmpty()
+                assertTrue(
+                    exposed.split(",").any { it.trim().equals("mcp-session-id", ignoreCase = true) },
+                    "expected mcp-session-id to be exposed, was '$exposed'",
+                )
+            }
+        }
+
+    @Test
+    fun `unauthenticated cross-origin POST mcp still carries allow-origin so browser can read the 401`() =
+        runTest {
+            withCorsApp {
+                val response =
+                    client.post("/mcp") {
+                        header(HttpHeaders.Origin, "https://inspector.example.com")
+                        contentType(ContentType.Application.Json)
+                        setBody("""{"jsonrpc":"2.0","id":1,"method":"initialize"}""")
+                    }
+
+                assertEquals(HttpStatusCode.Unauthorized, response.status)
+                assertEquals("*", response.allowOrigin())
+            }
+        }
+
+    @Test
+    fun `authenticated cross-origin POST mcp carries allow-origin`() =
+        runTest {
+            withCorsApp {
+                val response =
+                    client.post("/mcp") {
+                        header(HttpHeaders.Origin, "https://inspector.example.com")
+                        header("Authorization", "Bearer ${McpIntegrationTestHelper.TEST_BEARER_TOKEN}")
+                        header(HttpHeaders.Accept, "application/json, text/event-stream")
+                        contentType(ContentType.Application.Json)
+                        setBody(
+                            """{"jsonrpc":"2.0","id":1,"method":"initialize",""" +
+                                """"params":{"protocolVersion":"2025-06-18","capabilities":{},""" +
+                                """"clientInfo":{"name":"cors-test","version":"1.0"}}}""",
+                        )
+                    }
+
+                // Auth passed (not 401); regardless of the MCP-level outcome the CORS header must be present.
+                assertTrue(response.status != HttpStatusCode.Unauthorized, "auth should pass with valid token")
+                assertEquals("*", response.allowOrigin())
+            }
+        }
+
+    @Test
+    fun `WWW-Authenticate is exposed so a browser can read the OAuth discovery pointer on 401`() =
+        runTest {
+            withCorsApp(oauthEnabled = true) {
+                val response =
+                    client.post("/mcp") {
+                        header(HttpHeaders.Origin, "https://inspector.example.com")
+                        contentType(ContentType.Application.Json)
+                        setBody("""{"jsonrpc":"2.0","id":1,"method":"initialize"}""")
+                    }
+
+                assertEquals(HttpStatusCode.Unauthorized, response.status)
+                assertEquals("*", response.allowOrigin())
+                // The discovery header is actually sent...
+                val wwwAuth = response.headers[HttpHeaders.WWWAuthenticate].orEmpty()
+                assertTrue(
+                    wwwAuth.contains("resource_metadata"),
+                    "expected WWW-Authenticate with resource_metadata, was '$wwwAuth'",
+                )
+                // ...and exposed to browser JS.
+                val exposed = response.headerTokens(HttpHeaders.AccessControlExposeHeaders).map { it.lowercase() }
+                assertTrue(
+                    HttpHeaders.WWWAuthenticate.lowercase() in exposed,
+                    "expected WWW-Authenticate to be exposed, was $exposed",
+                )
+            }
+        }
+}

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/CorsIntegrationTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/CorsIntegrationTest.kt
@@ -1,8 +1,7 @@
 package com.danielealbano.androidremotecontrolmcp.integration
 
-import com.danielealbano.androidremotecontrolmcp.mcp.auth.McpAuthPlugin
-import com.danielealbano.androidremotecontrolmcp.mcp.configureCors
 import com.danielealbano.androidremotecontrolmcp.mcp.effectiveBaseUrl
+import com.danielealbano.androidremotecontrolmcp.mcp.installMcpBasePlugins
 import com.danielealbano.androidremotecontrolmcp.mcp.mcpStreamableHttp
 import com.danielealbano.androidremotecontrolmcp.services.sharing.EphemeralFileLinkService
 import io.ktor.client.request.get
@@ -15,16 +14,12 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
-import io.ktor.serialization.kotlinx.json.json
-import io.ktor.server.application.install
-import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
-import io.modelcontextprotocol.kotlin.sdk.types.McpJson
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -46,14 +41,12 @@ class CorsIntegrationTest {
     }
 
     /**
-     * Configures a test application mirroring the production plugin ordering in
-     * [com.danielealbano.androidremotecontrolmcp.mcp.McpServer.configureApplication]: ContentNegotiation,
-     * then [configureCors] (BEFORE auth so preflight is not failed closed), then [McpAuthPlugin], a
-     * `/health` and a stand-in `/register` route (both auth-excluded), and `/mcp`.
-     *
-     * NOTE: this replicates the production wiring rather than invoking it (McpServer builds Netty). If
-     * the production ordering or auth-exclusion set changes, this MUST be kept in sync or these tests
-     * stop protecting the real behavior.
+     * Configures a test application through the SAME [installMcpBasePlugins] the production
+     * [com.danielealbano.androidremotecontrolmcp.mcp.McpServer.configureApplication] uses, so the
+     * CORS-before-auth ordering under test is the real one (not a hand-copied replica): a production
+     * reorder would change [installMcpBasePlugins] and be caught here. Adds a `/health` and a stand-in
+     * `/register` route (both auth-excluded) plus `/mcp`. The full OAuth routes with CORS are exercised
+     * by the OAuth-flow suite via `McpIntegrationTestHelper.withOAuthTestApplication`.
      *
      * @param oauthEnabled When true, auth emits the RFC 9728 `WWW-Authenticate` discovery header on 401
      *   (the OAuth token check always denies here — only the 401 header path is under test).
@@ -66,9 +59,7 @@ class CorsIntegrationTest {
         val sdkServer = McpIntegrationTestHelper.createSdkServer(deps)
         testApplication {
             application {
-                install(ContentNegotiation) { json(McpJson) }
-                configureCors()
-                install(McpAuthPlugin) {
+                installMcpBasePlugins {
                     bearerTokenEnabled = true
                     expectedToken = McpIntegrationTestHelper.TEST_BEARER_TOKEN
                     this.oauthEnabled = oauthEnabled
@@ -191,8 +182,11 @@ class CorsIntegrationTest {
                         )
                     }
 
-                // Auth passed (not 401); regardless of the MCP-level outcome the CORS header must be present.
-                assertTrue(response.status != HttpStatusCode.Unauthorized, "auth should pass with valid token")
+                // Auth passed AND the MCP initialize succeeded (2xx), with the CORS header present.
+                assertTrue(
+                    response.status.value in 200..299,
+                    "authenticated initialize should succeed (2xx), was ${response.status}",
+                )
                 assertEquals("*", response.allowOrigin())
             }
         }

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/McpIntegrationTestHelper.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/McpIntegrationTestHelper.kt
@@ -7,8 +7,8 @@ import com.danielealbano.androidremotecontrolmcp.data.model.ToolPermissionsConfi
 import com.danielealbano.androidremotecontrolmcp.data.repository.OAuthClientRepository
 import com.danielealbano.androidremotecontrolmcp.data.repository.OAuthClientRepositoryImpl
 import com.danielealbano.androidremotecontrolmcp.data.repository.SettingsRepository
-import com.danielealbano.androidremotecontrolmcp.mcp.auth.McpAuthPlugin
 import com.danielealbano.androidremotecontrolmcp.mcp.effectiveBaseUrl
+import com.danielealbano.androidremotecontrolmcp.mcp.installMcpBasePlugins
 import com.danielealbano.androidremotecontrolmcp.mcp.mcpStreamableHttp
 import com.danielealbano.androidremotecontrolmcp.mcp.oauth.AuthorizationCodeStoreImpl
 import com.danielealbano.androidremotecontrolmcp.mcp.oauth.JwtTokenService
@@ -56,8 +56,6 @@ import com.danielealbano.androidremotecontrolmcp.services.sharing.EphemeralFileL
 import com.danielealbano.androidremotecontrolmcp.services.storage.FileOperationProvider
 import com.danielealbano.androidremotecontrolmcp.services.storage.StorageLocationProvider
 import io.ktor.serialization.kotlinx.json.json
-import io.ktor.server.application.install
-import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
 import io.mockk.every
@@ -296,8 +294,8 @@ object McpIntegrationTestHelper {
 
         testApplication {
             application {
-                install(ContentNegotiation) { json(McpJson) }
-                install(McpAuthPlugin) { expectedToken = TEST_BEARER_TOKEN }
+                // Uses the production base-plugin wiring (ContentNegotiation → CORS → auth).
+                installMcpBasePlugins { expectedToken = TEST_BEARER_TOKEN }
                 mcpStreamableHttp { sdkServer }
             }
 
@@ -350,8 +348,7 @@ object McpIntegrationTestHelper {
 
         testApplication {
             application {
-                install(ContentNegotiation) { json(McpJson) }
-                install(McpAuthPlugin) {
+                installMcpBasePlugins {
                     this.bearerTokenEnabled = bearerTokenEnabled
                     expectedToken = if (bearerTokenEnabled) TEST_BEARER_TOKEN else ""
                     this.oauthEnabled = oauthEnabled
@@ -408,8 +405,9 @@ object McpIntegrationTestHelper {
 
         testApplication {
             application {
-                install(ContentNegotiation) { json(McpJson) }
-                install(McpAuthPlugin) {
+                // Full production wiring WITH CORS in front of the real OAuth routes, so the
+                // OAuth-flow tests verify OAuth and CORS coexist end-to-end.
+                installMcpBasePlugins {
                     this.bearerTokenEnabled = bearerTokenEnabled
                     expectedToken = bearerToken
                     oauthEnabled = true

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -636,6 +636,8 @@ Tunnel architecture:
 | Device as Hotspot | Not accessible | Accessible to hotspot clients |
 | ADB Port Forward | Accessible via host | Accessible via host |
 
+**CORS (browser clients)**: The server sends permissive CORS (`Access-Control-Allow-Origin: *`, no credentials mode) so browser-based MCP clients (e.g. MCP Inspector) can complete the OAuth flow and `/mcp` exchange. This does not weaken authentication — `/mcp` still requires a bearer/OAuth token that a cross-origin page cannot obtain, and non-browser clients send no `Origin` so CORS is a no-op for them. **Trade-off**: the wildcard removes the browser same-origin barrier, so in OPEN mode (both auth methods disabled) on a network-reachable or DNS-rebindable binding, a malicious web page in the victim's browser could drive the tool surface. No `Origin`/`Host` allowlist is enforced because the device's public host is dynamic (changing IPs, Cloudflare/ngrok tunnels, `public_url_override`); any static allowlist would break remote access. Mitigation: stay on the loopback binding and keep at least one auth method enabled unless the network is trusted.
+
 ### Permission Security
 
 Only necessary permissions: `INTERNET`, `FOREGROUND_SERVICE`, `RECEIVE_BOOT_COMPLETED`, `QUERY_ALL_PACKAGES` (app listing), `KILL_BACKGROUND_PROCESSES` (app closing), `CAMERA` (camera tools, runtime), `RECORD_AUDIO` (video recording with audio, runtime), `ACCESS_FINE_LOCATION` (device location, runtime), `ACCESS_COARSE_LOCATION` (location fallback, declared), Accessibility Service (user-granted via Settings), SAF tree URI permissions (user-granted per storage location via system file picker). Display clear explanations before requesting.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -110,6 +110,7 @@ osmdroid = { group = "org.osmdroid", name = "osmdroid-android", version.ref = "o
 ktor-server-core = { group = "io.ktor", name = "ktor-server-core", version.ref = "ktor" }
 ktor-server-netty = { group = "io.ktor", name = "ktor-server-netty", version.ref = "ktor" }
 ktor-server-content-negotiation = { group = "io.ktor", name = "ktor-server-content-negotiation", version.ref = "ktor" }
+ktor-server-cors = { group = "io.ktor", name = "ktor-server-cors", version.ref = "ktor" }
 ktor-network-tls-certificates = { group = "io.ktor", name = "ktor-network-tls-certificates", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
 


### PR DESCRIPTION
## Summary

Browser-based MCP clients (e.g. the MCP Inspector) run in a web page, so the browser enforces CORS on the OAuth discovery/DCR/authorize flow and on the `/mcp` protocol exchange. The server installed no CORS plugin, so preflight `OPTIONS` and cross-origin requests were blocked and the Inspector could not connect. This adds a permissive, auth-safe CORS configuration.

## Changes

- **Dependency**: add `ktor-server-cors` (matching the existing Ktor 3.4.0 version).
- **`Cors.kt`** (new) — `Application.configureCors()`:
  - `anyHost()` (wildcard origin). Credentials mode is deliberately NOT enabled, so the wildcard is spec-legal and cookies are never attached. This does not weaken auth: `/mcp` still requires a bearer/OAuth token (which a cross-origin page cannot obtain) and OAuth is gated by on-device number-match approval.
  - Allows methods GET/POST/DELETE/OPTIONS and the `content-type`/`authorization`/`mcp-protocol-version`/`mcp-session-id` request headers (`allowNonSimpleContentTypes` for `application/json`).
  - Exposes `mcp-session-id` (session replay), `WWW-Authenticate` (RFC 9728 OAuth discovery pointer on 401), and `mcp-protocol-version` so browser JS can read them.
- **`McpServer.kt`** — installs `configureCors()` **before** `McpAuthPlugin`, because that plugin fails closed on token-less `/mcp` requests (including preflight `OPTIONS`); CORS must run first to answer the preflight.
- **`McpStreamableHttpExtension.kt`** — single-source the `mcp-session-id` header constant (now in `Cors.kt`).

## Testing

- New `CorsIntegrationTest` (6 tests): preflight on `/mcp` (not failed closed by auth) and on an OAuth endpoint; allow-headers/allow-methods content; `mcp-session-id` exposure; authenticated and unauthenticated cross-origin `POST /mcp` carrying `Access-Control-Allow-Origin`; `WWW-Authenticate` exposure for browser OAuth discovery on 401.
- `code-reviewer` run; the one should-fix it surfaced (`WWW-Authenticate` not exposed, which would silently break browser OAuth discovery) is fixed here.

## Checklist

- [x] All tests pass (`./gradlew :app:testDebugUnitTest`)
- [x] Lint passes (`ktlintCheck` + `detekt`)
- [x] Build succeeds (`./gradlew assembleDebug`)
- [ ] CI validated locally (`gh act --validate`)