### PR TITLE
fix(deps): close Dependabot jackson & logback CVE alerts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -200,6 +200,19 @@ ktlint {
     version.set("1.8.0")
 }
 
+// ktlint-cli 1.8.0 (the latest release) bundles logback 1.3.16, which trips CVE alerts. logback is
+// used only for ktlint's own build-time console logging and never ships in the APK. Force the patched
+// logback onto ktlint's resolvable configurations. Compatible: logback 1.5.x keeps the slf4j 2.0.x
+// binding ktlint already uses and only requires Java 11+, which the JDK 17 build satisfies.
+configurations.matching { it.name.startsWith("ktlint") }.configureEach {
+    resolutionStrategy {
+        force(
+            "ch.qos.logback:logback-core:1.5.34",
+            "ch.qos.logback:logback-classic:1.5.34",
+        )
+    }
+}
+
 android {
     namespace = "com.danielealbano.androidremotecontrolmcp"
     compileSdk = 36
@@ -386,6 +399,9 @@ dependencies {
     runtimeOnly(libs.slf4j.android)
 
     // OAuth (JWT signing/verification)
+    // The Jackson BOM aligns java-jwt's transitive jackson-core/jackson-databind to a patched
+    // release, closing the CVE alerts on the 2.21.3 versions the library would otherwise pull in.
+    implementation(platform(libs.jackson.bom))
     implementation(libs.java.jwt)
 
     // OAuth client logos (SSRF-guarded remote image loading)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,9 @@ mcp-kotlin-sdk = "0.8.3"
 # OAuth (JWT signing/verification)
 java-jwt = "4.5.2"
 
+# Jackson (transitive via java-jwt) — pinned to a patched release to close CVE alerts
+jackson = "2.21.5"
+
 # Image loading (OAuth client logos)
 coil = "3.2.0"
 
@@ -123,6 +126,9 @@ bouncy-castle-prov = { group = "org.bouncycastle", name = "bcprov-jdk18on", vers
 
 # OAuth (JWT signing/verification)
 java-jwt = { group = "com.auth0", name = "java-jwt", version.ref = "java-jwt" }
+
+# Jackson BOM — aligns transitive jackson-core/jackson-databind (pulled by java-jwt) to a patched release
+jackson-bom = { group = "com.fasterxml.jackson", name = "jackson-bom", version.ref = "jackson" }
 
 # Image loading (OAuth client logos)
 coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }


### PR DESCRIPTION
## What

Closes the Dependabot CVE alerts on two **transitive** dependencies, without upgrading AGP.

| Group | Alerts | Source | Fix |
|---|---|---|---|
| **jackson-core / jackson-databind** (2.21.3) | 11 | `com.auth0:java-jwt:4.5.2` (ships in APK) | Pin to **2.21.5** via the Jackson BOM |
| **logback-core / logback-classic** (1.3.16) | 2 | `com.pinterest.ktlint:ktlint-cli:1.8.0` (build tooling only) | Force **1.5.34** on ktlint's configs |

## Why these mechanisms

- **jackson** → `implementation(platform(libs.jackson.bom))` aligns java-jwt's transitive jackson artifacts to the patched 2.21.5 (same minor line as the current 2.21.3, patch-only — safe for java-jwt). Consistent with the existing `compose-bom` / `junit-bom` usage.
- **logback** → ktlint-cli 1.8.0 is the **latest** release and still bundles logback 1.3.16, so a version bump is impossible. logback is used only for ktlint's build-time console logging and never ships in the APK. The `ktlint` configuration is plugin-created and is not a child of `implementation`, so a BOM/constraint there wouldn't reach it — a scoped `resolutionStrategy.force` on the `ktlint*` configs is the correct tool. logback 1.5.x keeps the slf4j 2.0.x binding ktlint already uses and only needs Java 11+ (JDK 17 build satisfies it).

## Out of scope (intentionally deferred)

- **Netty (9 alerts)** come from AGP's Unified Test Platform (`com.android.tools.utp:*:31.13.2`, i.e. AGP 8.13) → `grpc-netty`. They are test/build tooling, never in the APK, and a scoped constraint does not reach AGP's internal UTP configs — so they are **deferred to a future AGP upgrade**.
- **BouncyCastle (1 alert)** is stale: the repo already depends on 1.85 (> the patched 1.80.2).

## Verification

- ✅ Resolution: jackson `2.21.3 -> 2.21.5` and logback `1.3.16 -> 1.5.34` on both gms & foss shipping runtime classpaths; no residual vulnerable versions in the app graph.
- ✅ `make lint` (ktlint + detekt) passes; ktlint-cli demonstrably still runs under logback 1.5.34.
- ✅ Full unit + integration suite (`make test-unit`) passes.
- ✅ gms + foss Kotlin compilation clean.

### Note for reviewers / CI

The `:app:generateLocationDb` task downloads the current month's DB-IP City Lite DB. As of the PR date the **August 2026** DB is not yet published by DB-IP (HTTP 404), so the APK-packaging step and the `build-release` CI job may go red on that task until DB-IP publishes it. This is a date-driven, repo-wide condition unrelated to this change.