### PR TITLE
ci(release): sign release APKs with keystore from CI secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,7 +161,29 @@ jobs:
           path: .dbip-cache
           key: dbip-csv-${{ steps.dbip-month.outputs.month }}
 
-      # ── 8. Build APKs with version name from tag (versionCode derived by Gradle from git) ──
+      # ── 8. Decode the release keystore and write signing config so the release APKs are signed.
+      #      app/build.gradle.kts applies the release signingConfig only when keystore.properties
+      #      exists at the repo root; without this step the release APKs build unsigned. ──
+      - name: Decode release keystore
+        env:
+          RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+          RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+        run: |
+          if [ -z "$RELEASE_KEYSTORE_BASE64" ]; then
+            echo "::error::RELEASE_KEYSTORE_BASE64 secret is not set; release APKs would be unsigned"
+            exit 1
+          fi
+          printf '%s' "$RELEASE_KEYSTORE_BASE64" | base64 -d > "$GITHUB_WORKSPACE/release.jks"
+          {
+            echo "storeFile=$GITHUB_WORKSPACE/release.jks"
+            echo "storePassword=$RELEASE_KEYSTORE_PASSWORD"
+            echo "keyAlias=$RELEASE_KEY_ALIAS"
+            echo "keyPassword=$RELEASE_KEY_PASSWORD"
+          } > "$GITHUB_WORKSPACE/keystore.properties"
+
+      # ── 9. Build APKs with version name from tag (versionCode derived by Gradle from git) ──
       - name: Build APKs
         env:
           VERSION_NAME: ${{ steps.parse-tag.outputs.version }}

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ keystore.properties
 *.jks
 *.keystore
 
+# Local release signing material (keystore, plaintext credentials, certs) — NEVER commit
+.release/
+
 # Environment / Secrets
 .env
 .env.*


### PR DESCRIPTION
Adds release signing to the tag-triggered release build.

## What
- New **Decode release keystore** step in `release.yml` (before Build APKs) that base64-decodes `RELEASE_KEYSTORE_BASE64` to `release.jks` and writes `keystore.properties` with the store/key credentials.
- `app/build.gradle.kts` already applies the release `signingConfig` when `keystore.properties` exists, so `assembleGmsRelease` / `assembleFossRelease` now produce **signed** `…-release.apk` (previously `…-release-unsigned.apk`).

## Secrets required (already set)
`RELEASE_KEYSTORE_BASE64`, `RELEASE_KEYSTORE_PASSWORD`, `RELEASE_KEY_ALIAS`, `RELEASE_KEY_PASSWORD`.

## Notes
- Debug APKs are unaffected (still debug-signed).
- Secrets are passed via `env` (masked in logs), never echoed.
- The signing path was verified locally against the generated keystore before merge.