### PR TITLE
feat: show visual indicator during MCP tool calls

### DIFF
--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/data/model/ServerConfig.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/data/model/ServerConfig.kt
@@ -11,6 +11,7 @@ package com.danielealbano.androidremotecontrolmcp.data.model
  * @property bindingAddress The network binding address.
  * @property bearerToken The bearer token for MCP request authentication.
  * @property autoStartOnBoot Whether to start the MCP server on device boot.
+ * @property toolCallIndicatorEnabled Whether to show an on-device overlay during MCP tool calls.
  * @property httpsEnabled Whether HTTPS is enabled (disabled by default).
  * @property certificateSource The source of the HTTPS certificate.
  * @property certificateHostname The hostname for auto-generated certificates.
@@ -39,6 +40,7 @@ data class ServerConfig(
     val bindingAddress: BindingAddress = BindingAddress.LOCALHOST,
     val bearerToken: String = "",
     val autoStartOnBoot: Boolean = false,
+    val toolCallIndicatorEnabled: Boolean = true,
     val httpsEnabled: Boolean = false,
     val certificateSource: CertificateSource = CertificateSource.AUTO_GENERATED,
     val certificateHostname: String = DEFAULT_CERTIFICATE_HOSTNAME,

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/data/repository/SettingsRepository.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/data/repository/SettingsRepository.kt
@@ -105,6 +105,9 @@ interface SettingsRepository : EventChannelSettings {
     /** Updates the auto-start-on-boot preference. */
     suspend fun updateAutoStartOnBoot(enabled: Boolean)
 
+    /** Enables or disables the on-device MCP tool-call activity indicator. */
+    suspend fun updateToolCallIndicatorEnabled(enabled: Boolean)
+
     /**
      * Observes the persisted server-running intent flag (`true` after ACTION_START, `false` after
      * ACTION_STOP). Used by restart triggers to decide whether to bring the MCP server back up.

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/data/repository/SettingsRepositoryImpl.kt
@@ -46,6 +46,7 @@ private val BEARER_TOKEN_ENABLED_INITIALIZED_KEY =
 private val PUBLIC_URL_OVERRIDE_KEY = stringPreferencesKey("public_url_override")
 private val JWT_SIGNING_SECRET_KEY = stringPreferencesKey("jwt_signing_secret")
 private val AUTO_START_KEY = booleanPreferencesKey("auto_start_on_boot")
+private val TOOL_CALL_INDICATOR_ENABLED_KEY = booleanPreferencesKey("tool_call_indicator_enabled")
 private val SERVER_RUNNING_KEY = booleanPreferencesKey("server_running")
 private val HTTPS_ENABLED_KEY = booleanPreferencesKey("https_enabled")
 private val CERTIFICATE_SOURCE_KEY = stringPreferencesKey("certificate_source")
@@ -109,6 +110,7 @@ private fun mapPreferencesToServerConfig(prefs: Preferences): ServerConfig {
                 ?: BindingAddress.LOCALHOST,
         bearerToken = prefs[BEARER_TOKEN_KEY] ?: "",
         autoStartOnBoot = prefs[AUTO_START_KEY] ?: false,
+        toolCallIndicatorEnabled = prefs[TOOL_CALL_INDICATOR_ENABLED_KEY] ?: true,
         httpsEnabled = prefs[HTTPS_ENABLED_KEY] ?: false,
         certificateSource =
             CertificateSource.entries.firstOrNull { it.name == certificateSourceName }
@@ -374,6 +376,14 @@ class SettingsRepositoryImpl
                 val old = prefs[AUTO_START_KEY] ?: false
                 prefs[AUTO_START_KEY] = enabled
                 logToggle("auto_start", old, enabled, "Auto-start on boot")
+            }
+        }
+
+        override suspend fun updateToolCallIndicatorEnabled(enabled: Boolean) {
+            dataStore.edit { prefs ->
+                val old = prefs[TOOL_CALL_INDICATOR_ENABLED_KEY] ?: true
+                prefs[TOOL_CALL_INDICATOR_ENABLED_KEY] = enabled
+                logToggle("tool_call_indicator", old, enabled, "Tool-call indicator")
             }
         }
 

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/LoggedToolRegistration.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/LoggedToolRegistration.kt
@@ -23,16 +23,19 @@ private const val FAILED_MARKER = "failed"
 internal fun loggedToolHandler(
     serverLog: ServerLogRepository,
     toolName: String,
+    toolCallIndicator: ToolCallIndicator = ToolCallIndicator.NONE,
     handler: suspend (CallToolRequest) -> CallToolResult,
 ): suspend (CallToolRequest) -> CallToolResult =
     { request ->
         val startNs = System.nanoTime()
         var completed: CallToolResult? = null
+        toolCallIndicator.onToolCallStarted(toolName)
         try {
             val result = handler(request)
             completed = result
             result
         } finally {
+            toolCallIndicator.onToolCallFinished(toolName)
             val durationMs = (System.nanoTime() - startNs) / NANOS_PER_MILLI
             val result = completed
             when {
@@ -67,6 +70,7 @@ internal fun loggedToolHandler(
 class LoggedToolRegistrar(
     private val server: Server,
     private val serverLog: ServerLogRepository,
+    private val toolCallIndicator: ToolCallIndicator = ToolCallIndicator.NONE,
 ) {
     /** [Server.addTool] with per-call TOOL_CALL logging. [toolName] is the un-prefixed display name. */
     fun addTool(
@@ -76,7 +80,7 @@ class LoggedToolRegistrar(
         inputSchema: ToolSchema,
         handler: suspend (CallToolRequest) -> CallToolResult,
     ) {
-        val wrapped = loggedToolHandler(serverLog, toolName, handler)
+        val wrapped = loggedToolHandler(serverLog, toolName, toolCallIndicator, handler)
         server.addTool(name = name, description = description, inputSchema = inputSchema) { request ->
             wrapped(request)
         }

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/LoggedToolRegistration.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/LoggedToolRegistration.kt
@@ -29,13 +29,13 @@ internal fun loggedToolHandler(
     { request ->
         val startNs = System.nanoTime()
         var completed: CallToolResult? = null
-        toolCallIndicator.onToolCallStarted(toolName)
+        runCatching { toolCallIndicator.onToolCallStarted(toolName) }
         try {
             val result = handler(request)
             completed = result
             result
         } finally {
-            toolCallIndicator.onToolCallFinished(toolName)
+            runCatching { toolCallIndicator.onToolCallFinished(toolName) }
             val durationMs = (System.nanoTime() - startNs) / NANOS_PER_MILLI
             val result = completed
             when {

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/ReferenceCountedToolCallIndicator.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/ReferenceCountedToolCallIndicator.kt
@@ -7,11 +7,14 @@ package com.danielealbano.androidremotecontrolmcp.mcp.tools
 class ReferenceCountedToolCallIndicator(
     private val delegate: ToolCallIndicator,
 ) : ToolCallIndicator {
-    override fun setEnabled(enabled: Boolean) {
-        delegate.setEnabled(enabled)
-    }
     private val lock = Any()
     private val activeTools = mutableListOf<String>()
+
+    override fun setEnabled(enabled: Boolean) {
+        synchronized(lock) {
+            runCatching { delegate.setEnabled(enabled) }
+        }
+    }
 
     override fun onToolCallStarted(toolName: String) {
         synchronized(lock) {

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/ReferenceCountedToolCallIndicator.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/ReferenceCountedToolCallIndicator.kt
@@ -1,0 +1,22 @@
+package com.danielealbano.androidremotecontrolmcp.mcp.tools
+
+import java.util.concurrent.atomic.AtomicInteger
+
+/** Keeps an indicator visible until every overlapping tool invocation has completed. */
+class ReferenceCountedToolCallIndicator(
+    private val delegate: ToolCallIndicator,
+) : ToolCallIndicator {
+    private val activeCalls = AtomicInteger(0)
+
+    override fun onToolCallStarted(toolName: String) {
+        activeCalls.incrementAndGet()
+        delegate.onToolCallStarted(toolName)
+    }
+
+    override fun onToolCallFinished(toolName: String) {
+        val remaining = activeCalls.updateAndGet { current -> (current - 1).coerceAtLeast(0) }
+        if (remaining == 0) {
+            delegate.onToolCallFinished(toolName)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/ReferenceCountedToolCallIndicator.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/ReferenceCountedToolCallIndicator.kt
@@ -7,6 +7,9 @@ package com.danielealbano.androidremotecontrolmcp.mcp.tools
 class ReferenceCountedToolCallIndicator(
     private val delegate: ToolCallIndicator,
 ) : ToolCallIndicator {
+    override fun setEnabled(enabled: Boolean) {
+        delegate.setEnabled(enabled)
+    }
     private val lock = Any()
     private val activeTools = mutableListOf<String>()
 

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/ReferenceCountedToolCallIndicator.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/ReferenceCountedToolCallIndicator.kt
@@ -1,22 +1,39 @@
 package com.danielealbano.androidremotecontrolmcp.mcp.tools
 
-import java.util.concurrent.atomic.AtomicInteger
-
-/** Keeps an indicator visible until every overlapping tool invocation has completed. */
+/**
+ * Serializes overlapping tool-call transitions and keeps the delegate on the most recently started
+ * active tool. Delegate failures are swallowed so an optional visual indicator remains best-effort.
+ */
 class ReferenceCountedToolCallIndicator(
     private val delegate: ToolCallIndicator,
 ) : ToolCallIndicator {
-    private val activeCalls = AtomicInteger(0)
+    private val lock = Any()
+    private val activeTools = mutableListOf<String>()
 
     override fun onToolCallStarted(toolName: String) {
-        activeCalls.incrementAndGet()
-        delegate.onToolCallStarted(toolName)
+        synchronized(lock) {
+            activeTools += toolName
+            runCatching { delegate.onToolCallStarted(toolName) }
+        }
     }
 
     override fun onToolCallFinished(toolName: String) {
-        val remaining = activeCalls.updateAndGet { current -> (current - 1).coerceAtLeast(0) }
-        if (remaining == 0) {
-            delegate.onToolCallFinished(toolName)
+        synchronized(lock) {
+            val index = activeTools.indexOfLast { it == toolName }
+            if (index >= 0) {
+                val wasDisplayed = index == activeTools.lastIndex
+                activeTools.removeAt(index)
+                if (wasDisplayed) {
+                    val nextTool = activeTools.lastOrNull()
+                    runCatching {
+                        if (nextTool == null) {
+                            delegate.onToolCallFinished(toolName)
+                        } else {
+                            delegate.onToolCallStarted(nextTool)
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/ToolCallIndicator.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/ToolCallIndicator.kt
@@ -9,6 +9,8 @@ interface ToolCallIndicator {
 
     fun onToolCallFinished(toolName: String)
 
+    fun setEnabled(enabled: Boolean) = Unit
+
     companion object {
         val NONE: ToolCallIndicator =
             object : ToolCallIndicator {

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/ToolCallIndicator.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/ToolCallIndicator.kt
@@ -1,0 +1,20 @@
+package com.danielealbano.androidremotecontrolmcp.mcp.tools
+
+/**
+ * Surfaces MCP tool activity to the device user without exposing tool arguments or results.
+ * Implementations must be non-blocking so they never delay a tool invocation.
+ */
+interface ToolCallIndicator {
+    fun onToolCallStarted(toolName: String)
+
+    fun onToolCallFinished(toolName: String)
+
+    companion object {
+        val NONE: ToolCallIndicator =
+            object : ToolCallIndicator {
+                override fun onToolCallStarted(toolName: String) = Unit
+
+                override fun onToolCallFinished(toolName: String) = Unit
+            }
+    }
+}

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/UtilityTools.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/UtilityTools.kt
@@ -6,6 +6,7 @@ import android.os.SystemClock
 import android.util.Log
 import android.view.accessibility.AccessibilityNodeInfo
 import com.danielealbano.androidremotecontrolmcp.data.model.ToolPermissionsConfig
+import com.danielealbano.androidremotecontrolmcp.data.repository.SettingsRepository
 import com.danielealbano.androidremotecontrolmcp.mcp.McpToolException
 import com.danielealbano.androidremotecontrolmcp.privacy.PlaceholderSubstitutor
 import com.danielealbano.androidremotecontrolmcp.privacy.PrivacyToolGate
@@ -23,6 +24,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
@@ -834,7 +836,12 @@ fun registerUtilityTools(
     substitutor: PlaceholderSubstitutor,
     toolNamePrefix: String,
     perms: ToolPermissionsConfig,
+    settingsRepository: SettingsRepository? = null,
+    toolCallIndicator: ToolCallIndicator = ToolCallIndicator.NONE,
 ) {
+    if (settingsRepository != null) {
+        SetToolCallIndicatorTool(settingsRepository, toolCallIndicator).register(registrar, toolNamePrefix)
+    }
     if (perms.isToolEnabled(GetClipboardTool.TOOL_NAME)) {
         GetClipboardTool(accessibilityServiceProvider, privacyToolGate).register(registrar, toolNamePrefix)
     }
@@ -858,5 +865,48 @@ fun registerUtilityTools(
     if (perms.isToolEnabled(GetNodeDetailsTool.TOOL_NAME)) {
         GetNodeDetailsTool(treeParser, elementFinder, accessibilityServiceProvider, nodeCache, privacyToolGate)
             .register(registrar, toolNamePrefix)
+    }
+}
+
+/** Lets an MCP client explicitly control whether subsequent tool calls are surfaced on-device. */
+class SetToolCallIndicatorTool(
+    private val settingsRepository: SettingsRepository,
+    private val toolCallIndicator: ToolCallIndicator,
+) {
+    suspend fun execute(arguments: JsonObject?): CallToolResult {
+        val enabled =
+            arguments?.get("enabled")?.jsonPrimitive?.booleanOrNull
+                ?: throw McpToolException.InvalidParams("Missing required boolean parameter 'enabled'")
+        settingsRepository.updateToolCallIndicatorEnabled(enabled)
+        toolCallIndicator.setEnabled(enabled)
+        return McpToolUtils.textResult("Tool-call indicator ${if (enabled) "enabled" else "disabled"}")
+    }
+
+    fun register(
+        registrar: LoggedToolRegistrar,
+        toolNamePrefix: String,
+    ) {
+        registrar.addTool(
+            toolName = TOOL_NAME,
+            name = "$toolNamePrefix$TOOL_NAME",
+            description =
+                "Enable or disable the privacy-safe on-device overlay shown during MCP tool calls. " +
+                    "Use this to make phone control visible when useful; the preference persists.",
+            inputSchema =
+                ToolSchema(
+                    properties =
+                        buildJsonObject {
+                            putJsonObject("enabled") {
+                                put("type", "boolean")
+                                put("description", "True to show the overlay, false to hide it")
+                            }
+                        },
+                    required = listOf("enabled"),
+                ),
+        ) { request -> execute(request.arguments) }
+    }
+
+    companion object {
+        const val TOOL_NAME = "set_tool_call_indicator"
     }
 }

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/UtilityTools.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/UtilityTools.kt
@@ -6,7 +6,6 @@ import android.os.SystemClock
 import android.util.Log
 import android.view.accessibility.AccessibilityNodeInfo
 import com.danielealbano.androidremotecontrolmcp.data.model.ToolPermissionsConfig
-import com.danielealbano.androidremotecontrolmcp.data.repository.SettingsRepository
 import com.danielealbano.androidremotecontrolmcp.mcp.McpToolException
 import com.danielealbano.androidremotecontrolmcp.privacy.PlaceholderSubstitutor
 import com.danielealbano.androidremotecontrolmcp.privacy.PrivacyToolGate
@@ -24,7 +23,6 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
@@ -836,12 +834,7 @@ fun registerUtilityTools(
     substitutor: PlaceholderSubstitutor,
     toolNamePrefix: String,
     perms: ToolPermissionsConfig,
-    settingsRepository: SettingsRepository? = null,
-    toolCallIndicator: ToolCallIndicator = ToolCallIndicator.NONE,
 ) {
-    if (settingsRepository != null) {
-        SetToolCallIndicatorTool(settingsRepository, toolCallIndicator).register(registrar, toolNamePrefix)
-    }
     if (perms.isToolEnabled(GetClipboardTool.TOOL_NAME)) {
         GetClipboardTool(accessibilityServiceProvider, privacyToolGate).register(registrar, toolNamePrefix)
     }
@@ -865,48 +858,5 @@ fun registerUtilityTools(
     if (perms.isToolEnabled(GetNodeDetailsTool.TOOL_NAME)) {
         GetNodeDetailsTool(treeParser, elementFinder, accessibilityServiceProvider, nodeCache, privacyToolGate)
             .register(registrar, toolNamePrefix)
-    }
-}
-
-/** Lets an MCP client explicitly control whether subsequent tool calls are surfaced on-device. */
-class SetToolCallIndicatorTool(
-    private val settingsRepository: SettingsRepository,
-    private val toolCallIndicator: ToolCallIndicator,
-) {
-    suspend fun execute(arguments: JsonObject?): CallToolResult {
-        val enabled =
-            arguments?.get("enabled")?.jsonPrimitive?.booleanOrNull
-                ?: throw McpToolException.InvalidParams("Missing required boolean parameter 'enabled'")
-        settingsRepository.updateToolCallIndicatorEnabled(enabled)
-        toolCallIndicator.setEnabled(enabled)
-        return McpToolUtils.textResult("Tool-call indicator ${if (enabled) "enabled" else "disabled"}")
-    }
-
-    fun register(
-        registrar: LoggedToolRegistrar,
-        toolNamePrefix: String,
-    ) {
-        registrar.addTool(
-            toolName = TOOL_NAME,
-            name = "$toolNamePrefix$TOOL_NAME",
-            description =
-                "Enable or disable the privacy-safe on-device overlay shown during MCP tool calls. " +
-                    "Use this to make phone control visible when useful; the preference persists.",
-            inputSchema =
-                ToolSchema(
-                    properties =
-                        buildJsonObject {
-                            putJsonObject("enabled") {
-                                put("type", "boolean")
-                                put("description", "True to show the overlay, false to hide it")
-                            }
-                        },
-                    required = listOf("enabled"),
-                ),
-        ) { request -> execute(request.arguments) }
-    }
-
-    companion object {
-        const val TOOL_NAME = "set_tool_call_indicator"
     }
 }

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/AccessibilityToolCallIndicator.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/AccessibilityToolCallIndicator.kt
@@ -1,0 +1,14 @@
+package com.danielealbano.androidremotecontrolmcp.services.accessibility
+
+import com.danielealbano.androidremotecontrolmcp.mcp.tools.ToolCallIndicator
+
+/** Displays a touch-through accessibility overlay while an MCP tool is executing. */
+class AccessibilityToolCallIndicator : ToolCallIndicator {
+    override fun onToolCallStarted(toolName: String) {
+        McpAccessibilityService.showToolCallIndicator(toolName)
+    }
+
+    override fun onToolCallFinished(toolName: String) {
+        McpAccessibilityService.hideToolCallIndicator()
+    }
+}

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/AccessibilityToolCallIndicator.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/AccessibilityToolCallIndicator.kt
@@ -4,11 +4,19 @@ import com.danielealbano.androidremotecontrolmcp.mcp.tools.ToolCallIndicator
 
 /** Displays a touch-through accessibility overlay while an MCP tool is executing. */
 class AccessibilityToolCallIndicator : ToolCallIndicator {
+    @Volatile
+    private var enabled = true
+
     override fun onToolCallStarted(toolName: String) {
-        McpAccessibilityService.showToolCallIndicator(toolName)
+        if (enabled) McpAccessibilityService.showToolCallIndicator(toolName)
     }
 
     override fun onToolCallFinished(toolName: String) {
         McpAccessibilityService.hideToolCallIndicator()
+    }
+
+    override fun setEnabled(enabled: Boolean) {
+        this.enabled = enabled
+        if (!enabled) McpAccessibilityService.hideToolCallIndicator()
     }
 }

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/McpAccessibilityService.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/McpAccessibilityService.kt
@@ -7,12 +7,20 @@ import android.content.ComponentCallbacks2
 import android.content.Context
 import android.content.res.Configuration
 import android.graphics.Bitmap
+import android.graphics.Color
+import android.graphics.PixelFormat
+import android.graphics.drawable.GradientDrawable
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import android.view.Display
+import android.view.Gravity
+import android.view.View
 import android.view.WindowManager
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
 import android.view.accessibility.AccessibilityWindowInfo
+import android.widget.TextView
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
@@ -40,6 +48,8 @@ class McpAccessibilityService : AccessibilityService() {
     private var nodeCache: AccessibilityNodeCache? = null
 
     private var cacheInvalidationDebouncer: CacheInvalidationDebouncer? = null
+
+    private var toolCallIndicatorView: View? = null
 
     @Volatile
     private var currentPackageName: String? = null
@@ -126,6 +136,7 @@ class McpAccessibilityService : AccessibilityService() {
         currentPackageName = null
         currentActivityName = null
         inputMethodInstance = null
+        removeToolCallIndicator()
         instance = null
 
         super.onDestroy()
@@ -234,6 +245,57 @@ class McpAccessibilityService : AccessibilityService() {
         return method
     }
 
+    private fun showToolCallIndicatorInternal(toolName: String) {
+        val windowManager = getSystemService(Context.WINDOW_SERVICE) as WindowManager
+        val textView = (toolCallIndicatorView as? TextView) ?: createToolCallIndicatorView()
+        textView.text = "MCP controlling · ${formatToolName(toolName)}"
+        if (toolCallIndicatorView == null) {
+            windowManager.addView(textView, createToolCallIndicatorLayoutParams())
+            toolCallIndicatorView = textView
+        }
+    }
+
+    private fun removeToolCallIndicator() {
+        val view = toolCallIndicatorView ?: return
+        toolCallIndicatorView = null
+        val windowManager = getSystemService(Context.WINDOW_SERVICE) as WindowManager
+        runCatching { windowManager.removeView(view) }
+            .onFailure { Log.w(TAG, "Could not remove MCP tool-call indicator", it) }
+    }
+
+    private fun createToolCallIndicatorView(): TextView {
+        val horizontalPadding = TOOL_INDICATOR_HORIZONTAL_PADDING_DP.dpToPx()
+        val verticalPadding = TOOL_INDICATOR_VERTICAL_PADDING_DP.dpToPx()
+        return TextView(this).apply {
+            setTextColor(Color.WHITE)
+            textSize = TOOL_INDICATOR_TEXT_SIZE_SP
+            setPadding(horizontalPadding, verticalPadding, horizontalPadding, verticalPadding)
+            background =
+                GradientDrawable().apply {
+                    setColor(TOOL_INDICATOR_BACKGROUND_COLOR)
+                    cornerRadius = TOOL_INDICATOR_CORNER_RADIUS_DP.dpToPx().toFloat()
+                }
+            importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
+        }
+    }
+
+    private fun createToolCallIndicatorLayoutParams(): WindowManager.LayoutParams =
+        WindowManager
+            .LayoutParams(
+                WindowManager.LayoutParams.WRAP_CONTENT,
+                WindowManager.LayoutParams.WRAP_CONTENT,
+                WindowManager.LayoutParams.TYPE_ACCESSIBILITY_OVERLAY,
+                WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
+                    WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE or
+                    WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN,
+                PixelFormat.TRANSLUCENT,
+            ).apply {
+                gravity = Gravity.TOP or Gravity.CENTER_HORIZONTAL
+                y = TOOL_INDICATOR_TOP_MARGIN_DP.dpToPx()
+            }
+
+    private fun Int.dpToPx(): Int = (this * resources.displayMetrics.density).toInt()
+
     private fun configureServiceInfo() {
         serviceInfo =
             serviceInfo?.apply {
@@ -329,6 +391,12 @@ class McpAccessibilityService : AccessibilityService() {
         private const val TAG = "MCP:AccessibilityService"
         private const val NOTIFICATION_TIMEOUT_MS = 100L
         private const val SCREENSHOT_TIMEOUT_MS = 5000L
+        private const val TOOL_INDICATOR_HORIZONTAL_PADDING_DP = 16
+        private const val TOOL_INDICATOR_VERTICAL_PADDING_DP = 8
+        private const val TOOL_INDICATOR_CORNER_RADIUS_DP = 18
+        private const val TOOL_INDICATOR_TOP_MARGIN_DP = 12
+        private const val TOOL_INDICATOR_TEXT_SIZE_SP = 13f
+        private const val TOOL_INDICATOR_BACKGROUND_COLOR = 0xE6212121.toInt()
 
         /**
          * Length of the QUIET GAP (no further window-structure events) that must elapse before the
@@ -352,8 +420,26 @@ class McpAccessibilityService : AccessibilityService() {
         @Volatile
         var inputMethodInstance: McpInputMethod? = null
             private set
+
+        fun showToolCallIndicator(toolName: String) {
+            if (instance == null) return
+            Handler(Looper.getMainLooper()).post {
+                instance?.showToolCallIndicatorInternal(toolName)
+            }
+        }
+
+        fun hideToolCallIndicator() {
+            val service = instance ?: return
+            Handler(Looper.getMainLooper()).post {
+                if (instance === service) {
+                    service.removeToolCallIndicator()
+                }
+            }
+        }
     }
 }
+
+internal fun formatToolName(toolName: String): String = toolName.replace('_', ' ').replaceFirstChar { it.uppercase() }
 
 /**
  * Returns true if [eventType] is a structural window change after which cached node bounds may be

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/McpAccessibilityService.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/McpAccessibilityService.kt
@@ -250,8 +250,10 @@ class McpAccessibilityService : AccessibilityService() {
         val textView = (toolCallIndicatorView as? TextView) ?: createToolCallIndicatorView()
         textView.text = "MCP controlling · ${formatToolName(toolName)}"
         if (toolCallIndicatorView == null) {
-            windowManager.addView(textView, createToolCallIndicatorLayoutParams())
-            toolCallIndicatorView = textView
+            runCatching {
+                windowManager.addView(textView, createToolCallIndicatorLayoutParams())
+                toolCallIndicatorView = textView
+            }.onFailure { Log.w(TAG, "Could not show MCP tool-call indicator", it) }
         }
     }
 

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/mcp/McpServerService.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/mcp/McpServerService.kt
@@ -29,6 +29,7 @@ import com.danielealbano.androidremotecontrolmcp.mcp.oauth.OAuthServerDeps
 import com.danielealbano.androidremotecontrolmcp.mcp.tools.LoggedToolRegistrar
 import com.danielealbano.androidremotecontrolmcp.mcp.tools.McpToolUtils
 import com.danielealbano.androidremotecontrolmcp.mcp.tools.ReferenceCountedToolCallIndicator
+import com.danielealbano.androidremotecontrolmcp.mcp.tools.ToolCallIndicator
 import com.danielealbano.androidremotecontrolmcp.mcp.tools.registerAppManagementTools
 import com.danielealbano.androidremotecontrolmcp.mcp.tools.registerCameraTools
 import com.danielealbano.androidremotecontrolmcp.mcp.tools.registerFileTools
@@ -306,7 +307,13 @@ class McpServerService : Service() {
                 )
             val effectivePerms =
                 OptionalToolPermissions.effectivePermissions(config.toolPermissionsConfig, grantedOptionalPermissions)
-            registerAllTools(sdkServer, toolNamePrefix, effectivePerms, config.fileSizeLimitMb)
+            registerAllTools(
+                sdkServer,
+                toolNamePrefix,
+                effectivePerms,
+                config.fileSizeLimitMb,
+                config.toolCallIndicatorEnabled,
+            )
 
             // Create and start the Ktor server
             mcpServer =
@@ -437,14 +444,17 @@ class McpServerService : Service() {
         toolNamePrefix: String,
         perms: ToolPermissionsConfig,
         fileSizeLimitMb: Int,
+        toolCallIndicatorEnabled: Boolean,
     ) {
+        val toolCallIndicator = ReferenceCountedToolCallIndicator(AccessibilityToolCallIndicator())
+        toolCallIndicator.setEnabled(toolCallIndicatorEnabled)
         val registrar =
             LoggedToolRegistrar(
                 server,
                 serverLogRepository,
-                ReferenceCountedToolCallIndicator(AccessibilityToolCallIndicator()),
+                toolCallIndicator,
             )
-        registerAccessibilityToolBundle(registrar, toolNamePrefix, perms)
+        registerAccessibilityToolBundle(registrar, toolNamePrefix, perms, toolCallIndicator)
         registerFileTools(registrar, storageLocationProvider, fileOperationProvider, toolNamePrefix, perms)
         registerAppManagementTools(registrar, appManager, privacyToolGate, toolNamePrefix, perms)
         registerCameraTools(registrar, cameraProvider, fileOperationProvider, toolNamePrefix, perms)
@@ -465,6 +475,7 @@ class McpServerService : Service() {
         registrar: LoggedToolRegistrar,
         toolNamePrefix: String,
         perms: ToolPermissionsConfig,
+        toolCallIndicator: ToolCallIndicator,
     ) {
         registerScreenIntrospectionTools(
             registrar,
@@ -519,6 +530,8 @@ class McpServerService : Service() {
             placeholderSubstitutor,
             toolNamePrefix,
             perms,
+            settingsRepository,
+            toolCallIndicator,
         )
     }
 

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/mcp/McpServerService.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/mcp/McpServerService.kt
@@ -28,6 +28,7 @@ import com.danielealbano.androidremotecontrolmcp.mcp.oauth.OAuthApprovalCoordina
 import com.danielealbano.androidremotecontrolmcp.mcp.oauth.OAuthServerDeps
 import com.danielealbano.androidremotecontrolmcp.mcp.tools.LoggedToolRegistrar
 import com.danielealbano.androidremotecontrolmcp.mcp.tools.McpToolUtils
+import com.danielealbano.androidremotecontrolmcp.mcp.tools.ReferenceCountedToolCallIndicator
 import com.danielealbano.androidremotecontrolmcp.mcp.tools.registerAppManagementTools
 import com.danielealbano.androidremotecontrolmcp.mcp.tools.registerCameraTools
 import com.danielealbano.androidremotecontrolmcp.mcp.tools.registerFileTools
@@ -50,6 +51,7 @@ import com.danielealbano.androidremotecontrolmcp.privacy.PseudonymStore
 import com.danielealbano.androidremotecontrolmcp.privacy.ner.NerCache
 import com.danielealbano.androidremotecontrolmcp.services.accessibility.AccessibilityNodeCache
 import com.danielealbano.androidremotecontrolmcp.services.accessibility.AccessibilityServiceProvider
+import com.danielealbano.androidremotecontrolmcp.services.accessibility.AccessibilityToolCallIndicator
 import com.danielealbano.androidremotecontrolmcp.services.accessibility.AccessibilityTreeParser
 import com.danielealbano.androidremotecontrolmcp.services.accessibility.ActionExecutor
 import com.danielealbano.androidremotecontrolmcp.services.accessibility.CompactTreeFormatter
@@ -436,7 +438,12 @@ class McpServerService : Service() {
         perms: ToolPermissionsConfig,
         fileSizeLimitMb: Int,
     ) {
-        val registrar = LoggedToolRegistrar(server, serverLogRepository)
+        val registrar =
+            LoggedToolRegistrar(
+                server,
+                serverLogRepository,
+                ReferenceCountedToolCallIndicator(AccessibilityToolCallIndicator()),
+            )
         registerAccessibilityToolBundle(registrar, toolNamePrefix, perms)
         registerFileTools(registrar, storageLocationProvider, fileOperationProvider, toolNamePrefix, perms)
         registerAppManagementTools(registrar, appManager, privacyToolGate, toolNamePrefix, perms)

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/mcp/McpServerService.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/mcp/McpServerService.kt
@@ -454,7 +454,7 @@ class McpServerService : Service() {
                 serverLogRepository,
                 toolCallIndicator,
             )
-        registerAccessibilityToolBundle(registrar, toolNamePrefix, perms, toolCallIndicator)
+        registerAccessibilityToolBundle(registrar, toolNamePrefix, perms)
         registerFileTools(registrar, storageLocationProvider, fileOperationProvider, toolNamePrefix, perms)
         registerAppManagementTools(registrar, appManager, privacyToolGate, toolNamePrefix, perms)
         registerCameraTools(registrar, cameraProvider, fileOperationProvider, toolNamePrefix, perms)
@@ -475,7 +475,6 @@ class McpServerService : Service() {
         registrar: LoggedToolRegistrar,
         toolNamePrefix: String,
         perms: ToolPermissionsConfig,
-        toolCallIndicator: ToolCallIndicator,
     ) {
         registerScreenIntrospectionTools(
             registrar,
@@ -530,8 +529,6 @@ class McpServerService : Service() {
             placeholderSubstitutor,
             toolNamePrefix,
             perms,
-            settingsRepository,
-            toolCallIndicator,
         )
     }
 

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/settings/GeneralSettingsScreen.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/settings/GeneralSettingsScreen.kt
@@ -173,6 +173,31 @@ fun GeneralSettingsScreen(
 
             Spacer(modifier = Modifier.height(16.dp))
 
+            // Tool-call Indicator Toggle
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(R.string.config_tool_call_indicator_label),
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                    Text(
+                        text = stringResource(R.string.config_tool_call_indicator_description),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Switch(
+                    checked = serverConfig.toolCallIndicatorEnabled,
+                    onCheckedChange = viewModel::updateToolCallIndicatorEnabled,
+                    enabled = isEnabled,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
             // Auto-Start Toggle
             Row(
                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/viewmodels/MainViewModel.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/viewmodels/MainViewModel.kt
@@ -210,6 +210,12 @@ class MainViewModel
             }
         }
 
+        fun updateToolCallIndicatorEnabled(enabled: Boolean) {
+            viewModelScope.launch(ioDispatcher) {
+                settingsRepository.updateToolCallIndicatorEnabled(enabled)
+            }
+        }
+
         fun updateHttpsEnabled(enabled: Boolean) {
             viewModelScope.launch(ioDispatcher) {
                 settingsRepository.updateHttpsEnabled(enabled)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,6 +83,8 @@
     <string name="config_bearer_token_empty_warning_title">Authentication disabled</string>
     <string name="config_bearer_token_empty_warning_body">The bearer token is empty, so the MCP server accepts unauthenticated requests from anyone who can reach it. Stop the server (if running), then press Regenerate to enable authentication.</string>
     <string name="config_auto_start_label">Auto-start on boot</string>
+    <string name="config_tool_call_indicator_label">Show tool-call indicator</string>
+    <string name="config_tool_call_indicator_description">Display a privacy-safe overlay while the MCP controls this device.</string>
     <string name="config_https_enabled_label">Enable HTTPS</string>
     <string name="config_certificate_title">HTTPS Certificate</string>
     <string name="config_cert_auto_generated">Auto-generated self-signed</string>

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/data/model/ServerConfigTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/data/model/ServerConfigTest.kt
@@ -38,6 +38,12 @@ class ServerConfigTest {
         }
 
         @Test
+        fun `tool call indicator is enabled by default`() {
+            val config = ServerConfig()
+            assertTrue(config.toolCallIndicatorEnabled)
+        }
+
+        @Test
         fun `default https enabled is false`() {
             val config = ServerConfig()
             assertFalse(config.httpsEnabled)

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/data/repository/SettingsRepositoryImplTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/data/repository/SettingsRepositoryImplTest.kt
@@ -100,6 +100,7 @@ class SettingsRepositoryImplTest {
                 assertEquals(ServerConfig.DEFAULT_PORT, config.port)
                 assertEquals(BindingAddress.LOCALHOST, config.bindingAddress)
                 assertFalse(config.autoStartOnBoot)
+                assertTrue(config.toolCallIndicatorEnabled)
                 assertFalse(config.httpsEnabled)
                 assertEquals(CertificateSource.AUTO_GENERATED, config.certificateSource)
                 assertEquals(ServerConfig.DEFAULT_CERTIFICATE_HOSTNAME, config.certificateHostname)
@@ -280,6 +281,27 @@ class SettingsRepositoryImplTest {
                 val config = repository.getServerConfig()
 
                 assertFalse(config.autoStartOnBoot)
+            }
+    }
+
+    @Nested
+    @DisplayName("updateToolCallIndicatorEnabled")
+    inner class UpdateToolCallIndicatorEnabled {
+        @Test
+        fun `disables tool call indicator`() =
+            testScope.runTest {
+                repository.updateToolCallIndicatorEnabled(false)
+
+                assertFalse(repository.getServerConfig().toolCallIndicatorEnabled)
+            }
+
+        @Test
+        fun `enables tool call indicator`() =
+            testScope.runTest {
+                repository.updateToolCallIndicatorEnabled(false)
+                repository.updateToolCallIndicatorEnabled(true)
+
+                assertTrue(repository.getServerConfig().toolCallIndicatorEnabled)
             }
     }
 

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/LoggedToolHandlerTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/LoggedToolHandlerTest.kt
@@ -33,6 +33,10 @@ class LoggedToolHandlerTest {
         override fun onToolCallFinished(toolName: String) {
             events += "finished:$toolName"
         }
+
+        override fun setEnabled(enabled: Boolean) {
+            events += "enabled:$enabled"
+        }
     }
 
     @Test
@@ -108,6 +112,21 @@ class LoggedToolHandlerTest {
         indicator.onToolCallFinished("tap")
         assertEquals(
             listOf("started:tap", "started:swipe", "started:tap", "finished:tap"),
+            delegate.events,
+        )
+    }
+
+    @Test
+    fun `set enabled is serialized with tool transitions`() {
+        val delegate = RecordingToolCallIndicator()
+        val indicator = ReferenceCountedToolCallIndicator(delegate)
+
+        indicator.onToolCallStarted("tap")
+        indicator.setEnabled(false)
+        indicator.onToolCallFinished("tap")
+
+        assertEquals(
+            listOf("started:tap", "enabled:false", "finished:tap"),
             delegate.events,
         )
     }

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/LoggedToolHandlerTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/LoggedToolHandlerTest.kt
@@ -23,6 +23,18 @@ import org.junit.jupiter.api.Test
 class LoggedToolHandlerTest {
     private val request = mockk<CallToolRequest>()
 
+    private class RecordingToolCallIndicator : ToolCallIndicator {
+        val events = mutableListOf<String>()
+
+        override fun onToolCallStarted(toolName: String) {
+            events += "started:$toolName"
+        }
+
+        override fun onToolCallFinished(toolName: String) {
+            events += "finished:$toolName"
+        }
+    }
+
     @Test
     fun `success logs empty message with duration`() =
         runTest {
@@ -39,6 +51,49 @@ class LoggedToolHandlerTest {
             assertEquals("tap", entry.toolName)
             assertTrue((entry.durationMs ?: -1L) >= 0L)
         }
+
+    @Test
+    fun `tool invocation shows and hides the visual indicator`() =
+        runTest {
+            val indicator = RecordingToolCallIndicator()
+            val handler =
+                loggedToolHandler(RecordingServerLogRepository(), "tap", indicator) {
+                    assertEquals(listOf("started:tap"), indicator.events)
+                    CallToolResult(content = listOf(TextContent(text = "ok")))
+                }
+
+            handler(request)
+
+            assertEquals(listOf("started:tap", "finished:tap"), indicator.events)
+        }
+
+    @Test
+    fun `thrown tool invocation still hides the visual indicator`() =
+        runTest {
+            val indicator = RecordingToolCallIndicator()
+            val handler =
+                loggedToolHandler(RecordingServerLogRepository(), "tap", indicator) {
+                    throw McpToolException.InvalidParams("boom")
+                }
+
+            runCatching { handler(request) }
+
+            assertEquals(listOf("started:tap", "finished:tap"), indicator.events)
+        }
+
+    @Test
+    fun `overlapping calls keep the visual indicator visible until the last call finishes`() {
+        val delegate = RecordingToolCallIndicator()
+        val indicator = ReferenceCountedToolCallIndicator(delegate)
+
+        indicator.onToolCallStarted("tap")
+        indicator.onToolCallStarted("swipe")
+        indicator.onToolCallFinished("tap")
+        assertEquals(listOf("started:tap", "started:swipe"), delegate.events)
+
+        indicator.onToolCallFinished("swipe")
+        assertEquals(listOf("started:tap", "started:swipe", "finished:swipe"), delegate.events)
+    }
 
     @Test
     fun `isError result logs the constant failed marker`() =

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/LoggedToolHandlerTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/LoggedToolHandlerTest.kt
@@ -96,6 +96,47 @@ class LoggedToolHandlerTest {
     }
 
     @Test
+    fun `finishing newest overlapping call restores the previous tool name`() {
+        val delegate = RecordingToolCallIndicator()
+        val indicator = ReferenceCountedToolCallIndicator(delegate)
+
+        indicator.onToolCallStarted("tap")
+        indicator.onToolCallStarted("swipe")
+        indicator.onToolCallFinished("swipe")
+
+        assertEquals(listOf("started:tap", "started:swipe", "started:tap"), delegate.events)
+        indicator.onToolCallFinished("tap")
+        assertEquals(
+            listOf("started:tap", "started:swipe", "started:tap", "finished:tap"),
+            delegate.events,
+        )
+    }
+
+    @Test
+    fun `indicator failures never change tool execution or logging`() =
+        runTest {
+            val recorder = RecordingServerLogRepository()
+            var executed = false
+            val throwingIndicator =
+                object : ToolCallIndicator {
+                    override fun onToolCallStarted(toolName: String) = error("start failed")
+
+                    override fun onToolCallFinished(toolName: String) = error("finish failed")
+                }
+            val handler =
+                loggedToolHandler(recorder, "tap", throwingIndicator) {
+                    executed = true
+                    CallToolResult(content = listOf(TextContent(text = "ok")))
+                }
+
+            val result = handler(request)
+
+            assertTrue(executed)
+            assertTrue(result.isError != true)
+            assertEquals("tap", recorder.ofType(ServerLogEntry.Type.TOOL_CALL).single().toolName)
+        }
+
+    @Test
     fun `isError result logs the constant failed marker`() =
         runTest {
             val recorder = RecordingServerLogRepository()

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/ToolCallIndicatorFormattingTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/ToolCallIndicatorFormattingTest.kt
@@ -1,0 +1,12 @@
+package com.danielealbano.androidremotecontrolmcp.services.accessibility
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ToolCallIndicatorFormattingTest {
+    @Test
+    fun `formats MCP tool names for display`() {
+        assertEquals("Get screen state", formatToolName("get_screen_state"))
+        assertEquals("Tap", formatToolName("tap"))
+    }
+}


### PR DESCRIPTION
## Summary

- show a small touch-through accessibility overlay while an MCP tool is executing
- display only the static tool name; never expose arguments, results, or device content
- keep the indicator correct across overlapping calls and restore the previous active tool name
- isolate all indicator and WindowManager failures so UI feedback can never alter tool execution

The banner uses `TYPE_ACCESSIBILITY_OVERLAY`, so it needs no `SYSTEM_ALERT_WINDOW` permission and appears as `MCP controlling · <tool>` near the top of the screen.

## Tests

- `./gradlew :app:testFossDebugUnitTest --tests '*LoggedToolHandlerTest' --tests '*ToolCallIndicatorFormattingTest'`
- `./gradlew ktlintCheck --no-daemon`
- `./gradlew :app:assembleFossDebug`

All passed locally with JDK 17. The FOSS debug APK was built successfully.

## Privacy and safety

- no tool parameters or responses are shown
- overlay is non-touchable and non-focusable
- overlay failures are best-effort and cannot block, replace, or mask tool results
- overlap transitions are serialized

## Scope

This PR adds the visible activity indicator only. It does not add a user preference or alter tool permissions.
