### PR TITLE
ci/perf: parallelize CI and cache the build (~36 min -> ~8 min warm)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,9 +296,21 @@ jobs:
           retention-days: 14
 
   build-release:
-    name: Build Release
+    name: Build Release - ${{ matrix.label }}
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    # One runner per flavour so gms and foss assemble in parallel instead of one job
+    # building all four APKs serially. fail-fast off: a foss break must not cancel gms.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - flavor: gms
+            label: GMS
+            cap: Gms
+          - flavor: foss
+            label: FOSS
+            cap: Foss
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -377,36 +389,19 @@ jobs:
           path: .dbip-cache
           key: dbip-csv-${{ steps.dbip-month.outputs.month }}
 
-      - name: Build debug APKs (gms + foss)
-        run: ./gradlew assembleGmsDebug assembleFossDebug
+      - name: Build ${{ matrix.label }} debug + release APKs
+        run: ./gradlew assemble${{ matrix.cap }}Debug assemble${{ matrix.cap }}Release
 
-      - name: Build release APKs (gms + foss)
-        run: ./gradlew assembleGmsRelease assembleFossRelease
-
-      - name: Upload gms debug APK
+      - name: Upload ${{ matrix.label }} debug APK
         uses: actions/upload-artifact@v7
         with:
-          name: app-gms-debug
-          path: app/build/outputs/apk/gms/debug/app-gms-debug.apk
+          name: app-${{ matrix.flavor }}-debug
+          path: app/build/outputs/apk/${{ matrix.flavor }}/debug/app-${{ matrix.flavor }}-debug.apk
           retention-days: 30
 
-      - name: Upload foss debug APK
+      - name: Upload ${{ matrix.label }} release APK
         uses: actions/upload-artifact@v7
         with:
-          name: app-foss-debug
-          path: app/build/outputs/apk/foss/debug/app-foss-debug.apk
-          retention-days: 30
-
-      - name: Upload gms release APK
-        uses: actions/upload-artifact@v7
-        with:
-          name: app-gms-release
-          path: app/build/outputs/apk/gms/release/app-gms-release-unsigned.apk
-          retention-days: 30
-
-      - name: Upload foss release APK
-        uses: actions/upload-artifact@v7
-        with:
-          name: app-foss-release
-          path: app/build/outputs/apk/foss/release/app-foss-release-unsigned.apk
+          name: app-${{ matrix.flavor }}-release
+          path: app/build/outputs/apk/${{ matrix.flavor }}/release/app-${{ matrix.flavor }}-release-unsigned.apk
           retention-days: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# The four jobs below are independent — none consumes another's artifacts; each checks out
+# fresh, rebuilds its native deps from cache, and runs its own Gradle tasks. They therefore run
+# in PARALLEL on separate runners instead of in a needs: chain, cutting wall-clock from the sum
+# of their durations (~36 min) to the longest single job (~13 min). The former chain existed only
+# as a fail-fast gate; we trade that for faster feedback. Do NOT re-add needs: unless a real
+# artifact dependency is introduced.
 jobs:
   lint:
     name: Lint
@@ -61,7 +67,6 @@ jobs:
   test-unit:
     name: Unit & Integration Tests
     runs-on: ubuntu-latest
-    needs: lint
     timeout-minutes: 25
     steps:
       - name: Checkout
@@ -151,7 +156,6 @@ jobs:
   test-e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
-    needs: test-unit
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -294,7 +298,6 @@ jobs:
   build-release:
     name: Build Release
     runs-on: ubuntu-latest
-    needs: test-e2e
     timeout-minutes: 25
     steps:
       - name: Checkout

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -594,7 +594,11 @@ tasks.register<JacocoCoverageVerification>("jacocoTestCoverageVerification") {
  * builder. A proper typed task (vs a bare Exec writing into the source tree) so AGP can wire it as a
  * generated assets source with correct task dependencies. Keyed on [month] so it refreshes monthly.
  */
+@CacheableTask
 abstract class GenerateLocationDbTask : DefaultTask() {
+    // NONE: only the script's content matters for the output, not its path on disk — so the
+    // cache entry stays valid across differently-rooted checkouts (e.g. CI vs local).
+    @get:PathSensitive(PathSensitivity.NONE)
     @get:InputFile
     abstract val script: RegularFileProperty
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,13 @@
 # JVM memory allocation
 org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 
+# Build performance: reuse task outputs across builds/CI runs (the build cache is persisted
+# across CI runs by gradle/actions/setup-gradle) and run independent tasks/projects in parallel.
+# The configuration cache is intentionally NOT enabled: configuration reads git via ProcessBuilder
+# and uses androidComponents/taskGraph.whenReady, which the configuration cache rejects.
+org.gradle.caching=true
+org.gradle.parallel=true
+
 # AndroidX
 android.useAndroidX=true
 


### PR DESCRIPTION
Reduces CI wall-clock from **~36 min** toward **~8 min** by de-serializing the jobs, splitting the release build per-flavour, and enabling the Gradle build cache.

## Commits
1. **ci: run lint, unit, e2e, and release jobs in parallel**
2. **ci: split Build Release into parallel per-flavour jobs** (GMS / FOSS)
3. **perf(build): enable Gradle build cache + parallel, cache generated location DB**

---

## 1. Parallelize the job graph

CI ran as a strict serial chain even though **each job already runs on its own runner**:

```
lint ──▶ test-unit ──▶ test-e2e ──▶ build-release      wall = SUM ≈ 36 min
(2m15)     (8m30)        (12m20)       (12m53)
```

None of these jobs consumes another's artifacts — each checks out fresh, restores its native deps from cache, and runs independent Gradle tasks. The `needs:` chain was only a **fail-fast gate**, not a data dependency. Dropping it runs all four in parallel:

```
lint ─┐
test-unit ─┤ (4 runners at once)              wall = MAX ≈ 13 min  (−64%)
test-e2e ─┤
build-release ─┘
```

Trade-off (chosen deliberately): the expensive e2e/redroid and release jobs now run even when lint/unit fail — full feedback in one shot. **Required checks are unaffected** — the ruleset requires `Lint`, `Unit & Integration Tests`, `E2E Tests` (gated on outcome, not order).

## 2. Split Build Release per flavour

`build-release` built all four APKs (gms/foss × debug/release) serially in one job. A matrix now runs **Build Release - GMS** and **Build Release - FOSS** on separate runners, each assembling only its flavour (`fail-fast: false` so one flavour's failure doesn't cancel the other). `build-release` is not a required check, so the rename is safe.

## 3. Build cache + cacheable location DB

Per-step timing showed the real E2E cost was **not** redroid (image pull = 29s) but the **Android APK build = 7m18s**, because nothing was cached:

| E2E step | Time |
|---|---|
| Build gms debug APK | **7m18s** |
| Run E2E tests (redroid boot + install + test) | 3m30s |
| image pull / kernel modules / gradle setup / misc | ~1.5 min |

- **`org.gradle.caching=true` + `org.gradle.parallel=true`** — CI reuses compiled Kotlin/KSP task outputs across runs (the Gradle home, incl. the build cache, is persisted by `gradle/actions/setup-gradle`) instead of recompiling ~314 files from scratch in every assemble job.
- **`GenerateLocationDbTask` → `@CacheableTask`** (with `@PathSensitive(NONE)` on the builder script) so its ~1.5-min CSV parse is stored/restored from the build cache. Verified locally: the task resolves **FROM-CACHE (1m37s → <1s)** after a clean. (Previously only the *source CSV* was cached, not the generated `location-db.bin.gz`.)
- The **configuration cache is intentionally left off** — configuration reads git via `ProcessBuilder` and uses `androidComponents`/`taskGraph.whenReady`, which it does not support.

---

## Expected impact

| | wall-clock |
|---|---|
| Before | ~36 min |
| After parallelization + split | ~13 min |
| After build cache (warm) | **~7–8 min** (E2E-bound) |

**Timing caveat:** the build-cache win only appears on **warm** runs. This PR's *first* run is cold (no cache to restore — `main` doesn't have caching yet), so it **seeds** the cache and still shows the ~7-min cold compile. The compile speedup lands on subsequent runs / after merge on `main`.

## Validation
- YAML parses; all four jobs confirmed with no `needs:`; matrix yields `Build Release - GMS` / `- FOSS`.
- `generateLocationDb` verified FROM-CACHE (1m37s → <1s) after clean.
- `make lint` green (detekt 0 findings) with parallel + caching enabled.
- The real proof is this PR's own run (four jobs launching simultaneously) and the next run's compile-cache hit.

## Not done (deliberately)
- **`prepare-natives` job** — analysis showed it doesn't reduce wall-clock: native caches are keyed on vendored-source hashes (warm ~always), so a shared prepare job only adds a serial prefix on the common path while saving compute solely on rare cold-cache runs. Skipped for the wait-time goal.
