### PR TITLE
fix(build): fall back to earlier months when DB-IP DB is unpublished

### DIFF
--- a/scripts/location-db/build_location_db.py
+++ b/scripts/location-db/build_location_db.py
@@ -9,7 +9,9 @@ Usage:
   python3 build_location_db.py --out app/src/main/assets/geo/location-db.bin.gz
   python3 build_location_db.py --csv /path/to/dbip-city-lite.csv.gz --out out.bin.gz
 
-By default the current month's CSV is downloaded (and cached) if --csv is not given.
+By default the newest available monthly CSV is downloaded (and cached) if --csv is not
+given: the current month is tried first, then earlier months in sequence (up to 6 months
+total), since DB-IP publishes each month's file a few days into the month.
 Both IPv4 and IPv6 are ingested at city granularity.
 
 Attribution: this product includes IP geolocation data created by DB-IP.com,
@@ -25,6 +27,7 @@ import gzip
 import io
 import ipaddress
 import sys
+import urllib.error
 import urllib.request
 from pathlib import Path
 
@@ -32,24 +35,69 @@ from location_db import LocationDbBuilder, LocationDbReader
 
 DBIP_URL = "https://download.db-ip.com/free/dbip-city-lite-{month}.csv.gz"
 
+# DB-IP publishes the new monthly DB a few days into the month, so the current month's
+# file is often absent (HTTP 404) at build time. Try the current month, then walk back up
+# to this many months total, using the newest one that is actually available.
+FALLBACK_MONTHS = 6
+
 
 def _default_month() -> str:
     return datetime.date.today().strftime("%Y-%m")
 
 
-def _download(month: str, dest: Path) -> Path:
-    url = DBIP_URL.format(month=month)
+def _previous_month(month: str) -> str:
+    """Return the YYYY-MM string for the calendar month before [month]."""
+    year, mon = (int(p) for p in month.split("-"))
+    if mon == 1:
+        return f"{year - 1:04d}-12"
+    return f"{year:04d}-{mon - 1:02d}"
+
+
+def _candidate_months(start_month: str, count: int) -> list[str]:
+    """[start_month] and the [count]-1 preceding months, newest first."""
+    months = [start_month]
+    for _ in range(count - 1):
+        months.append(_previous_month(months[-1]))
+    return months
+
+
+def _download(month: str, dest: Path) -> Path | None:
+    """Fetch the DB-IP CSV for [month] into [dest]. Return the path, or None if that
+    month is not published yet (HTTP 404)."""
     if dest.exists():
         print(f"using cached {dest} ({dest.stat().st_size:,} bytes)")
         return dest
+    url = DBIP_URL.format(month=month)
     print(f"downloading {url} ...")
     dest.parent.mkdir(parents=True, exist_ok=True)
     # DB-IP rejects the default urllib user-agent (403), so present a browser-like one.
     req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0 (location-db build)"})
-    with urllib.request.urlopen(req) as resp, open(dest, "wb") as f:  # noqa: S310 (trusted host)
-        f.write(resp.read())
+    try:
+        with urllib.request.urlopen(req) as resp, open(dest, "wb") as f:  # noqa: S310 (trusted host)
+            f.write(resp.read())
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            print(f"  {month} not published yet (HTTP 404)")
+            return None
+        raise
     print(f"saved {dest} ({dest.stat().st_size:,} bytes)")
     return dest
+
+
+def _resolve_csv(start_month: str, cache_dir: Path) -> Path:
+    """Return the newest available DB-IP CSV, trying [start_month] then earlier months.
+
+    Fails only when none of the last [FALLBACK_MONTHS] months is available.
+    """
+    candidates = _candidate_months(start_month, FALLBACK_MONTHS)
+    for month in candidates:
+        result = _download(month, cache_dir / f"dbip-city-lite-{month}.csv.gz")
+        if result is not None:
+            return result
+    raise SystemExit(
+        f"No DB-IP City Lite database available for any of the last {FALLBACK_MONTHS} months "
+        f"({', '.join(candidates)}). DB-IP may be delayed; retry later or pass --csv explicitly."
+    )
 
 
 def _open_csv(path: Path) -> io.TextIOBase:
@@ -118,7 +166,7 @@ def main() -> int:
     ap.add_argument("--cache-dir", type=Path, default=Path("/tmp/dbip-cache"))
     args = ap.parse_args()
 
-    csv_path = args.csv or _download(args.month, args.cache_dir / f"dbip-city-lite-{args.month}.csv.gz")
+    csv_path = args.csv or _resolve_csv(args.month, args.cache_dir)
     blob = build(csv_path)
     gz = gzip.compress(blob, mtime=0)
 

--- a/scripts/location-db/test_build_location_db.py
+++ b/scripts/location-db/test_build_location_db.py
@@ -1,0 +1,100 @@
+"""Tests for the DB-IP month-fallback download logic (stdlib only, no network).
+
+Run: python3 -m pytest scripts/location-db/test_build_location_db.py
+ or: python3 scripts/location-db/test_build_location_db.py
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import build_location_db as b
+
+
+def test_previous_month_within_year():
+    assert b._previous_month("2026-08") == "2026-07"
+    assert b._previous_month("2026-12") == "2026-11"
+
+
+def test_previous_month_year_boundary():
+    assert b._previous_month("2026-01") == "2025-12"
+
+
+def test_candidate_months_newest_first():
+    assert b._candidate_months("2026-08", 6) == [
+        "2026-08",
+        "2026-07",
+        "2026-06",
+        "2026-05",
+        "2026-04",
+        "2026-03",
+    ]
+
+
+def test_candidate_months_crosses_year_boundary():
+    assert b._candidate_months("2026-02", 4) == ["2026-02", "2026-01", "2025-12", "2025-11"]
+
+
+def _with_fake_download(fake):
+    """Return a (setup, teardown) pair that swaps build_location_db._download for [fake]."""
+    original = b._download
+    b._download = fake
+    return original
+
+
+def test_resolve_csv_returns_current_month_first():
+    # Every month "available": resolution must stop at the current month without walking back.
+    calls: list[str] = []
+
+    def fake(month: str, dest: Path) -> Path:
+        calls.append(month)
+        return dest
+
+    original = _with_fake_download(fake)
+    try:
+        result = b._resolve_csv("2026-08", Path("/cache"))
+    finally:
+        b._download = original
+    assert result.name == "dbip-city-lite-2026-08.csv.gz"
+    assert calls == ["2026-08"]
+
+
+def test_resolve_csv_falls_back_to_newest_available():
+    # Only 2026-08 exists; starting from 2027-01 must walk back through 404s to it.
+    def fake(month: str, dest: Path) -> Path | None:
+        return dest if month == "2026-08" else None
+
+    original = _with_fake_download(fake)
+    try:
+        result = b._resolve_csv("2027-01", Path("/cache"))
+    finally:
+        b._download = original
+    assert result.name == "dbip-city-lite-2026-08.csv.gz"
+
+
+def test_resolve_csv_raises_when_no_month_available():
+    def fake(month: str, dest: Path) -> None:
+        return None
+
+    original = _with_fake_download(fake)
+    try:
+        raised = False
+        try:
+            b._resolve_csv("2030-06", Path("/cache"))
+        except SystemExit:
+            raised = True
+    finally:
+        b._download = original
+    assert raised, "expected SystemExit when no month is available"
+
+
+def _run():
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for fn in fns:
+        fn()
+        print(f"ok  {fn.__name__}")
+    print(f"\n{len(fns)} passed")
+
+
+if __name__ == "__main__":
+    _run()


### PR DESCRIPTION
## Problem

`:app:generateLocationDb` downloads the **current month's** DB-IP City Lite database. DB-IP publishes each month's file a few days into the month, so at every month rollover the current month's file is briefly a `404` — which broke the build (and the `build-release` CI job) with:

```
urllib.error.HTTPError: HTTP Error 404: Not Found
> Process 'command 'python3'' finished with non-zero exit value 1
```

## Fix

Try the current month first, then walk back through earlier months in sequence — **up to 6 months total** — and use the newest one that is actually published. Only fail if none of the last 6 months is available, and then with a clear message rather than a raw traceback.

- `_previous_month` / `_candidate_months` — month arithmetic (handles the year boundary, e.g. `2026-01` → `2025-12`).
- `_download` now returns `None` on a `404` (month not published) instead of raising, and re-raises any other HTTP error.
- `_resolve_csv` walks the candidates newest-first and returns the first available; raises `SystemExit` with a helpful message if all 6 are missing.

Per-month caching is unchanged (each month keeps its own `.dbip-cache` file), so an already-downloaded month is reused.

## Verification

- ✅ Real-network check: from a `404` start month it walks back through 404s to the newest available DB; all-missing → clean `SystemExit`.
- ✅ `./gradlew :app:generateLocationDb` runs end-to-end (BUILD SUCCESSFUL, valid sample lookups).
- ✅ New `scripts/location-db/test_build_location_db.py` — 7 tests (month arithmetic incl. year boundary + resolve/fallback/exhausted paths, network mocked); existing `test_location_db.py` (6 tests) still pass. Both run via `python3 -m pytest scripts/location-db/` or the standalone `python3 scripts/location-db/test_*.py` runner.