### PR TITLE
test: retry transient 404/5xx tunnel edge errors in tunnel integration tests

### DIFF
--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/CloudflareTunnelIntegrationTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/CloudflareTunnelIntegrationTest.kt
@@ -170,7 +170,10 @@ class CloudflareTunnelIntegrationTest {
      * Fetches a URL with retries.
      *
      * Cloudflare Quick Tunnels can take a moment to become fully routable
-     * after the URL is reported. Retries handle transient 502/503 responses.
+     * after the URL is reported. While the edge is still wiring up the route
+     * it returns transient errors — 404 (route/DNS not propagated yet) and the
+     * whole 5xx range (Bad Gateway plus Cloudflare Argo error 1033 → HTTP 530
+     * and edge errors 520–527). Retries handle all of these.
      */
     private fun fetchUrlWithRetry(url: String): String {
         var lastException: Exception? = null
@@ -186,8 +189,8 @@ class CloudflareTunnelIntegrationTest {
                     return connection.inputStream.bufferedReader().readText()
                 }
 
-                // Retry on 502/503 (tunnel not yet fully routed)
-                if (responseCode in RETRYABLE_HTTP_CODES) {
+                // Retry while the tunnel is not yet fully routed
+                if (responseCode == HTTP_NOT_FOUND || responseCode in HTTP_SERVER_ERROR_RANGE) {
                     Thread.sleep(FETCH_RETRY_DELAY_MS * (attempt + 1))
                     return@repeat
                 }
@@ -212,7 +215,8 @@ class CloudflareTunnelIntegrationTest {
         private const val FETCH_READ_TIMEOUT_MS = 10_000
         private const val FETCH_RETRY_DELAY_MS = 2_000L
         private const val HTTP_OK = 200
-        private val RETRYABLE_HTTP_CODES = listOf(502, 503)
+        private const val HTTP_NOT_FOUND = 404
+        private val HTTP_SERVER_ERROR_RANGE = 500..599
 
         @JvmStatic
         @BeforeAll

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/NgrokTunnelIntegrationTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/NgrokTunnelIntegrationTest.kt
@@ -154,7 +154,9 @@ class NgrokTunnelIntegrationTest {
      * Fetches a URL with retries.
      *
      * ngrok tunnels can take a moment to become fully routable after the
-     * URL is reported. Retries handle transient 502/503 responses.
+     * URL is reported. While the edge is still wiring up the route it returns
+     * transient errors — 404 (route not ready) and the whole 5xx range
+     * (Bad Gateway / upstream errors). Retries handle all of these.
      */
     private fun fetchUrlWithRetry(url: String): String {
         var lastException: Exception? = null
@@ -171,7 +173,7 @@ class NgrokTunnelIntegrationTest {
                     return connection.inputStream.bufferedReader().readText()
                 }
 
-                if (responseCode in RETRYABLE_HTTP_CODES) {
+                if (responseCode == HTTP_NOT_FOUND || responseCode in HTTP_SERVER_ERROR_RANGE) {
                     Thread.sleep(FETCH_RETRY_DELAY_MS * (attempt + 1))
                     return@repeat
                 }
@@ -196,7 +198,8 @@ class NgrokTunnelIntegrationTest {
         private const val FETCH_READ_TIMEOUT_MS = 10_000
         private const val FETCH_RETRY_DELAY_MS = 2_000L
         private const val HTTP_OK = 200
-        private val RETRYABLE_HTTP_CODES = listOf(404, 502, 503)
+        private const val HTTP_NOT_FOUND = 404
+        private val HTTP_SERVER_ERROR_RANGE = 500..599
 
         @JvmStatic
         @BeforeAll


### PR DESCRIPTION
## Problem

The `main` CI job **Unit & Integration Tests** failed on a single test:

```
CloudflareTunnelIntegrationTest > tunnel connects and proxies traffic to local test server() FAILED
    org.opentest4j.AssertionFailedError at CloudflareTunnelIntegrationTest.kt:195
```

The test starts a real Cloudflare Quick Tunnel, reaches `Connected`, then does an HTTP GET through the tunnel URL. It failed at the `fail("Unexpected HTTP response code: $responseCode")` branch because the fetch retry logic only retried on **502/503**. When a freshly created Quick Tunnel is resolvable but the edge is not yet routing to the origin, Cloudflare returns a transient **HTTP 530** (Argo error 1033, "tunnel not ready") — sometimes **404** before DNS propagates, or edge errors **520–527**. None of those were retried, so the first non-200 response failed the test outright.

This is a flaky test caused by external-infrastructure timing, not a code regression.

## Fix

Widen the retryable HTTP set in **both** tunnel integration tests to **404 plus the whole 5xx range (500–599)**, replacing the fixed `listOf(502, 503)` (Cloudflare) and `listOf(404, 502, 503)` (ngrok) with a single consistent check. The 5xx range cleanly covers Cloudflare's 530 and 520–527 edge errors as well as Bad Gateway / upstream errors on both providers.

## Scope investigation

- `CloudflareTunnelIntegrationTest` and `NgrokTunnelIntegrationTest` are the only tests with this live-tunnel fetch-and-retry pattern — both updated.
- The e2e tests that inspect `responseCode` (`E2EErrorHandlingTest`, `AndroidContainerSetup`, `OAuthFlowE2ETest`) hit the **local Redroid container directly**, not a live Cloudflare/ngrok tunnel, so they cannot see the transient 530/404 — no change needed there.

## Verification

Ran locally with `cloudflared` installed and `NGROK_AUTHTOKEN` set:

- `:app:ktlintCheck` + `:app:detekt` — pass
- `CloudflareTunnelIntegrationTest` — 1 test, 0 skipped, 0 failures
- `NgrokTunnelIntegrationTest` — 1 test, 0 skipped, 0 failures