### PR TITLE
build(release): git-derived versionCode + signed AAB tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
         uses: actions/checkout@v7
         with:
           submodules: true
+          # Full history + tags: build.gradle.kts derives versionName/versionCode from
+          # git and fails configuration without them (no hardcoded fallback).
+          fetch-depth: 0
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -65,6 +68,9 @@ jobs:
         uses: actions/checkout@v7
         with:
           submodules: true
+          # Full history + tags: build.gradle.kts derives versionName/versionCode from
+          # git and fails configuration without them (no hardcoded fallback).
+          fetch-depth: 0
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -152,6 +158,9 @@ jobs:
         uses: actions/checkout@v7
         with:
           submodules: true
+          # Full history + tags: build.gradle.kts derives versionName/versionCode from
+          # git and fails configuration without them (no hardcoded fallback).
+          fetch-depth: 0
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -292,8 +301,10 @@ jobs:
         uses: actions/checkout@v7
         with:
           submodules: true
-          # Full history + tags so Gradle can derive versionName (git describe)
-          # and versionCode (git rev-list --count) accurately.
+          # Full history + tags: build.gradle.kts derives versionName/versionCode from
+          # git and fails configuration without them (no hardcoded fallback). On
+          # pull_request runs this reflects the ephemeral merge ref, not the post-merge
+          # main commit; these artifacts are unsigned and never shipped.
           fetch-depth: 0
 
       - name: Set up JDK 17

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,6 +292,9 @@ jobs:
         uses: actions/checkout@v7
         with:
           submodules: true
+          # Full history + tags so Gradle can derive versionName (git describe)
+          # and versionCode (git rev-list --count) accurately.
+          fetch-depth: 0
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           allowed-conclusions: success
           running-workflow-name: 'Create Draft Release'
 
-      # ── 4. Parse tag → VERSION_NAME, VERSION_CODE, pre-release flag ──
+      # ── 4. Parse tag → VERSION_NAME + pre-release flag (versionCode is derived by Gradle) ──
       - name: Parse tag
         id: parse-tag
         env:
@@ -53,37 +53,25 @@ jobs:
           # Strip 'v' prefix to get version
           VERSION="${TAG#v}"
 
-          # Parse: MAJOR.MINOR.PATCH[-PRERELEASE]
+          # Validate MAJOR.MINOR.PATCH[-PRERELEASE] and extract the pre-release suffix
           if [[ "$VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-(.+))?$ ]]; then
-            MAJOR="${BASH_REMATCH[1]}"
-            MINOR="${BASH_REMATCH[2]}"
-            PATCH="${BASH_REMATCH[3]}"
             PRERELEASE="${BASH_REMATCH[5]}"
           else
             echo "::error::Invalid version format: $VERSION (expected: MAJOR.MINOR.PATCH[-PRERELEASE])"
             exit 1
           fi
 
-          # Compute VERSION_CODE offset based on pre-release type
-          # alpha=01, beta=10, rc{N}=20+N, release=99
+          # Determine the pre-release flag from the tag suffix.
+          # The numeric versionCode is derived by Gradle from git history
+          # (see app/build.gradle.kts getGitVersionCode); no version-code math here.
           if [ -z "$PRERELEASE" ]; then
-            OFFSET=99
             IS_PRERELEASE="false"
-          elif [ "$PRERELEASE" = "alpha" ]; then
-            OFFSET=1
-            IS_PRERELEASE="true"
-          elif [ "$PRERELEASE" = "beta" ]; then
-            OFFSET=10
+          elif [ "$PRERELEASE" = "alpha" ] || [ "$PRERELEASE" = "beta" ]; then
             IS_PRERELEASE="true"
           elif [[ "$PRERELEASE" =~ ^rc([0-9]+)$ ]]; then
             RC_NUM=$((10#${BASH_REMATCH[1]}))
             if [ "$RC_NUM" -lt 1 ]; then
               echo "::error::RC number must be >= 1 (got rc${RC_NUM})"
-              exit 1
-            fi
-            OFFSET=$(( 20 + RC_NUM ))
-            if [ "$OFFSET" -ge 99 ]; then
-              echo "::error::RC number too high: rc${RC_NUM} (max rc78)"
               exit 1
             fi
             IS_PRERELEASE="true"
@@ -92,17 +80,8 @@ jobs:
             exit 1
           fi
 
-          VERSION_CODE=$(( MAJOR * 1000000 + MINOR * 10000 + PATCH * 100 + OFFSET ))
-
-          # Android versionCode must fit in a signed 32-bit integer (max 2147483647)
-          if [ "$VERSION_CODE" -gt 2147483647 ]; then
-            echo "::error::VERSION_CODE overflow: $VERSION_CODE exceeds Android maximum (2147483647)"
-            exit 1
-          fi
-
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "version-code=$VERSION_CODE" >> "$GITHUB_OUTPUT"
           echo "is-prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
 
           echo "### Parsed Tag" >> "$GITHUB_STEP_SUMMARY"
@@ -110,7 +89,6 @@ jobs:
           echo "|-------|-------|" >> "$GITHUB_STEP_SUMMARY"
           echo "| Tag | \`$TAG\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Version Name | \`$VERSION\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Version Code | \`$VERSION_CODE\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Pre-release | $IS_PRERELEASE |" >> "$GITHUB_STEP_SUMMARY"
 
       # ── 5. Setup build toolchains (same as CI build-release job) ──
@@ -183,12 +161,11 @@ jobs:
           path: .dbip-cache
           key: dbip-csv-${{ steps.dbip-month.outputs.month }}
 
-      # ── 8. Build APKs with version from tag ──
+      # ── 8. Build APKs with version name from tag (versionCode derived by Gradle from git) ──
       - name: Build APKs
         env:
           VERSION_NAME: ${{ steps.parse-tag.outputs.version }}
-          VERSION_CODE: ${{ steps.parse-tag.outputs.version-code }}
-        run: ./gradlew assembleGmsDebug assembleFossDebug assembleGmsRelease assembleFossRelease -PVERSION_NAME="$VERSION_NAME" -PVERSION_CODE="$VERSION_CODE"
+        run: ./gradlew assembleGmsDebug assembleFossDebug assembleGmsRelease assembleFossRelease -PVERSION_NAME="$VERSION_NAME"
 
       # ── 8. Rename APKs with proper names (per flavor: gms + foss) ──
       - name: Rename APKs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -617,10 +617,9 @@ Local development requires Android SDK, emulator/device, and standard Android de
 
 ### Versioning
 - Follow **semantic versioning** (MAJOR.MINOR.PATCH).
-- Version defined in `gradle.properties`:
-  - `VERSION_NAME=1.0.0`
-  - `VERSION_CODE=1` (auto-increment for each release).
-- Bump version: `make version-bump-patch`, `make version-bump-minor`, `make version-bump-major`.
+- `VERSION_NAME` is derived from git tags, with a `gradle.properties` fallback for git-less builds.
+- `versionCode` is derived from git history by Gradle (`getGitVersionCode`) and is never hardcoded; a full git checkout is required or the build fails at configuration (override with `-PVERSION_CODE=<integer>`).
+- Bump the version name: `make version-bump-patch`, `make version-bump-minor`, `make version-bump-major` (the version code is git-derived, not bumped).
 
 ### Health check endpoint (MCP server)
 - Implement `/health` endpoint in Ktor server.

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,11 @@ build-release: compile-cloudflared compile-ngrok-native ## Build gms + foss rele
 	$(GRADLE) assembleGmsRelease assembleFossRelease
 
 build-release-bundle: compile-cloudflared compile-ngrok-native ## Build signed gms release AAB for Google Play upload
+	@test -f keystore.properties || { \
+		echo "ERROR: keystore.properties not found — the AAB would be UNSIGNED and rejected by Google Play."; \
+		echo "Create it from keystore.properties.example first."; \
+		exit 1; \
+	}
 	$(GRADLE) bundleGmsRelease
 	@echo "AAB: app/build/outputs/bundle/gmsRelease/app-gms-release.aab"
 
@@ -289,11 +294,8 @@ version-bump-patch: ## Bump patch version (1.0.0 -> 1.0.1)
 	NEW_PATCH=$$((PATCH + 1)); \
 	NEW_VERSION="$$MAJOR.$$MINOR.$$NEW_PATCH"; \
 	sed -i.bak "s/^VERSION_NAME=.*/VERSION_NAME=$$NEW_VERSION/" gradle.properties; \
-	CODE=$$(grep '^VERSION_CODE=' gradle.properties | cut -d= -f2); \
-	NEW_CODE=$$((CODE + 1)); \
-	sed -i.bak "s/^VERSION_CODE=.*/VERSION_CODE=$$NEW_CODE/" gradle.properties; \
 	rm -f gradle.properties.bak; \
-	echo "Version bumped: $$CURRENT -> $$NEW_VERSION (code: $$CODE -> $$NEW_CODE)"
+	echo "Version bumped: $$CURRENT -> $$NEW_VERSION (versionCode is derived from git, not bumped here)"
 
 version-bump-minor: ## Bump minor version (1.0.0 -> 1.1.0)
 	@CURRENT=$$(grep '^VERSION_NAME=' gradle.properties | cut -d= -f2); \
@@ -302,11 +304,8 @@ version-bump-minor: ## Bump minor version (1.0.0 -> 1.1.0)
 	NEW_MINOR=$$((MINOR + 1)); \
 	NEW_VERSION="$$MAJOR.$$NEW_MINOR.0"; \
 	sed -i.bak "s/^VERSION_NAME=.*/VERSION_NAME=$$NEW_VERSION/" gradle.properties; \
-	CODE=$$(grep '^VERSION_CODE=' gradle.properties | cut -d= -f2); \
-	NEW_CODE=$$((CODE + 1)); \
-	sed -i.bak "s/^VERSION_CODE=.*/VERSION_CODE=$$NEW_CODE/" gradle.properties; \
 	rm -f gradle.properties.bak; \
-	echo "Version bumped: $$CURRENT -> $$NEW_VERSION (code: $$CODE -> $$NEW_CODE)"
+	echo "Version bumped: $$CURRENT -> $$NEW_VERSION (versionCode is derived from git, not bumped here)"
 
 version-bump-major: ## Bump major version (1.0.0 -> 2.0.0)
 	@CURRENT=$$(grep '^VERSION_NAME=' gradle.properties | cut -d= -f2); \
@@ -314,11 +313,8 @@ version-bump-major: ## Bump major version (1.0.0 -> 2.0.0)
 	NEW_MAJOR=$$((MAJOR + 1)); \
 	NEW_VERSION="$$NEW_MAJOR.0.0"; \
 	sed -i.bak "s/^VERSION_NAME=.*/VERSION_NAME=$$NEW_VERSION/" gradle.properties; \
-	CODE=$$(grep '^VERSION_CODE=' gradle.properties | cut -d= -f2); \
-	NEW_CODE=$$((CODE + 1)); \
-	sed -i.bak "s/^VERSION_CODE=.*/VERSION_CODE=$$NEW_CODE/" gradle.properties; \
 	rm -f gradle.properties.bak; \
-	echo "Version bumped: $$CURRENT -> $$NEW_VERSION (code: $$CODE -> $$NEW_CODE)"
+	echo "Version bumped: $$CURRENT -> $$NEW_VERSION (versionCode is derived from git, not bumped here)"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Native Binary Compilation (cloudflared + ngrok)

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
         install install-release uninstall grant-permissions start-server forward-port \
         setup-emulator start-emulator stop-emulator \
         logs logs-clear \
+        build-release-bundle \
         version-bump-patch version-bump-minor version-bump-major \
         compile-cloudflared compile-ngrok-native check-so-alignment \
         all ci
@@ -126,6 +127,10 @@ build-foss: compile-cloudflared compile-ngrok-native ## Build foss (F-Droid) deb
 
 build-release: compile-cloudflared compile-ngrok-native ## Build gms + foss release APKs
 	$(GRADLE) assembleGmsRelease assembleFossRelease
+
+build-release-bundle: compile-cloudflared compile-ngrok-native ## Build signed gms release AAB for Google Play upload
+	$(GRADLE) bundleGmsRelease
+	@echo "AAB: app/build/outputs/bundle/gmsRelease/app-gms-release.aab"
 
 clean: ## Clean build artifacts
 	$(GRADLE) clean

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -83,10 +83,10 @@ fun getGitDescribeVersion(): String? {
  *   files): a local dirty build sorts one above the clean build at the same commit
  *   without ever colliding with the next commit's code.
  *
- * Requires full history: a shallow clone is detected (git rev-parse
- * --is-shallow-repository) and treated as underivable. Returns null when git is
- * unavailable, the clone is shallow, or a command errors, so the caller can fall back
- * to the gradle.properties value (e.g. building from a source tarball).
+ * Requires full history: a shallow clone (detected via the `shallow` marker file in
+ * the git dir) is treated as underivable. Returns null when git is unavailable, the
+ * clone is shallow, or a command errors; the caller then FAILS the build — there is no
+ * hardcoded fallback — unless an explicit -PVERSION_CODE is supplied.
  */
 fun getGitVersionCode(): Int? {
     // Capture stdout only (stderr is discarded) so a git warning/hint printed to
@@ -110,10 +110,12 @@ fun getGitVersionCode(): Int? {
         }
 
     // A shallow clone yields a truncated commit count; refuse to derive a wrong,
-    // too-low code from it and treat it as underivable. Only a confirmed "true"
-    // counts as shallow (an unavailable check on very old git is ignored).
-    val shallow = runGit("rev-parse", "--is-shallow-repository")
-    if (shallow != null && shallow.first == 0 && shallow.second == "true") return null
+    // too-low code from it and treat it as underivable. Detected via the `shallow`
+    // marker file in the git dir, which works on all git versions (unlike
+    // `rev-parse --is-shallow-repository`, which requires git >= 2.15).
+    val gitDir = runGit("rev-parse", "--git-dir") ?: return null
+    if (gitDir.first != 0) return null
+    if (rootDir.resolve(gitDir.second).resolve("shallow").exists()) return null
 
     val (countExit, countOutput) = runGit("rev-list", "--count", "HEAD") ?: return null
     if (countExit != 0) return null

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -71,6 +71,53 @@ fun getGitDescribeVersion(): String? {
     }
 }
 
+/**
+ * Derives the numeric version code from git history.
+ *
+ * `versionCode = (2_000_000 + commitCount) * 10 + (dirty ? 1 : 0)` where:
+ * - `commitCount` is `git rev-list --count HEAD` — strictly monotonic on `main`, so
+ *   every commit/merge auto-increments the code with no manual bumping.
+ * - The `2_000_000` base clears the ceiling of the previous scheme (max 1_090_099 for
+ *   v1.9.0), so codes under the new scheme never regress below already-shipped builds.
+ * - The trailing digit marks a dirty working tree (uncommitted changes to tracked
+ *   files): a local dirty build sorts one above the clean build at the same commit
+ *   without ever colliding with the next commit's code.
+ *
+ * Requires full history (git rev-list is inaccurate on a shallow clone). Returns null
+ * when git is unavailable or a command fails, so the caller can fall back to the
+ * gradle.properties value (e.g. building from a source tarball).
+ */
+fun getGitVersionCode(): Int? {
+    fun runGit(vararg args: String): Pair<Int, String>? =
+        try {
+            val process =
+                ProcessBuilder(listOf("git", *args))
+                    .directory(rootDir)
+                    .redirectErrorStream(true)
+                    .start()
+            val output =
+                process
+                    .inputStream
+                    .bufferedReader()
+                    .readText()
+                    .trim()
+            Pair(process.waitFor(), output)
+        } catch (_: Exception) {
+            null
+        }
+
+    val (countExit, countOutput) = runGit("rev-list", "--count", "HEAD") ?: return null
+    if (countExit != 0) return null
+    val commitCount = countOutput.toIntOrNull() ?: return null
+
+    // `git diff --quiet HEAD` exits non-zero when tracked files differ from HEAD
+    // (staged or unstaged). Untracked files are intentionally ignored.
+    val (dirtyExit, _) = runGit("diff", "--quiet", "HEAD") ?: return null
+    val dirty = dirtyExit != 0
+
+    return (2_000_000 + commitCount) * 10 + if (dirty) 1 else 0
+}
+
 val isExplicitVersion =
     project.gradle.startParameter
         .projectProperties
@@ -78,7 +125,23 @@ val isExplicitVersion =
 val fallbackVersion = project.findProperty("VERSION_NAME") as String? ?: "1.0.0"
 val versionNameProp =
     if (isExplicitVersion) fallbackVersion else (getGitDescribeVersion() ?: fallbackVersion)
-val versionCodeProp = (project.findProperty("VERSION_CODE") as String?)?.toInt() ?: 1
+val isExplicitVersionCode =
+    project.gradle.startParameter
+        .projectProperties
+        .containsKey("VERSION_CODE")
+val versionCodeProp =
+    if (isExplicitVersionCode) {
+        // An explicit -PVERSION_CODE override MUST be a valid integer; fail loudly
+        // rather than silently degrading to a fallback and shipping a wrong code.
+        val raw = project.findProperty("VERSION_CODE") as String
+        raw.toIntOrNull() ?: error("VERSION_CODE must be an integer, got: \"$raw\"")
+    } else {
+        // Prefer the git-derived code; fall back to the gradle.properties value only
+        // when git is unavailable (e.g. building from a source tarball).
+        getGitVersionCode()
+            ?: (project.findProperty("VERSION_CODE") as String?)?.toIntOrNull()
+            ?: 1
+    }
 
 ktlint {
     version.set("1.8.0")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -83,17 +83,20 @@ fun getGitDescribeVersion(): String? {
  *   files): a local dirty build sorts one above the clean build at the same commit
  *   without ever colliding with the next commit's code.
  *
- * Requires full history (git rev-list is inaccurate on a shallow clone). Returns null
- * when git is unavailable or a command fails, so the caller can fall back to the
- * gradle.properties value (e.g. building from a source tarball).
+ * Requires full history: a shallow clone is detected (git rev-parse
+ * --is-shallow-repository) and treated as underivable. Returns null when git is
+ * unavailable, the clone is shallow, or a command errors, so the caller can fall back
+ * to the gradle.properties value (e.g. building from a source tarball).
  */
 fun getGitVersionCode(): Int? {
+    // Capture stdout only (stderr is discarded) so a git warning/hint printed to
+    // stderr can never be merged into and corrupt the numeric output we parse.
     fun runGit(vararg args: String): Pair<Int, String>? =
         try {
             val process =
                 ProcessBuilder(listOf("git", *args))
                     .directory(rootDir)
-                    .redirectErrorStream(true)
+                    .redirectError(ProcessBuilder.Redirect.DISCARD)
                     .start()
             val output =
                 process
@@ -106,14 +109,26 @@ fun getGitVersionCode(): Int? {
             null
         }
 
+    // A shallow clone yields a truncated commit count; refuse to derive a wrong,
+    // too-low code from it and treat it as underivable. Only a confirmed "true"
+    // counts as shallow (an unavailable check on very old git is ignored).
+    val shallow = runGit("rev-parse", "--is-shallow-repository")
+    if (shallow != null && shallow.first == 0 && shallow.second == "true") return null
+
     val (countExit, countOutput) = runGit("rev-list", "--count", "HEAD") ?: return null
     if (countExit != 0) return null
     val commitCount = countOutput.toIntOrNull() ?: return null
 
-    // `git diff --quiet HEAD` exits non-zero when tracked files differ from HEAD
-    // (staged or unstaged). Untracked files are intentionally ignored.
+    // `git diff --quiet HEAD` exits 1 when tracked files differ from HEAD (staged or
+    // unstaged); untracked files are intentionally ignored. Any other non-zero exit is
+    // a git error, not a dirty tree, so bail to the fallback rather than mislabel it.
     val (dirtyExit, _) = runGit("diff", "--quiet", "HEAD") ?: return null
-    val dirty = dirtyExit != 0
+    val dirty =
+        when (dirtyExit) {
+            0 -> false
+            1 -> true
+            else -> return null
+        }
 
     return (2_000_000 + commitCount) * 10 + if (dirty) 1 else 0
 }
@@ -136,11 +151,15 @@ val versionCodeProp =
         val raw = project.findProperty("VERSION_CODE") as String
         raw.toIntOrNull() ?: error("VERSION_CODE must be an integer, got: \"$raw\"")
     } else {
-        // Prefer the git-derived code; fall back to the gradle.properties value only
-        // when git is unavailable (e.g. building from a source tarball).
+        // The version code is ALWAYS derived from git — there is no hardcoded fallback.
+        // Fail loudly if it cannot be derived (no repository, shallow clone, or git
+        // error) so a build can never silently ship a wrong/placeholder code.
         getGitVersionCode()
-            ?: (project.findProperty("VERSION_CODE") as String?)?.toIntOrNull()
-            ?: 1
+            ?: error(
+                "Cannot derive versionCode from git (missing repository, shallow clone, " +
+                    "or git error). Build from a full git checkout, or pass an explicit " +
+                    "-PVERSION_CODE=<integer>.",
+            )
     }
 
 ktlint {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -111,11 +111,13 @@ fun getGitVersionCode(): Int? {
 
     // A shallow clone yields a truncated commit count; refuse to derive a wrong,
     // too-low code from it and treat it as underivable. Detected via the `shallow`
-    // marker file in the git dir, which works on all git versions (unlike
-    // `rev-parse --is-shallow-repository`, which requires git >= 2.15).
-    val gitDir = runGit("rev-parse", "--git-dir") ?: return null
-    if (gitDir.first != 0) return null
-    if (rootDir.resolve(gitDir.second).resolve("shallow").exists()) return null
+    // marker file, which lives in the COMMON git dir (shared across linked worktrees,
+    // so `--git-common-dir` is required — `--git-dir` would point at a worktree's
+    // private dir and miss it). Works on all git versions (unlike
+    // `rev-parse --is-shallow-repository`, git >= 2.15; --git-common-dir exists since 2.5).
+    val gitCommonDir = runGit("rev-parse", "--git-common-dir") ?: return null
+    if (gitCommonDir.first != 0) return null
+    if (rootDir.resolve(gitCommonDir.second).resolve("shallow").exists()) return null
 
     val (countExit, countOutput) = runGit("rev-list", "--count", "HEAD") ?: return null
     if (countExit != 0) return null

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -72,6 +72,41 @@ fun getGitDescribeVersion(): String? {
 }
 
 /**
+ * Runs `git <args>` in the repo root, capturing stdout only. stderr is discarded so a
+ * git warning/hint can never be merged into and corrupt the parsed output. Returns
+ * (exitCode, trimmed stdout), or null if the process could not be started.
+ */
+fun runGit(vararg args: String): Pair<Int, String>? =
+    try {
+        val process =
+            ProcessBuilder(listOf("git", *args))
+                .directory(rootDir)
+                .redirectError(ProcessBuilder.Redirect.DISCARD)
+                .start()
+        val output =
+            process
+                .inputStream
+                .bufferedReader()
+                .readText()
+                .trim()
+        Pair(process.waitFor(), output)
+    } catch (_: Exception) {
+        null
+    }
+
+/**
+ * True when the working tree is a shallow clone, detected via the `shallow` marker file
+ * in the COMMON git dir (shared across linked worktrees, so `--git-common-dir` is
+ * required — `--git-dir` points at a worktree's private dir and would miss it).
+ * `--git-common-dir` exists since git 2.5; on older/absent git this returns false.
+ */
+fun isShallowClone(): Boolean {
+    val gitCommonDir = runGit("rev-parse", "--git-common-dir") ?: return false
+    if (gitCommonDir.first != 0) return false
+    return rootDir.resolve(gitCommonDir.second).resolve("shallow").exists()
+}
+
+/**
  * Derives the numeric version code from git history.
  *
  * `versionCode = (2_000_000 + commitCount) * 10 + (dirty ? 1 : 0)` where:
@@ -83,49 +118,20 @@ fun getGitDescribeVersion(): String? {
  *   files): a local dirty build sorts one above the clean build at the same commit
  *   without ever colliding with the next commit's code.
  *
- * Requires full history: a shallow clone (detected via the `shallow` marker file in
- * the git dir) is treated as underivable. Returns null when git is unavailable, the
- * clone is shallow, or a command errors; the caller then FAILS the build — there is no
- * hardcoded fallback — unless an explicit -PVERSION_CODE is supplied.
+ * Returns null only when git is unavailable (no repository / git absent), so the caller
+ * fails the build rather than falling back to a hardcoded code. A shallow clone still
+ * derives a (truncated) code here so config-only work — `help`, dependency resolution,
+ * IDE sync — is not broken; shipping a shallow (wrong) code is prevented separately by
+ * the release-artifact guard (see gradle.taskGraph.whenReady below).
  */
 fun getGitVersionCode(): Int? {
-    // Capture stdout only (stderr is discarded) so a git warning/hint printed to
-    // stderr can never be merged into and corrupt the numeric output we parse.
-    fun runGit(vararg args: String): Pair<Int, String>? =
-        try {
-            val process =
-                ProcessBuilder(listOf("git", *args))
-                    .directory(rootDir)
-                    .redirectError(ProcessBuilder.Redirect.DISCARD)
-                    .start()
-            val output =
-                process
-                    .inputStream
-                    .bufferedReader()
-                    .readText()
-                    .trim()
-            Pair(process.waitFor(), output)
-        } catch (_: Exception) {
-            null
-        }
-
-    // A shallow clone yields a truncated commit count; refuse to derive a wrong,
-    // too-low code from it and treat it as underivable. Detected via the `shallow`
-    // marker file, which lives in the COMMON git dir (shared across linked worktrees,
-    // so `--git-common-dir` is required — `--git-dir` would point at a worktree's
-    // private dir and miss it). Works on all git versions (unlike
-    // `rev-parse --is-shallow-repository`, git >= 2.15; --git-common-dir exists since 2.5).
-    val gitCommonDir = runGit("rev-parse", "--git-common-dir") ?: return null
-    if (gitCommonDir.first != 0) return null
-    if (rootDir.resolve(gitCommonDir.second).resolve("shallow").exists()) return null
-
     val (countExit, countOutput) = runGit("rev-list", "--count", "HEAD") ?: return null
     if (countExit != 0) return null
     val commitCount = countOutput.toIntOrNull() ?: return null
 
     // `git diff --quiet HEAD` exits 1 when tracked files differ from HEAD (staged or
     // unstaged); untracked files are intentionally ignored. Any other non-zero exit is
-    // a git error, not a dirty tree, so bail to the fallback rather than mislabel it.
+    // a git error, not a dirty tree, so bail rather than mislabel it.
     val (dirtyExit, _) = runGit("diff", "--quiet", "HEAD") ?: return null
     val dirty =
         when (dirtyExit) {
@@ -156,15 +162,39 @@ val versionCodeProp =
         raw.toIntOrNull() ?: error("VERSION_CODE must be an integer, got: \"$raw\"")
     } else {
         // The version code is ALWAYS derived from git — there is no hardcoded fallback.
-        // Fail loudly if it cannot be derived (no repository, shallow clone, or git
-        // error) so a build can never silently ship a wrong/placeholder code.
+        // Fail only when git is entirely unavailable (no repository); a shallow clone
+        // still derives a code so config-only tasks (help, dependency resolution, IDE
+        // sync) are not broken. A shallow RELEASE build is rejected by the guard below.
         getGitVersionCode()
             ?: error(
-                "Cannot derive versionCode from git (missing repository, shallow clone, " +
-                    "or git error). Build from a full git checkout, or pass an explicit " +
-                    "-PVERSION_CODE=<integer>.",
+                "Cannot derive versionCode: no git repository found. Build from a git " +
+                    "checkout, or pass an explicit -PVERSION_CODE=<integer>.",
             )
     }
+
+// A release/bundle artifact must carry a full-history git-derived code. A shallow
+// checkout yields a truncated (wrong, too-low) count, so refuse to build one from a
+// shallow tree — but only for actual release-artifact tasks, so config-only work
+// (help, dependency resolution, IDE sync) on a shallow checkout is unaffected.
+gradle.taskGraph.whenReady {
+    val buildingReleaseArtifact =
+        !isExplicitVersionCode &&
+            gradle.taskGraph.allTasks.any { task ->
+                task.name.contains("Release") &&
+                    (
+                        task.name.startsWith("assemble") ||
+                            task.name.startsWith("bundle") ||
+                            task.name.startsWith("package")
+                    )
+            }
+    if (buildingReleaseArtifact && (getGitVersionCode() == null || isShallowClone())) {
+        error(
+            "Refusing to build a release artifact without a full-history git versionCode " +
+                "(missing repository or shallow clone). Build from a full git checkout, or " +
+                "pass an explicit -PVERSION_CODE=<integer>.",
+        )
+    }
+}
 
 ktlint {
     version.set("1.8.0")

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -572,8 +572,8 @@ debug builds get a per-flavor suffix so both can be installed side by side.
 ### Versioning
 
 - **Semantic versioning** (MAJOR.MINOR.PATCH): MAJOR for breaking MCP protocol changes, MINOR for new features, PATCH for bug fixes
-- Version defined in `gradle.properties` (`VERSION_NAME`, `VERSION_CODE`)
-- Bump via Makefile: `make version-bump-patch`, `make version-bump-minor`, `make version-bump-major`
+- `VERSION_NAME` is derived from git tags (with a `gradle.properties` fallback for git-less builds); the `versionCode` is derived from git history by Gradle, never hardcoded (see [TOOLS.md](TOOLS.md) → VERSION_CODE Derivation)
+- Bump the version name via Makefile: `make version-bump-patch`, `make version-bump-minor`, `make version-bump-major` (the version code is git-derived, not bumped)
 
 ### APK Signing
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -202,18 +202,15 @@ Tags MUST follow semantic versioning with a `v` prefix:
 
 ### VERSION_CODE Derivation
 
-The `VERSION_CODE` (Android integer version) is automatically computed from the tag:
+The Android `versionCode` is **derived from git history** by Gradle (`getGitVersionCode` in `app/build.gradle.kts`) — it is never hardcoded and is not taken from the tag:
 
-**Formula**: `MAJOR × 1,000,000 + MINOR × 10,000 + PATCH × 100 + OFFSET`
+**Formula**: `versionCode = (2,000,000 + <commits reachable from HEAD>) × 10 + (dirty ? 1 : 0)`
 
-| Pre-release type | Offset | Example tag | VERSION_CODE |
-|-----------------|--------|-------------|-------------|
-| `alpha` | 01 | `v1.2.3-alpha` | `1020301` |
-| `beta` | 10 | `v1.2.3-beta` | `1020310` |
-| `rc{N}` | 20+N | `v1.2.3-rc1` | `1020321` |
-| stable (no suffix) | 99 | `v1.2.3` | `1020399` |
+- The commit count (`git rev-list --count HEAD`) is strictly increasing on `main`, so every commit/merge auto-increments the code with no manual bumping.
+- The `2,000,000` base clears the ceiling of the previous scheme (max `1,090,099` for `v1.9.0`) so codes never regress below already-shipped builds.
+- The trailing digit marks a dirty working tree (uncommitted changes to tracked files) so a local dirty build sorts above the clean build at the same commit.
 
-This ensures correct ordering: `alpha < beta < rc1 < rc2 < ... < release`.
+Requires a **full git checkout**: a shallow clone or a git-less source tree cannot derive the code and the build fails at configuration (pass `-PVERSION_CODE=<integer>` to override). CI and release jobs check out with `fetch-depth: 0` for this reason.
 
 ### APK Naming
 
@@ -224,7 +221,7 @@ Attached APKs follow this naming convention:
 ### Pipeline Behavior
 
 1. **CI Gate**: The workflow waits for the CI pipeline (`Build Release` check) to pass on the tagged commit before proceeding. If CI hasn't completed yet, it polls until it finishes or the job timeout (150 minutes) is reached.
-2. **Build**: APKs are built with `VERSION_NAME` and `VERSION_CODE` injected from the tag.
+2. **Build**: APKs are built with `VERSION_NAME` injected from the tag; the `versionCode` is derived by Gradle from git history (not from the tag).
 3. **Release Notes**: GitHub's native auto-generated notes (`gh release create --generate-notes`) — merged PR list + full changelog link. Finalize the draft body manually before publishing.
 4. **Draft Release**: Created as draft — you must manually review and publish.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,9 @@ android.useAndroidX=true
 # Kotlin code style
 kotlin.code.style=official
 
-# Application versioning (semantic versioning)
+# Application versioning.
+# VERSION_NAME is a fallback used only when git describe is unavailable (e.g. a source
+# tarball); normal builds derive the name from git tags. There is intentionally NO
+# VERSION_CODE here: the version code is always derived from git history in
+# app/build.gradle.kts (getGitVersionCode), never hardcoded.
 VERSION_NAME=1.0.0
-VERSION_CODE=1

--- a/keystore.properties.example
+++ b/keystore.properties.example
@@ -1,0 +1,24 @@
+# Release signing configuration.
+#
+# Copy this file to `keystore.properties` (repo root) and fill in real values.
+# `keystore.properties` is gitignored and MUST NEVER be committed.
+#
+# When `keystore.properties` exists, the `release` build type is signed with the
+# key below (see app/build.gradle.kts). Without it, release builds are unsigned.
+#
+# Generate a keystore first (keep it OUTSIDE the repo and back it up — losing it
+# means you can never publish an update to the same app again):
+#
+#   keytool -genkeypair -v \
+#     -keystore ~/keys/android-remote-control-mcp-release.jks \
+#     -alias upload \
+#     -keyalg RSA -keysize 4096 -validity 10000 \
+#     -storetype JKS
+#
+# storeFile MUST be an absolute path (it is resolved relative to the app/ module,
+# so a repo-root-relative path would not resolve correctly).
+
+storeFile=/absolute/path/to/android-remote-control-mcp-release.jks
+storePassword=CHANGE_ME
+keyAlias=upload
+keyPassword=CHANGE_ME


### PR DESCRIPTION
## Summary

Two related changes toward producing signed, Play-ready release builds:

1. **Signed AAB build tooling** — a `make build-release-bundle` target that builds the signed `gms` release AAB (`bundleGmsRelease`) for Google Play upload, reusing the same native-lib prerequisites as `build-release`, plus a `keystore.properties.example` template documenting the release signing config the build reads.
2. **git-derived `versionCode`** — replace the manual / tag-offset version code with a value derived from git history, making Gradle the single source of truth.

## New versionCode scheme

```
versionCode = (2_000_000 + `git rev-list --count HEAD`) * 10 + (dirty ? 1 : 0)
```

- **Monotonic, zero manual bumping** — the commit count strictly increases on `main`, so every commit/merge auto-increments the code.
- **No regression** — the `2_000_000` base clears the previous scheme's ceiling (max `1_090_099` for `v1.9.0`), so codes never drop below already-shipped builds.
- **Dirty marker** — the trailing digit flags a dirty working tree (uncommitted changes to tracked files; untracked files ignored), so a local dirty build sorts one above the clean build at the same commit without colliding with the next commit's code.
- **Overrides & fallback** — an explicit `-PVERSION_CODE` still overrides (and now fails loudly on a non-integer value instead of silently degrading); when git is unavailable (e.g. a source tarball) it falls back to `gradle.properties VERSION_CODE`.

Example values: clean `HEAD` at count 715 → `20007150`; the same commit dirty → `20007151`.

## Single source of truth

- `release.yml` no longer computes a version code — it keeps only the version-name and prerelease-flag parsing from the tag, and no longer passes `-PVERSION_CODE`.
- `ci.yml`'s `build-release` job now checks out full history (`fetch-depth: 0`) so `git rev-list` / `git describe` are accurate for its uploaded artifacts.

## Verification

- Merged-manifest checks confirm the computed code in both states: clean → `20007150`, dirty → `20007141` (count 714/715 during development).
- Explicit-override behavior: `-PVERSION_CODE=abc` fails the build with a clear message; `-PVERSION_CODE=5000` yields `versionCode=5000`.
- `make lint` (ktlint + detekt) passes.

## Notes

- `keystore.properties` remains gitignored; only the `.example` placeholder template is tracked. No secret material is committed.
