### PR TITLE
feat: Server screen network-access & tunnel suggestion card

### DIFF
--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/MainScreen.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/MainScreen.kt
@@ -61,6 +61,14 @@ fun MainScreen(
                         pendingSettingsRoute = SettingsRoute.Permissions.route
                         selectedTabRoute = TopLevelRoute.Settings.route
                     },
+                    onNavigateToNetworkSettings = {
+                        pendingSettingsRoute = SettingsRoute.General.route
+                        selectedTabRoute = TopLevelRoute.Settings.route
+                    },
+                    onNavigateToTunnelSettings = {
+                        pendingSettingsRoute = SettingsRoute.Tunnel.route
+                        selectedTabRoute = TopLevelRoute.Settings.route
+                    },
                     modifier = Modifier.padding(paddingValues),
                     viewModel = viewModel,
                 )
@@ -87,6 +95,14 @@ fun MainScreen(
                 ServerTabScreen(
                     onNavigateToPermissions = {
                         pendingSettingsRoute = SettingsRoute.Permissions.route
+                        selectedTabRoute = TopLevelRoute.Settings.route
+                    },
+                    onNavigateToNetworkSettings = {
+                        pendingSettingsRoute = SettingsRoute.General.route
+                        selectedTabRoute = TopLevelRoute.Settings.route
+                    },
+                    onNavigateToTunnelSettings = {
+                        pendingSettingsRoute = SettingsRoute.Tunnel.route
                         selectedTabRoute = TopLevelRoute.Settings.route
                     },
                     modifier = Modifier.padding(paddingValues),

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/ServerScreen.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/ServerScreen.kt
@@ -5,7 +5,9 @@ package com.danielealbano.androidremotecontrolmcp.ui.screens
 import android.content.Intent
 import android.widget.Toast
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -17,6 +19,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.AlertDialog
@@ -42,6 +45,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.danielealbano.androidremotecontrolmcp.R
+import com.danielealbano.androidremotecontrolmcp.data.model.BindingAddress
 import com.danielealbano.androidremotecontrolmcp.ui.ApprovalActivity
 import com.danielealbano.androidremotecontrolmcp.ui.components.BatteryOptimizationCard
 import com.danielealbano.androidremotecontrolmcp.ui.components.ConnectionInfoCard
@@ -57,6 +61,8 @@ import com.danielealbano.androidremotecontrolmcp.utils.NetworkUtils
 fun ServerScreen(
     onNavigateToPermissions: () -> Unit,
     onShowAllLogs: () -> Unit,
+    onNavigateToNetworkSettings: () -> Unit,
+    onNavigateToTunnelSettings: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: MainViewModel = hiltViewModel(),
     channelViewModel: ChannelViewModel = hiltViewModel(),
@@ -114,6 +120,20 @@ fun ServerScreen(
                 PendingApprovalsCard(
                     count = pendingApprovalCount,
                     onClick = { context.startActivity(Intent(context, ApprovalActivity::class.java)) },
+                )
+                Spacer(Modifier.height(16.dp))
+            }
+
+            if (serverConfig.bindingAddress == BindingAddress.LOCALHOST && !serverConfig.tunnelEnabled) {
+                NetworkAccessSuggestionCard(
+                    onEnableWifi = {
+                        viewModel.updateBindingAddress(BindingAddress.NETWORK)
+                        onNavigateToNetworkSettings()
+                    },
+                    onSetUpTunnel = {
+                        viewModel.updateTunnelEnabled(true)
+                        onNavigateToTunnelSettings()
+                    },
                 )
                 Spacer(Modifier.height(16.dp))
             }
@@ -201,6 +221,48 @@ private fun NoAuthWarningCard() {
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurface,
             )
+        }
+    }
+}
+
+@Composable
+private fun NetworkAccessSuggestionCard(
+    onEnableWifi: () -> Unit,
+    onSetUpTunnel: () -> Unit,
+) {
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Default.Info,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+                Spacer(Modifier.width(12.dp))
+                Text(
+                    text = stringResource(R.string.server_network_access_suggestion_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.server_network_access_suggestion_body),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.height(8.dp))
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
+            ) {
+                TextButton(onClick = onEnableWifi) {
+                    Text(stringResource(R.string.server_network_access_suggestion_wifi))
+                }
+                TextButton(onClick = onSetUpTunnel) {
+                    Text(stringResource(R.string.server_network_access_suggestion_tunnel))
+                }
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/ServerTabScreen.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/ServerTabScreen.kt
@@ -14,6 +14,8 @@ import com.danielealbano.androidremotecontrolmcp.ui.viewmodels.MainViewModel
 @Composable
 fun ServerTabScreen(
     onNavigateToPermissions: () -> Unit,
+    onNavigateToNetworkSettings: () -> Unit,
+    onNavigateToTunnelSettings: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: MainViewModel = hiltViewModel(),
 ) {
@@ -27,6 +29,8 @@ fun ServerTabScreen(
             ServerScreen(
                 onNavigateToPermissions = onNavigateToPermissions,
                 onShowAllLogs = { navController.navigate(ServerRoute.Logs.route) },
+                onNavigateToNetworkSettings = onNavigateToNetworkSettings,
+                onNavigateToTunnelSettings = onNavigateToTunnelSettings,
                 viewModel = viewModel,
             )
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -126,6 +126,12 @@
     <string name="permission_warning_message">Accessibility permission is required. Tap to grant.</string>
     <string name="server_pending_approvals_message">%1$d pending connection approval(s). Tap to review.</string>
 
+    <!-- Network Access Suggestion (main screen: localhost-only bind with no tunnel) -->
+    <string name="server_network_access_suggestion_title">Reachable from this device only</string>
+    <string name="server_network_access_suggestion_body">The server is bound to localhost with no tunnel, so only this device can reach it. Bind to the network (0.0.0.0) for access over Wi-Fi, or set up a tunnel for access over the internet.</string>
+    <string name="server_network_access_suggestion_wifi">Enable Wi-Fi access</string>
+    <string name="server_network_access_suggestion_tunnel">Set up tunnel</string>
+
     <!-- Battery Optimization -->
     <string name="battery_optimization_card_title">Keep the server running</string>
     <string name="battery_optimization_card_body">Android battery optimization can stop the MCP server in the background. Disable it for this app so the server stays reachable.</string>


### PR DESCRIPTION
## Summary

Adds a suggestion card to the Server (main) screen that appears only when the server binds **localhost-only** and **no tunnel** is enabled — i.e. it is reachable from this device only. The card explains the situation and offers two one-tap actions to make the server reachable, each of which applies the relevant setting and deep-links into its settings section. The card auto-hides the moment either condition changes.

## Changes

- **`ServerScreen.kt`** — new `NetworkAccessSuggestionCard` composable, rendered in the existing advisory-card stack (top of screen) under the condition `bindingAddress == LOCALHOST && !tunnelEnabled`. Its two buttons act, then navigate:
  - **Enable Wi-Fi access** → `updateBindingAddress(NETWORK)` (binds `0.0.0.0`) then opens **General** settings.
  - **Set up tunnel** → `updateTunnelEnabled(true)` (flips the tunnel master switch) then opens **Tunnel** settings to configure the provider.
  - Buttons use the now-stable `FlowRow` so they reflow instead of clipping at large font scales / narrow widths.
- **`ServerTabScreen.kt` / `MainScreen.kt`** — thread two navigation callbacks through, reusing the existing `pendingSettingsRoute` cross-tab deep-link mechanism (same one the permissions card uses).
- **`strings.xml`** — 4 new strings (title, body, two button labels).

## Notes

- The mandatory `0.0.0.0` network-exposure warning **remains intact** in the General settings screen for direct changes there; only the card's one-tap button enables directly (deliberate product decision).
- Both binding address and tunnel are read at **server start**, so if the server is already running when a button is tapped, the setting is saved and takes effect on the next stop/start — consistent with the settings pages, which disable these controls while the server runs.

## Testing

- `make lint` ✅
- `./gradlew :app:assembleGmsDebug` ✅
- `make test-unit` ✅
- Installed on a physical device (RMX5313, Android 16) and verified.

## Checklist

- [x] All tests pass (`make test-unit`)
- [x] Lint passes (`make lint`)
- [x] Build succeeds