### PR TITLE
fix: match short-form component names in accessibility/notification permission checks

### DIFF
--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/utils/PermissionUtils.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/utils/PermissionUtils.kt
@@ -155,8 +155,13 @@ object PermissionUtils {
 
     /**
      * Returns `true` when [flattenedComponent] (a single `package/class` entry) resolves
-     * to [expectedPackage] and [expectedClass], expanding the leading-dot short form the
-     * same way [android.content.ComponentName.unflattenFromString] does.
+     * to [expectedPackage] and [expectedClass].
+     *
+     * The separator validation and leading-dot expansion mirror
+     * [android.content.ComponentName.unflattenFromString]: an entry with no `/`, or with
+     * an empty class part, is rejected; a class part beginning with `.` is prefixed with
+     * its own package part. An empty package part is parsed like AOSP but can never equal
+     * [expectedPackage] (`context.packageName` is never empty), so such entries never match.
      */
     private fun componentMatches(
         flattenedComponent: String,
@@ -164,7 +169,7 @@ object PermissionUtils {
         expectedClass: String,
     ): Boolean {
         val separatorIndex = flattenedComponent.indexOf(COMPONENT_SEPARATOR)
-        if (separatorIndex <= 0 || separatorIndex >= flattenedComponent.length - 1) {
+        if (separatorIndex < 0 || separatorIndex >= flattenedComponent.length - 1) {
             return false
         }
 

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/utils/PermissionUtils.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/utils/PermissionUtils.kt
@@ -12,6 +12,8 @@ import androidx.core.content.ContextCompat
  */
 object PermissionUtils {
     private const val ENABLED_SERVICES_SEPARATOR = ':'
+    private const val COMPONENT_SEPARATOR = '/'
+    private const val SHORT_FORM_CLASS_PREFIX = '.'
 
     /**
      * Checks whether a specific accessibility service is currently enabled.
@@ -27,18 +29,13 @@ object PermissionUtils {
         context: Context,
         serviceClass: Class<*>,
     ): Boolean {
-        val expectedComponentName =
-            "${context.packageName}/${serviceClass.canonicalName}"
-
         val enabledServices =
             Settings.Secure.getString(
                 context.contentResolver,
                 Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES,
             ) ?: return false
 
-        return enabledServices
-            .split(ENABLED_SERVICES_SEPARATOR)
-            .any { it.equals(expectedComponentName, ignoreCase = true) }
+        return isServiceListed(enabledServices, context.packageName, serviceClass)
     }
 
     /**
@@ -117,18 +114,70 @@ object PermissionUtils {
         context: Context,
         serviceClass: Class<*>,
     ): Boolean {
-        val expectedComponentName =
-            "${context.packageName}/${serviceClass.canonicalName}"
-
         val enabledListeners =
             Settings.Secure.getString(
                 context.contentResolver,
                 "enabled_notification_listeners",
             ) ?: return false
 
-        return enabledListeners
+        return isServiceListed(enabledListeners, context.packageName, serviceClass)
+    }
+
+    /**
+     * Checks whether [serviceClass] appears in a colon-separated list of flattened
+     * component names ([Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES] or
+     * `enabled_notification_listeners`).
+     *
+     * Android stores component names in either the fully-qualified form
+     * (`package/package.path.ServiceClass`) or the leading-dot short form
+     * (`package/.path.ServiceClass`), expanding the short form against the package
+     * internally. This matcher mirrors `ComponentName.unflattenFromString`: a class
+     * part beginning with `.` is resolved against its own package part before the
+     * comparison, so both encodings of the same component match. Malformed entries
+     * (missing separator, empty package, or empty class) never match.
+     *
+     * @param enabledEntries Raw colon-separated setting value.
+     * @param expectedPackage The package the service belongs to (`context.packageName`).
+     * @param serviceClass The service class to look for.
+     * @return `true` if any entry resolves to [expectedPackage] + [serviceClass], `false` otherwise.
+     */
+    private fun isServiceListed(
+        enabledEntries: String,
+        expectedPackage: String,
+        serviceClass: Class<*>,
+    ): Boolean {
+        val expectedClass = serviceClass.name
+
+        return enabledEntries
             .split(ENABLED_SERVICES_SEPARATOR)
-            .any { it.equals(expectedComponentName, ignoreCase = true) }
+            .any { entry -> componentMatches(entry, expectedPackage, expectedClass) }
+    }
+
+    /**
+     * Returns `true` when [flattenedComponent] (a single `package/class` entry) resolves
+     * to [expectedPackage] and [expectedClass], expanding the leading-dot short form the
+     * same way [android.content.ComponentName.unflattenFromString] does.
+     */
+    private fun componentMatches(
+        flattenedComponent: String,
+        expectedPackage: String,
+        expectedClass: String,
+    ): Boolean {
+        val separatorIndex = flattenedComponent.indexOf(COMPONENT_SEPARATOR)
+        if (separatorIndex <= 0 || separatorIndex >= flattenedComponent.length - 1) {
+            return false
+        }
+
+        val packagePart = flattenedComponent.substring(0, separatorIndex)
+        val classPart = flattenedComponent.substring(separatorIndex + 1)
+        val resolvedClass =
+            if (classPart[0] == SHORT_FORM_CLASS_PREFIX) {
+                packagePart + classPart
+            } else {
+                classPart
+            }
+
+        return packagePart == expectedPackage && resolvedClass == expectedClass
     }
 
     /**

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/utils/PermissionUtils.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/utils/PermissionUtils.kt
@@ -133,8 +133,9 @@ object PermissionUtils {
      * (`package/.path.ServiceClass`), expanding the short form against the package
      * internally. This matcher mirrors `ComponentName.unflattenFromString`: a class
      * part beginning with `.` is resolved against its own package part before the
-     * comparison, so both encodings of the same component match. Malformed entries
-     * (missing separator, empty package, or empty class) never match.
+     * comparison, so both encodings of the same component match. Entries with no
+     * separator or an empty class part are rejected; an entry with an empty package
+     * part is parsed but can never equal a non-empty package, so none of these match.
      *
      * @param enabledEntries Raw colon-separated setting value.
      * @param expectedPackage The package the service belongs to (`context.packageName`).

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/utils/PermissionUtilsTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/utils/PermissionUtilsTest.kt
@@ -6,6 +6,8 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.provider.Settings
 import androidx.core.content.ContextCompat
+import com.danielealbano.androidremotecontrolmcp.services.accessibility.McpAccessibilityService
+import com.danielealbano.androidremotecontrolmcp.services.notifications.McpNotificationListenerService
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -51,9 +53,7 @@ class PermissionUtilsTest {
             assertTrue(
                 PermissionUtils.isAccessibilityServiceEnabled(
                     mockContext,
-                    Class.forName(
-                        "com.danielealbano.androidremotecontrolmcp.services.accessibility.McpAccessibilityService",
-                    ),
+                    McpAccessibilityService::class.java,
                 ),
             )
         }
@@ -90,9 +90,7 @@ class PermissionUtilsTest {
             assertTrue(
                 PermissionUtils.isAccessibilityServiceEnabled(
                     mockContext,
-                    Class.forName(
-                        "com.danielealbano.androidremotecontrolmcp.services.accessibility.McpAccessibilityService",
-                    ),
+                    McpAccessibilityService::class.java,
                 ),
             )
         }
@@ -108,9 +106,7 @@ class PermissionUtilsTest {
             assertTrue(
                 PermissionUtils.isAccessibilityServiceEnabled(
                     mockContext,
-                    Class.forName(
-                        "com.danielealbano.androidremotecontrolmcp.services.accessibility.McpAccessibilityService",
-                    ),
+                    McpAccessibilityService::class.java,
                 ),
             )
         }
@@ -124,9 +120,7 @@ class PermissionUtilsTest {
             assertFalse(
                 PermissionUtils.isAccessibilityServiceEnabled(
                     mockContext,
-                    Class.forName(
-                        "com.danielealbano.androidremotecontrolmcp.services.accessibility.McpAccessibilityService",
-                    ),
+                    McpAccessibilityService::class.java,
                 ),
             )
         }
@@ -140,9 +134,7 @@ class PermissionUtilsTest {
             assertFalse(
                 PermissionUtils.isAccessibilityServiceEnabled(
                     mockContext,
-                    Class.forName(
-                        "com.danielealbano.androidremotecontrolmcp.services.accessibility.McpAccessibilityService",
-                    ),
+                    McpAccessibilityService::class.java,
                 ),
             )
         }
@@ -156,9 +148,7 @@ class PermissionUtilsTest {
             assertFalse(
                 PermissionUtils.isAccessibilityServiceEnabled(
                     mockContext,
-                    Class.forName(
-                        "com.danielealbano.androidremotecontrolmcp.services.accessibility.McpAccessibilityService",
-                    ),
+                    McpAccessibilityService::class.java,
                 ),
             )
         }
@@ -172,9 +162,22 @@ class PermissionUtilsTest {
             assertFalse(
                 PermissionUtils.isAccessibilityServiceEnabled(
                     mockContext,
-                    Class.forName(
-                        "com.danielealbano.androidremotecontrolmcp.services.accessibility.McpAccessibilityService",
-                    ),
+                    McpAccessibilityService::class.java,
+                ),
+            )
+        }
+
+        @Test
+        fun `returns false when the class name casing differs`() {
+            every {
+                Settings.Secure.getString(mockContentResolver, Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES)
+            } returns "com.danielealbano.androidremotecontrolmcp/" +
+                "com.danielealbano.androidremotecontrolmcp.services.accessibility.MCPAccessibilityService"
+
+            assertFalse(
+                PermissionUtils.isAccessibilityServiceEnabled(
+                    mockContext,
+                    McpAccessibilityService::class.java,
                 ),
             )
         }
@@ -189,9 +192,7 @@ class PermissionUtilsTest {
             assertFalse(
                 PermissionUtils.isAccessibilityServiceEnabled(
                     mockContext,
-                    Class.forName(
-                        "com.danielealbano.androidremotecontrolmcp.services.accessibility.McpAccessibilityService",
-                    ),
+                    McpAccessibilityService::class.java,
                 ),
             )
         }
@@ -206,9 +207,7 @@ class PermissionUtilsTest {
             assertFalse(
                 PermissionUtils.isAccessibilityServiceEnabled(
                     mockContext,
-                    Class.forName(
-                        "com.danielealbano.androidremotecontrolmcp.services.accessibility.McpAccessibilityService",
-                    ),
+                    McpAccessibilityService::class.java,
                 ),
             )
         }
@@ -222,9 +221,7 @@ class PermissionUtilsTest {
             assertFalse(
                 PermissionUtils.isAccessibilityServiceEnabled(
                     mockContext,
-                    Class.forName(
-                        "com.danielealbano.androidremotecontrolmcp.services.accessibility.McpAccessibilityService",
-                    ),
+                    McpAccessibilityService::class.java,
                 ),
             )
         }
@@ -239,9 +236,7 @@ class PermissionUtilsTest {
             assertTrue(
                 PermissionUtils.isAccessibilityServiceEnabled(
                     mockContext,
-                    Class.forName(
-                        "com.danielealbano.androidremotecontrolmcp.services.accessibility.McpAccessibilityService",
-                    ),
+                    McpAccessibilityService::class.java,
                 ),
             )
         }
@@ -313,13 +308,11 @@ class PermissionUtilsTest {
                 Settings.Secure.getString(mockContentResolver, "enabled_notification_listeners")
             } returns serviceName
 
-            val serviceClass =
-                Class.forName(
-                    "com.danielealbano.androidremotecontrolmcp" +
-                        ".services.notifications.McpNotificationListenerService",
-                )
             assertTrue(
-                PermissionUtils.isNotificationListenerEnabled(mockContext, serviceClass),
+                PermissionUtils.isNotificationListenerEnabled(
+                    mockContext,
+                    McpNotificationListenerService::class.java,
+                ),
             )
         }
 
@@ -330,13 +323,11 @@ class PermissionUtilsTest {
             } returns "com.danielealbano.androidremotecontrolmcp/" +
                 ".services.notifications.McpNotificationListenerService"
 
-            val serviceClass =
-                Class.forName(
-                    "com.danielealbano.androidremotecontrolmcp" +
-                        ".services.notifications.McpNotificationListenerService",
-                )
             assertTrue(
-                PermissionUtils.isNotificationListenerEnabled(mockContext, serviceClass),
+                PermissionUtils.isNotificationListenerEnabled(
+                    mockContext,
+                    McpNotificationListenerService::class.java,
+                ),
             )
         }
 
@@ -350,13 +341,26 @@ class PermissionUtilsTest {
                 "com.danielealbano.androidremotecontrolmcp/" +
                 ".services.notifications.McpNotificationListenerService"
 
-            val serviceClass =
-                Class.forName(
-                    "com.danielealbano.androidremotecontrolmcp" +
-                        ".services.notifications.McpNotificationListenerService",
-                )
             assertTrue(
-                PermissionUtils.isNotificationListenerEnabled(mockContext, serviceClass),
+                PermissionUtils.isNotificationListenerEnabled(
+                    mockContext,
+                    McpNotificationListenerService::class.java,
+                ),
+            )
+        }
+
+        @Test
+        fun `returns false when the class name casing differs`() {
+            every {
+                Settings.Secure.getString(mockContentResolver, "enabled_notification_listeners")
+            } returns "com.danielealbano.androidremotecontrolmcp/" +
+                "com.danielealbano.androidremotecontrolmcp.services.notifications.MCPNotificationListenerService"
+
+            assertFalse(
+                PermissionUtils.isNotificationListenerEnabled(
+                    mockContext,
+                    McpNotificationListenerService::class.java,
+                ),
             )
         }
 

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/utils/PermissionUtilsTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/utils/PermissionUtilsTest.kt
@@ -79,6 +79,57 @@ class PermissionUtilsTest {
                 PermissionUtils.isAccessibilityServiceEnabled(mockContext, Any::class.java),
             )
         }
+
+        @Test
+        fun `returns true when service is enabled via short-form component name`() {
+            every {
+                Settings.Secure.getString(mockContentResolver, Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES)
+            } returns "com.danielealbano.androidremotecontrolmcp/" +
+                ".services.accessibility.McpAccessibilityService"
+
+            assertTrue(
+                PermissionUtils.isAccessibilityServiceEnabled(
+                    mockContext,
+                    Class.forName(
+                        "com.danielealbano.androidremotecontrolmcp.services.accessibility.McpAccessibilityService",
+                    ),
+                ),
+            )
+        }
+
+        @Test
+        fun `returns true when short-form service is among multiple entries`() {
+            every {
+                Settings.Secure.getString(mockContentResolver, Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES)
+            } returns "com.other.package/com.other.Service:" +
+                "com.danielealbano.androidremotecontrolmcp/" +
+                ".services.accessibility.McpAccessibilityService"
+
+            assertTrue(
+                PermissionUtils.isAccessibilityServiceEnabled(
+                    mockContext,
+                    Class.forName(
+                        "com.danielealbano.androidremotecontrolmcp.services.accessibility.McpAccessibilityService",
+                    ),
+                ),
+            )
+        }
+
+        @Test
+        fun `returns false for malformed entry without component separator`() {
+            every {
+                Settings.Secure.getString(mockContentResolver, Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES)
+            } returns "com.danielealbano.androidremotecontrolmcp.services.accessibility.McpAccessibilityService"
+
+            assertFalse(
+                PermissionUtils.isAccessibilityServiceEnabled(
+                    mockContext,
+                    Class.forName(
+                        "com.danielealbano.androidremotecontrolmcp.services.accessibility.McpAccessibilityService",
+                    ),
+                ),
+            )
+        }
     }
 
     @Nested
@@ -146,6 +197,23 @@ class PermissionUtilsTest {
             every {
                 Settings.Secure.getString(mockContentResolver, "enabled_notification_listeners")
             } returns serviceName
+
+            val serviceClass =
+                Class.forName(
+                    "com.danielealbano.androidremotecontrolmcp" +
+                        ".services.notifications.McpNotificationListenerService",
+                )
+            assertTrue(
+                PermissionUtils.isNotificationListenerEnabled(mockContext, serviceClass),
+            )
+        }
+
+        @Test
+        fun `returns true when service is enabled via short-form component name`() {
+            every {
+                Settings.Secure.getString(mockContentResolver, "enabled_notification_listeners")
+            } returns "com.danielealbano.androidremotecontrolmcp/" +
+                ".services.notifications.McpNotificationListenerService"
 
             val serviceClass =
                 Class.forName(

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/utils/PermissionUtilsTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/utils/PermissionUtilsTest.kt
@@ -341,24 +341,6 @@ class PermissionUtilsTest {
         }
 
         @Test
-        fun `returns true when short-form service is among multiple entries`() {
-            every {
-                Settings.Secure.getString(mockContentResolver, "enabled_notification_listeners")
-            } returns "com.other.package/com.other.Service:" +
-                "com.danielealbano.androidremotecontrolmcp/" +
-                ".services.notifications.McpNotificationListenerService"
-
-            val serviceClass =
-                Class.forName(
-                    "com.danielealbano.androidremotecontrolmcp" +
-                        ".services.notifications.McpNotificationListenerService",
-                )
-            assertTrue(
-                PermissionUtils.isNotificationListenerEnabled(mockContext, serviceClass),
-            )
-        }
-
-        @Test
         fun `returns true when short-form service follows a non-matching and an empty entry`() {
             // The non-matching entry and the empty entry precede the match, so `any`
             // must evaluate both (including componentMatches("")) before matching.

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/utils/PermissionUtilsTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/utils/PermissionUtilsTest.kt
@@ -130,6 +130,71 @@ class PermissionUtilsTest {
                 ),
             )
         }
+
+        @Test
+        fun `returns false for entry with empty class part`() {
+            every {
+                Settings.Secure.getString(mockContentResolver, Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES)
+            } returns "com.danielealbano.androidremotecontrolmcp/"
+
+            assertFalse(
+                PermissionUtils.isAccessibilityServiceEnabled(
+                    mockContext,
+                    Class.forName(
+                        "com.danielealbano.androidremotecontrolmcp.services.accessibility.McpAccessibilityService",
+                    ),
+                ),
+            )
+        }
+
+        @Test
+        fun `returns false for entry with empty package part`() {
+            every {
+                Settings.Secure.getString(mockContentResolver, Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES)
+            } returns "/com.danielealbano.androidremotecontrolmcp.services.accessibility.McpAccessibilityService"
+
+            assertFalse(
+                PermissionUtils.isAccessibilityServiceEnabled(
+                    mockContext,
+                    Class.forName(
+                        "com.danielealbano.androidremotecontrolmcp.services.accessibility.McpAccessibilityService",
+                    ),
+                ),
+            )
+        }
+
+        @Test
+        fun `returns false when short-form resolves to a different class in the same package`() {
+            every {
+                Settings.Secure.getString(mockContentResolver, Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES)
+            } returns "com.danielealbano.androidremotecontrolmcp/.services.accessibility.OtherService"
+
+            assertFalse(
+                PermissionUtils.isAccessibilityServiceEnabled(
+                    mockContext,
+                    Class.forName(
+                        "com.danielealbano.androidremotecontrolmcp.services.accessibility.McpAccessibilityService",
+                    ),
+                ),
+            )
+        }
+
+        @Test
+        fun `returns true when short-form service follows an empty leading entry`() {
+            every {
+                Settings.Secure.getString(mockContentResolver, Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES)
+            } returns ":com.danielealbano.androidremotecontrolmcp/" +
+                ".services.accessibility.McpAccessibilityService"
+
+            assertTrue(
+                PermissionUtils.isAccessibilityServiceEnabled(
+                    mockContext,
+                    Class.forName(
+                        "com.danielealbano.androidremotecontrolmcp.services.accessibility.McpAccessibilityService",
+                    ),
+                ),
+            )
+        }
     }
 
     @Nested
@@ -214,6 +279,41 @@ class PermissionUtilsTest {
                 Settings.Secure.getString(mockContentResolver, "enabled_notification_listeners")
             } returns "com.danielealbano.androidremotecontrolmcp/" +
                 ".services.notifications.McpNotificationListenerService"
+
+            val serviceClass =
+                Class.forName(
+                    "com.danielealbano.androidremotecontrolmcp" +
+                        ".services.notifications.McpNotificationListenerService",
+                )
+            assertTrue(
+                PermissionUtils.isNotificationListenerEnabled(mockContext, serviceClass),
+            )
+        }
+
+        @Test
+        fun `returns true when short-form service is among multiple entries`() {
+            every {
+                Settings.Secure.getString(mockContentResolver, "enabled_notification_listeners")
+            } returns "com.other.package/com.other.Service:" +
+                "com.danielealbano.androidremotecontrolmcp/" +
+                ".services.notifications.McpNotificationListenerService"
+
+            val serviceClass =
+                Class.forName(
+                    "com.danielealbano.androidremotecontrolmcp" +
+                        ".services.notifications.McpNotificationListenerService",
+                )
+            assertTrue(
+                PermissionUtils.isNotificationListenerEnabled(mockContext, serviceClass),
+            )
+        }
+
+        @Test
+        fun `returns true when short-form service precedes a trailing empty entry`() {
+            every {
+                Settings.Secure.getString(mockContentResolver, "enabled_notification_listeners")
+            } returns "com.danielealbano.androidremotecontrolmcp/" +
+                ".services.notifications.McpNotificationListenerService:"
 
             val serviceClass =
                 Class.forName(

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/utils/PermissionUtilsTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/utils/PermissionUtilsTest.kt
@@ -180,6 +180,56 @@ class PermissionUtilsTest {
         }
 
         @Test
+        fun `returns false for entry with a duplicated component separator`() {
+            every {
+                Settings.Secure.getString(mockContentResolver, Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES)
+            } returns "com.danielealbano.androidremotecontrolmcp//" +
+                "services.accessibility.McpAccessibilityService"
+
+            assertFalse(
+                PermissionUtils.isAccessibilityServiceEnabled(
+                    mockContext,
+                    Class.forName(
+                        "com.danielealbano.androidremotecontrolmcp.services.accessibility.McpAccessibilityService",
+                    ),
+                ),
+            )
+        }
+
+        @Test
+        fun `returns false for entry with a component separator inside the class part`() {
+            every {
+                Settings.Secure.getString(mockContentResolver, Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES)
+            } returns "com.danielealbano.androidremotecontrolmcp/" +
+                "services/accessibility.McpAccessibilityService"
+
+            assertFalse(
+                PermissionUtils.isAccessibilityServiceEnabled(
+                    mockContext,
+                    Class.forName(
+                        "com.danielealbano.androidremotecontrolmcp.services.accessibility.McpAccessibilityService",
+                    ),
+                ),
+            )
+        }
+
+        @Test
+        fun `returns false for short-form entry with an empty package part`() {
+            every {
+                Settings.Secure.getString(mockContentResolver, Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES)
+            } returns "/.services.accessibility.McpAccessibilityService"
+
+            assertFalse(
+                PermissionUtils.isAccessibilityServiceEnabled(
+                    mockContext,
+                    Class.forName(
+                        "com.danielealbano.androidremotecontrolmcp.services.accessibility.McpAccessibilityService",
+                    ),
+                ),
+            )
+        }
+
+        @Test
         fun `returns true when short-form service follows an empty leading entry`() {
             every {
                 Settings.Secure.getString(mockContentResolver, Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES)
@@ -309,11 +359,14 @@ class PermissionUtilsTest {
         }
 
         @Test
-        fun `returns true when short-form service precedes a trailing empty entry`() {
+        fun `returns true when short-form service follows a non-matching and an empty entry`() {
+            // The non-matching entry and the empty entry precede the match, so `any`
+            // must evaluate both (including componentMatches("")) before matching.
             every {
                 Settings.Secure.getString(mockContentResolver, "enabled_notification_listeners")
-            } returns "com.danielealbano.androidremotecontrolmcp/" +
-                ".services.notifications.McpNotificationListenerService:"
+            } returns "com.other.package/com.other.Service::" +
+                "com.danielealbano.androidremotecontrolmcp/" +
+                ".services.notifications.McpNotificationListenerService"
 
             val serviceClass =
                 Class.forName(


### PR DESCRIPTION
## Summary

Fixes #142.

`PermissionUtils.isAccessibilityServiceEnabled()` and `isNotificationListenerEnabled()` compared each entry of the `Settings.Secure` enabled-services string against the fully-qualified `package/canonicalName` spelling only, using `equals(ignoreCase = true)`. Android also accepts and internally expands the leading-dot **short form** (`package/.path.ServiceClass`), so a service granted that way (adb, CI, emulators, test harnesses) binds and runs while the app reports it as **disabled**. That same boolean gates the **Start** and **Event Channel** buttons plus the permission warning card, so the effect is functional, not cosmetic. The system Settings UI always writes the fully-qualified form, which is why shipped paths never hit it.

## Changes

- Replace the string comparison with a matcher that resolves each `:`-separated entry the way `android.content.ComponentName.unflattenFromString` does — a class part beginning with `.` is prefixed with its own package part — so both encodings of the same component match. Both checks share one `componentMatches` helper via `isServiceListed`.
- The matcher is pure-JVM string parsing rather than the real `android.content.ComponentName`. The unit tests run against the mockable `android.jar` with `unitTests.isReturnDefaultValues = true`, under which the framework `ComponentName` methods return stubbed defaults; pure parsing keeps the exact runtime code path unit-testable.
- The separator validation mirrors AOSP exactly (`sep < 0 || (sep+1) >= length`); malformed entries (missing separator, empty class) never match, and an empty package part is parsed like AOSP but can never equal the non-empty `context.packageName`.
- Two deliberate, AOSP-faithful behavior changes: use `serviceClass.name` (`getName()`) instead of `canonicalName` (identical for these top-level services, correct for nested classes), and case-sensitive comparison instead of `ignoreCase = true` (the framework stores exact package/class casing).

## Testing

- Added regression tests to `PermissionUtilsTest` — **20 cases total (14 accessibility, 6 notification listener)** — covering: short-form spelling (standalone, among multiple entries, after a leading empty entry, after a non-matching + embedded empty entry), same-package short-form resolving to a different class, class-name casing mismatch (locks the case-sensitive contract), and malformed entries (no separator, empty class part, empty package part, duplicated separator, separator inside the class part). Test service arguments use compile-checked `::class.java` references rather than duplicated `Class.forName` string literals.
- Verified through multiple rounds of independent, blind adversarial code review to a genuine zero-findings PASS.
- `make lint` clean (ktlint + detekt); full `:app:testFossDebugUnitTest` suite passes.

## Checklist

- [x] All tests pass (`make test-unit`)
- [x] Lint passes (`make lint`)
- [x] Build succeeds (CI: Build Release - FOSS / GMS green)
- [x] CI validated (all checks green on head commit)