### PR TITLE
fix(deps): pin build/test-tooling transitives to CVE-patched versions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -308,19 +308,9 @@ kotlin {
     }
 }
 
-// AGP's Unified Test Platform (com.android.tools.utp) drags a vulnerable netty 4.1.x onto the
-// build/test-tooling classpath via grpc-netty. It never ships in the APK and this project never runs
-// UTP, but Dependabot still flags it. A scoped `constraints {}` cannot reach AGP's internal UTP
-// configurations, so force every netty 4.1.x transitive up to the first patched 4.1 release across
-// ALL configurations. The 4.2.x line used by the shipping Ktor engine is untouched.
-configurations.configureEach {
-    resolutionStrategy.eachDependency {
-        if (requested.group == "io.netty" && requested.version?.startsWith("4.1.") == true) {
-            useVersion("4.1.136.Final")
-            because("CVE-patched netty; UTP/grpc-netty pulls a vulnerable 4.1.x build-tooling transitive")
-        }
-    }
-}
+// Tooling-transitive CVE forces (netty 4.1.x, bouncycastle, httpclient, commons-lang3) live in the
+// root build.gradle.kts `allprojects` block so they apply to every module uniformly. The shipping
+// netty 4.2.x pins for Ktor's server engine remain here as scoped constraints (see below).
 
 dependencies {
     // AndroidX Core

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,29 @@
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 
+// The GitHub dependency graph (what Dependabot scans) also captures the Gradle plugin/buildscript
+// classpath, where AGP's own transitives pull vulnerable bouncycastle/httpclient/commons-lang3 (e.g.
+// apkzlib -> bcprov 1.79). These run only inside Gradle at build time and never ship, but Dependabot
+// still flags them, and the `allprojects` project-configuration forces below cannot reach the
+// buildscript classpath. Force them to their patched releases here. (netty 4.1.x is not on this
+// classpath — it is a project-configuration transitive only.)
+buildscript {
+    configurations.configureEach {
+        resolutionStrategy.eachDependency {
+            val group = requested.group
+            val name = requested.name
+            when {
+                group == "org.bouncycastle" &&
+                    name in setOf("bcprov-jdk18on", "bcutil-jdk18on", "bcpkix-jdk18on") ->
+                    useVersion("1.85")
+                group == "org.apache.httpcomponents" && name in setOf("httpclient", "httpmime") ->
+                    useVersion("4.5.14")
+                group == "org.apache.commons" && name == "commons-lang3" ->
+                    useVersion("3.18.0")
+            }
+        }
+    }
+}
+
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.jvm) apply false
@@ -17,5 +41,42 @@ tasks.withType<DependencyUpdatesTask> {
     rejectVersionIf {
         val version = candidate.version.uppercase()
         listOf("ALPHA", "BETA", "RC", "DEV", "SNAPSHOT", "M1", "M2", "M3").any { version.contains(it) }
+    }
+}
+
+// Every Dependabot-flagged CVE in this repo originates from BUILD/TEST-TOOLING transitives that never
+// ship in the APK and never run at app runtime: Android Lint's `androidLintTool` configuration and
+// AGP's Unified Test Platform (UTP) configurations pull vulnerable bouncycastle/httpclient/commons-lang3,
+// and UTP's grpc-netty drags a vulnerable netty 4.1.x. Scoped `constraints {}` cannot reach these
+// AGP-internal tooling configurations, and the forces must apply to :app, :compose-test-app and
+// :e2e-tests alike — so force every affected transitive up to its first patched release across ALL
+// projects and ALL configurations. The shipping runtime is unaffected: Ktor's server engine keeps its
+// netty 4.2.x line (pinned to 4.2.16.Final by :app constraints, which this 4.1.x rule never matches),
+// and the app's direct bouncycastle is already 1.85.
+allprojects {
+    configurations.configureEach {
+        resolutionStrategy.eachDependency {
+            val group = requested.group
+            val name = requested.name
+            when {
+                group == "io.netty" && requested.version?.startsWith("4.1.") == true -> {
+                    useVersion("4.1.136.Final")
+                    because("CVE-patched netty; UTP/grpc-netty pulls a vulnerable 4.1.x tooling transitive")
+                }
+                group == "org.bouncycastle" &&
+                    name in setOf("bcprov-jdk18on", "bcutil-jdk18on", "bcpkix-jdk18on") -> {
+                    useVersion("1.85")
+                    because("CVE-2025-14813; androidLintTool/UTP pull vulnerable bouncycastle 1.79 (tooling only)")
+                }
+                group == "org.apache.httpcomponents" && name in setOf("httpclient", "httpmime") -> {
+                    useVersion("4.5.14")
+                    because("CVE-2020-13956; androidLintTool/UTP pull vulnerable httpclient 4.5.6 (tooling only)")
+                }
+                group == "org.apache.commons" && name == "commons-lang3" -> {
+                    useVersion("3.18.0")
+                    because("CVE-2025-48924; androidLintTool/UTP pull vulnerable commons-lang3 3.16.0 (tooling only)")
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Resolves all 13 open Dependabot alerts (1 critical, 5 high, 7 moderate). **Every one originates from build/test-tooling transitives that never ship in the APK and never run at app runtime** — verified by resolving the shipped release classpath directly (Netty is entirely `4.2.16.Final`, Bouncy Castle is `1.85`).

## Where the alerts actually come from

| Source | Packages |
|---|---|
| Android Lint (`androidLintTool` config) | `bcprov/bcpkix 1.79`, `httpclient/httpmime 4.5.6`, `commons-lang3 3.16.0` |
| AGP Unified Test Platform (UTP configs) | same three + `grpc-netty → netty 4.1.110/4.1.93` |
| **AGP plugin/buildscript classpath** (e.g. `apkzlib → bcprov 1.79`) | `bcprov 1.79`, `httpclient/httpmime 4.5.6`, `commons-lang3 3.16.0` |

The GitHub dependency graph scans **both** project configurations **and** the Gradle plugin classpath — confirmed from the repo SBOM, which lists buildscript-only AGP internals (`apkzlib`, `builder-model`, `gradle-api`, `apksig`). So the transitives are pinned in two places.

## Changes (`build.gradle.kts` + `app/build.gradle.kts`)

- **`allprojects { … }`** resolutionStrategy — every project configuration:
  `netty 4.1.x → 4.1.136.Final`, `bouncycastle → 1.85`, `httpclient/httpmime → 4.5.14`, `commons-lang3 → 3.18.0`
- **`buildscript { … }`** resolutionStrategy — the Gradle plugin classpath:
  `bouncycastle → 1.85`, `httpclient/httpmime → 4.5.14`, `commons-lang3 → 3.18.0`
- Removed the now-redundant `:app`-only Netty force (the `allprojects` block subsumes it). The shipped Netty `4.2.16.Final` constraints remain untouched.

## Nothing shipped changed

Ktor's server engine keeps its Netty 4.2.x line (`4.2.16.Final` via `:app` constraints, which the `4.1.x` rule never matches); the app's direct Bouncy Castle was already `1.85`.

## Verification

Resolved **every module configuration and the plugin classpath** before/after and grepped for genuinely-resolved (non-redirected) vulnerable coordinates:

| Coordinate | Before | After |
|---|---|---|
| netty 4.1.x (`<4.1.136`) | present | **0** |
| bcprov/bcpkix/bcutil 1.79 | present | **0** |
| httpclient/httpmime 4.5.6 | present | **0** |
| commons-lang3 3.16.0 | present | **0** |

- `make lint` ✅
- `:app:assembleGmsDebug` + `:app:assembleGmsRelease` ✅ (APK signing exercised under forced Bouncy Castle)
- `make test-unit` ✅

## Checklist

- [x] All tests pass (`make test-unit`)
- [x] Lint passes (`make lint`)
- [x] Build succeeds (debug + release)