### PR TITLE
feat: add package parameter to send_intent

### DIFF
--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/IntentTools.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/IntentTools.kt
@@ -45,19 +45,19 @@ class SendIntentHandler
             val action =
                 McpToolUtils
                     .optionalString(arguments, "action", "")
-                    .ifEmpty { null }
+                    .ifBlank { null }
             val data =
                 McpToolUtils
                     .optionalString(arguments, "data", "")
-                    .ifEmpty { null }
+                    .ifBlank { null }
             val component =
                 McpToolUtils
                     .optionalString(arguments, "component", "")
-                    .ifEmpty { null }
+                    .ifBlank { null }
             val packageName =
                 McpToolUtils
                     .optionalString(arguments, "package", "")
-                    .ifEmpty { null }
+                    .ifBlank { null }
 
             val extras = extractExtras(arguments)
             val extrasTypes = extractExtrasTypes(arguments)
@@ -194,22 +194,6 @@ class SendIntentHandler
                 required = listOf("type"),
             )
 
-        private fun JsonObjectBuilder.putStringProperty(
-            name: String,
-            description: String,
-        ) = putJsonObject(name) {
-            put("type", "string")
-            put("description", description)
-        }
-
-        private fun JsonObjectBuilder.putObjectProperty(
-            name: String,
-            description: String,
-        ) = putJsonObject(name) {
-            put("type", "object")
-            put("description", description)
-        }
-
         companion object {
             const val TOOL_NAME = "send_intent"
             private const val TAG = "MCP:SendIntentTool"
@@ -238,6 +222,22 @@ class SendIntentHandler
                     "FLAG_ACTIVITY_NEW_TASK auto-added for activity type."
         }
     }
+
+private fun JsonObjectBuilder.putStringProperty(
+    name: String,
+    description: String,
+) = putJsonObject(name) {
+    put("type", "string")
+    put("description", description)
+}
+
+private fun JsonObjectBuilder.putObjectProperty(
+    name: String,
+    description: String,
+) = putJsonObject(name) {
+    put("type", "object")
+    put("description", description)
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // open_uri

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/IntentTools.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/IntentTools.kt
@@ -10,6 +10,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonObjectBuilder
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -53,6 +54,10 @@ class SendIntentHandler
                 McpToolUtils
                     .optionalString(arguments, "component", "")
                     .ifEmpty { null }
+            val packageName =
+                McpToolUtils
+                    .optionalString(arguments, "package", "")
+                    .ifEmpty { null }
 
             val extras = extractExtras(arguments)
             val extrasTypes = extractExtrasTypes(arguments)
@@ -61,7 +66,7 @@ class SendIntentHandler
             Logger.d(TAG, "Executing send_intent: type=$type, action=$action")
             val result =
                 intentDispatcher.sendIntent(
-                    SendIntentRequest(type, action, data, component, extras, extrasTypes, flags),
+                    SendIntentRequest(type, action, data, component, packageName, extras, extrasTypes, flags),
                 )
             val actionLabel = action ?: "(none)"
             return McpToolUtils.handleActionResult(
@@ -173,55 +178,37 @@ class SendIntentHandler
             ToolSchema(
                 properties =
                     buildJsonObject {
-                        putJsonObject("type") {
-                            put("type", "string")
-                            put("description", "The intent delivery type: 'activity', 'broadcast', or 'service'")
-                        }
-                        putJsonObject("action") {
-                            put("type", "string")
-                            put("description", "The intent action (e.g., 'android.intent.action.VIEW')")
-                        }
-                        putJsonObject("data") {
-                            put("type", "string")
-                            put("description", "Data URI for the intent")
-                        }
-                        putJsonObject("component") {
-                            put("type", "string")
-                            put(
-                                "description",
-                                "Target component as 'package/class' " +
-                                    "(e.g., 'com.example.app/com.example.app.MyActivity')",
-                            )
-                        }
-                        putJsonObject("extras") {
-                            put("type", "object")
-                            put(
-                                "description",
-                                "Key-value extras. Values auto-typed: " +
-                                    "string\u2192String, integer\u2192Int/Long, decimal\u2192Double, " +
-                                    "boolean\u2192Boolean, string array\u2192StringArrayList",
-                            )
-                        }
-                        putJsonObject("extras_types") {
-                            put("type", "object")
-                            put(
-                                "description",
-                                "Type overrides for extras keys. " +
-                                    "Supported: 'string', 'int', 'long', 'float', 'double', 'boolean'",
-                            )
-                        }
+                        putStringProperty("type", "The intent delivery type: 'activity', 'broadcast', or 'service'")
+                        putStringProperty("action", "The intent action (e.g., 'android.intent.action.VIEW')")
+                        putStringProperty("data", "Data URI for the intent")
+                        putStringProperty("component", COMPONENT_DESCRIPTION)
+                        putStringProperty("package", PACKAGE_DESCRIPTION)
+                        putObjectProperty("extras", EXTRAS_DESCRIPTION)
+                        putObjectProperty("extras_types", EXTRAS_TYPES_DESCRIPTION)
                         putJsonObject("flags") {
                             put("type", "array")
                             putJsonObject("items") { put("type", "string") }
-                            put(
-                                "description",
-                                "Intent flag names (e.g., 'FLAG_ACTIVITY_CLEAR_TOP'). " +
-                                    "FLAG_ACTIVITY_NEW_TASK auto-added for activity type.",
-                            )
+                            put("description", FLAGS_DESCRIPTION)
                         }
                     },
                 required = listOf("type"),
             )
+
+        private fun JsonObjectBuilder.putStringProperty(
+            name: String,
+            description: String,
+        ) = putJsonObject(name) {
+            put("type", "string")
+            put("description", description)
+        }
+
+        private fun JsonObjectBuilder.putObjectProperty(
+            name: String,
+            description: String,
+        ) = putJsonObject(name) {
+            put("type", "object")
+            put("description", description)
+        }
 
         companion object {
             const val TOOL_NAME = "send_intent"
@@ -231,6 +218,24 @@ class SendIntentHandler
                 "Send an Android intent. Supports starting activities, " +
                     "sending broadcasts, and starting services. Use for opening specific " +
                     "settings pages, triggering app-specific actions, or sending broadcasts."
+            private const val COMPONENT_DESCRIPTION =
+                "Target component as 'package/class' " +
+                    "(e.g., 'com.example.app/com.example.app.MyActivity')"
+            private const val PACKAGE_DESCRIPTION =
+                "Target package scoping delivery (maps to Intent.setPackage(), " +
+                    "equivalent to 'am ... -p'). For broadcasts this reaches a " +
+                    "manifest-declared receiver in that app without needing the " +
+                    "receiver's class name (e.g., 'com.example.app')"
+            private const val EXTRAS_DESCRIPTION =
+                "Key-value extras. Values auto-typed: " +
+                    "string→String, integer→Int/Long, decimal→Double, " +
+                    "boolean→Boolean, string array→StringArrayList"
+            private const val EXTRAS_TYPES_DESCRIPTION =
+                "Type overrides for extras keys. " +
+                    "Supported: 'string', 'int', 'long', 'float', 'double', 'boolean'"
+            private const val FLAGS_DESCRIPTION =
+                "Intent flag names (e.g., 'FLAG_ACTIVITY_CLEAR_TOP'). " +
+                    "FLAG_ACTIVITY_NEW_TASK auto-added for activity type."
         }
     }
 

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/intents/IntentDispatcher.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/intents/IntentDispatcher.kt
@@ -7,6 +7,9 @@ package com.danielealbano.androidremotecontrolmcp.services.intents
  * @property action Intent action string (e.g., `"android.intent.action.VIEW"`).
  * @property data Data URI for the intent.
  * @property component Target component as `"package/class"`.
+ * @property packageName Target package scoping delivery via `Intent.setPackage()`
+ *   (equivalent to `am ... -p`). For broadcasts this reaches a manifest-declared
+ *   receiver in that app without needing the receiver's class name.
  * @property extras Key-value extras with auto type inference.
  * @property extrasTypes Explicit type overrides for extras keys.
  * @property flags Intent flag names resolved via reflection.
@@ -16,6 +19,7 @@ data class SendIntentRequest(
     val action: String? = null,
     val data: String? = null,
     val component: String? = null,
+    val packageName: String? = null,
     val extras: Map<String, Any?>? = null,
     val extrasTypes: Map<String, String>? = null,
     val flags: List<String>? = null,

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/intents/IntentDispatcherImpl.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/intents/IntentDispatcherImpl.kt
@@ -67,6 +67,10 @@ class IntentDispatcherImpl
                 intent.component = parseComponent(request.component).getOrThrow()
             }
 
+            if (request.packageName != null) {
+                intent.setPackage(request.packageName)
+            }
+
             applyFlags(intent, request)
             request.extras?.forEach { (key, value) ->
                 putExtraWithInference(intent, key, value, request.extrasTypes?.get(key))

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/IntentToolsIntegrationTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/IntentToolsIntegrationTest.kt
@@ -120,6 +120,82 @@ class IntentToolsIntegrationTest {
         }
 
     @Test
+    fun `send_intent broadcast with package passes package through`() =
+        runTest {
+            val deps = McpIntegrationTestHelper.createMockDependencies()
+            coEvery {
+                deps.intentDispatcher.sendIntent(
+                    SendIntentRequest(
+                        type = "broadcast",
+                        action = "com.example.ACTION",
+                        packageName = "com.example.app",
+                    ),
+                )
+            } returns Result.success(Unit)
+
+            McpIntegrationTestHelper.withTestApplication(deps) { client, _ ->
+                val result =
+                    client.callTool(
+                        name = "android_send_intent",
+                        arguments =
+                            mapOf(
+                                "type" to "broadcast",
+                                "action" to "com.example.ACTION",
+                                "package" to "com.example.app",
+                            ),
+                    )
+                assertNotEquals(true, result.isError)
+                coVerify {
+                    deps.intentDispatcher.sendIntent(
+                        SendIntentRequest(
+                            type = "broadcast",
+                            action = "com.example.ACTION",
+                            packageName = "com.example.app",
+                        ),
+                    )
+                }
+            }
+        }
+
+    @Test
+    fun `send_intent with package and component passes both through`() =
+        runTest {
+            val deps = McpIntegrationTestHelper.createMockDependencies()
+            coEvery {
+                deps.intentDispatcher.sendIntent(
+                    SendIntentRequest(
+                        type = "activity",
+                        component = "com.example.app/com.example.app.MyActivity",
+                        packageName = "com.example.app",
+                    ),
+                )
+            } returns Result.success(Unit)
+
+            McpIntegrationTestHelper.withTestApplication(deps) { client, _ ->
+                val result =
+                    client.callTool(
+                        name = "android_send_intent",
+                        arguments =
+                            mapOf(
+                                "type" to "activity",
+                                "component" to "com.example.app/com.example.app.MyActivity",
+                                "package" to "com.example.app",
+                            ),
+                    )
+                assertNotEquals(true, result.isError)
+                coVerify {
+                    deps.intentDispatcher.sendIntent(
+                        SendIntentRequest(
+                            type = "activity",
+                            component = "com.example.app/com.example.app.MyActivity",
+                            packageName = "com.example.app",
+                        ),
+                    )
+                }
+            }
+        }
+
+    @Test
     fun `send_intent with flags passes flags through`() =
         runTest {
             val deps = McpIntegrationTestHelper.createMockDependencies()

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/IntentToolsTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/IntentToolsTest.kt
@@ -291,6 +291,39 @@ class IntentToolsTest {
             }
 
         @Test
+        fun `send_intent with package passes packageName to dispatcher`() =
+            runTest {
+                coEvery {
+                    mockIntentDispatcher.sendIntent(
+                        SendIntentRequest(
+                            type = "broadcast",
+                            action = "com.example.ACTION",
+                            packageName = "com.example.app",
+                        ),
+                    )
+                } returns Result.success(Unit)
+
+                val params =
+                    buildJsonObject {
+                        put("type", "broadcast")
+                        put("action", "com.example.ACTION")
+                        put("package", "com.example.app")
+                    }
+                val result = handler.execute(params)
+
+                assertEquals(1, result.content.size)
+                coVerify {
+                    mockIntentDispatcher.sendIntent(
+                        SendIntentRequest(
+                            type = "broadcast",
+                            action = "com.example.ACTION",
+                            packageName = "com.example.app",
+                        ),
+                    )
+                }
+            }
+
+        @Test
         fun `send_intent dispatcher failure returns error result`() =
             runTest {
                 coEvery {
@@ -361,6 +394,7 @@ class IntentToolsTest {
                             action = "android.intent.action.VIEW",
                             data = "https://example.com",
                             component = "com.example/com.example.Activity",
+                            packageName = "com.example",
                             extras = mapOf("id" to 42L, "name" to "test"),
                             extrasTypes = mapOf("id" to "long"),
                             flags = listOf("FLAG_ACTIVITY_CLEAR_TOP"),
@@ -374,6 +408,7 @@ class IntentToolsTest {
                         put("action", "android.intent.action.VIEW")
                         put("data", "https://example.com")
                         put("component", "com.example/com.example.Activity")
+                        put("package", "com.example")
                         putJsonObject("extras") {
                             put("id", 42)
                             put("name", "test")
@@ -400,6 +435,7 @@ class IntentToolsTest {
                             action = "android.intent.action.VIEW",
                             data = "https://example.com",
                             component = "com.example/com.example.Activity",
+                            packageName = "com.example",
                             extras = mapOf("id" to 42L, "name" to "test"),
                             extrasTypes = mapOf("id" to "long"),
                             flags = listOf("FLAG_ACTIVITY_CLEAR_TOP"),

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/IntentToolsTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/mcp/tools/IntentToolsTest.kt
@@ -324,6 +324,29 @@ class IntentToolsTest {
             }
 
         @Test
+        fun `send_intent with blank string params normalizes them to null`() =
+            runTest {
+                coEvery {
+                    mockIntentDispatcher.sendIntent(SendIntentRequest(type = "activity"))
+                } returns Result.success(Unit)
+
+                val params =
+                    buildJsonObject {
+                        put("type", "activity")
+                        put("action", "   ")
+                        put("data", "")
+                        put("component", " ")
+                        put("package", "  ")
+                    }
+                val result = handler.execute(params)
+
+                assertEquals(1, result.content.size)
+                coVerify {
+                    mockIntentDispatcher.sendIntent(SendIntentRequest(type = "activity"))
+                }
+            }
+
+        @Test
         fun `send_intent dispatcher failure returns error result`() =
             runTest {
                 coEvery {

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/intents/IntentDispatcherImplTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/intents/IntentDispatcherImplTest.kt
@@ -554,6 +554,62 @@ class IntentDispatcherImplTest {
             }
     }
 
+    // ─── sendIntent package tests ────────────────────────────────────────
+
+    @Nested
+    @DisplayName("sendIntent package")
+    inner class SendIntentPackage {
+        @Test
+        fun `sendIntent with package scopes intent via setPackage`() =
+            runTest {
+                val result =
+                    dispatcher.sendIntent(
+                        SendIntentRequest(
+                            type = "broadcast",
+                            action = "com.example.ACTION",
+                            packageName = "com.example.app",
+                        ),
+                    )
+
+                assertTrue(result.isSuccess)
+                verify(exactly = 1) { anyConstructed<Intent>().setPackage("com.example.app") }
+            }
+
+        @Test
+        fun `sendIntent without package does not call setPackage`() =
+            runTest {
+                val result =
+                    dispatcher.sendIntent(
+                        SendIntentRequest(
+                            type = "broadcast",
+                            action = "com.example.ACTION",
+                        ),
+                    )
+
+                assertTrue(result.isSuccess)
+                verify(exactly = 0) { anyConstructed<Intent>().setPackage(any()) }
+            }
+
+        @Test
+        fun `sendIntent with package and component applies both`() =
+            runTest {
+                every { anyConstructed<Intent>().setComponent(any()) } answers { self as Intent }
+
+                val result =
+                    dispatcher.sendIntent(
+                        SendIntentRequest(
+                            type = "activity",
+                            component = "com.example.app/com.example.app.MyActivity",
+                            packageName = "com.example.app",
+                        ),
+                    )
+
+                assertTrue(result.isSuccess)
+                verify(exactly = 1) { anyConstructed<Intent>().setComponent(any()) }
+                verify(exactly = 1) { anyConstructed<Intent>().setPackage("com.example.app") }
+            }
+    }
+
     // ─── sendIntent exception handling tests ─────────────────────────────
 
     @Nested

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -2835,6 +2835,22 @@ Sends an Android intent. Supports starting activities, sending broadcasts, and s
 }
 ```
 
+**Example Response**:
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "Intent sent successfully: type=activity, action=android.settings.WIFI_SETTINGS"
+      }
+    ]
+  }
+}
+```
+
 **Example Request** (broadcast scoped to a specific app's manifest receiver):
 ```json
 {
@@ -2861,7 +2877,7 @@ Sends an Android intent. Supports starting activities, sending broadcasts, and s
     "content": [
       {
         "type": "text",
-        "text": "Intent sent successfully: type=activity, action=android.settings.WIFI_SETTINGS"
+        "text": "Intent sent successfully: type=broadcast, action=com.example.app.ACTION_REFRESH"
       }
     ]
   }

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -2776,6 +2776,7 @@ Sends an Android intent. Supports starting activities, sending broadcasts, and s
 | `action` | string | No | Intent action (e.g., `"android.intent.action.VIEW"`) |
 | `data` | string | No | Data URI for the intent |
 | `component` | string | No | Target component as `"package/class"` (e.g., `"com.example.app/com.example.app.MyActivity"`) |
+| `package` | string | No | Target package scoping delivery (maps to `Intent.setPackage()`, equivalent to `am ... -p`). For broadcasts this reaches a manifest-declared receiver in that app without needing the receiver's class name (e.g., `"com.example.app"`) |
 | `extras` | object | No | Key-value extras. Values auto-typed: string→String, integer→Int/Long, decimal→Double, boolean→Boolean, string array→StringArrayList |
 | `extras_types` | object | No | Type overrides for extras keys. Supported: `"string"`, `"int"`, `"long"`, `"float"`, `"double"`, `"boolean"` |
 | `flags` | array | No | Intent flag names (e.g., `"FLAG_ACTIVITY_CLEAR_TOP"`). `FLAG_ACTIVITY_NEW_TASK` auto-added for activity type |
@@ -2789,6 +2790,7 @@ Sends an Android intent. Supports starting activities, sending broadcasts, and s
     "action": { "type": "string", "description": "The intent action (e.g., 'android.intent.action.VIEW')" },
     "data": { "type": "string", "description": "Data URI for the intent" },
     "component": { "type": "string", "description": "Target component as 'package/class'" },
+    "package": { "type": "string", "description": "Target package scoping delivery (maps to Intent.setPackage())" },
     "extras": { "type": "object", "description": "Key-value extras with auto type inference" },
     "extras_types": { "type": "object", "description": "Type overrides for extras keys" },
     "flags": { "type": "array", "items": { "type": "string" }, "description": "Intent flag names" }
@@ -2828,6 +2830,23 @@ Sends an Android intent. Supports starting activities, sending broadcasts, and s
       "extras": { "referrer": "mcp", "count": 42 },
       "extras_types": { "count": "long" },
       "flags": ["FLAG_ACTIVITY_CLEAR_TOP"]
+    }
+  }
+}
+```
+
+**Example Request** (broadcast scoped to a specific app's manifest receiver):
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "android_send_intent",
+    "arguments": {
+      "type": "broadcast",
+      "action": "com.example.app.ACTION_REFRESH",
+      "package": "com.example.app"
     }
   }
 }

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -324,7 +324,7 @@ The MCP server exposes 55 tools across 13 categories. For full JSON-RPC schemas,
 
 | Tool | Description | Required Params | Optional Params |
 |------|-------------|-----------------|-----------------|
-| `android_send_intent` | Send an Android intent (activity, broadcast, or service) | `type` (string: activity/broadcast/service) | `action` (string), `data` (string), `component` (string, package/class), `extras` (object), `extras_types` (object), `flags` (string[]) |
+| `android_send_intent` | Send an Android intent (activity, broadcast, or service) | `type` (string: activity/broadcast/service) | `action` (string), `data` (string), `component` (string, package/class), `package` (string, target package / setPackage), `extras` (object), `extras_types` (object), `flags` (string[]) |
 | `android_open_uri` | Open a URI using ACTION_VIEW | `uri` (string) | `package_name` (string), `mime_type` (string) |
 
 **Extras type inference**: String values → `String`, integers fitting Int range → `Int`, integers exceeding Int range → `Long`, decimals → `Double`, booleans → `Boolean`, string arrays → `StringArrayList`. Use `extras_types` to override (supported: `"string"`, `"int"`, `"long"`, `"float"`, `"double"`, `"boolean"`).


### PR DESCRIPTION
## Summary

Adds an optional `package` parameter to the `android_send_intent` MCP tool, mapping to `Intent.setPackage()` (the public-API equivalent of `am ... -p`).

Since API 26, an implicit broadcast is not delivered to a manifest-declared receiver. Previously the only ways to reach another app's receiver via `send_intent` were the `FLAG_RECEIVER_INCLUDE_BACKGROUND` hidden flag or supplying the receiver's fully-qualified, app-internal class name through `component` — both brittle and undocumented. Scoping the intent to a package with `setPackage()` reaches the manifest receiver using only the target's public package id.

Closes #144

## Changes

- `SendIntentRequest`: new optional `packageName` field (the MCP-facing JSON key is `package`; the Kotlin field is `packageName` because `package` is a reserved keyword).
- `IntentDispatcherImpl.buildIntent()`: applies `intent.setPackage(...)` when provided. When both `package` and `component` are supplied, both are applied.
- `SendIntentHandler`: parses the `package` argument and exposes it in the input schema. `buildInputSchema` was refactored to `putStringProperty`/`putObjectProperty` helpers (file-level) plus description constants — behavior-preserving.
- Input normalization: `action`, `data`, `component`, and `package` now use `.ifBlank { null }`, so whitespace-only values are treated as absent (a blank `package` no longer reaches `setPackage()` and silently scopes a broadcast to a non-existent app).
- Docs: `docs/MCP_TOOLS.md` parameter table, input schema, and a broadcast-scoped example with a matching response; `docs/PROJECT.md` intent-tools table updated with the new `package` param.

## Testing

- Dispatcher, handler, and integration coverage for: scoped-delivery, no-package (negative), `package`+`component` combined, and blank-string normalization to null.
- `make lint` passes (ktlint + detekt).
- Full unit + JVM integration suite passes (`make test-unit`).
- Adversarial code review completed: **zero findings** (CRITICAL/WARNING/INFO) after fixes.

## Checklist

- [x] All tests pass (`make test-unit`)
- [x] Lint passes (`make lint`)
- [x] Build succeeds — validated in CI (Build Release FOSS + GMS)
- [x] CI green (Lint, Unit & Integration, E2E, Build Release FOSS/GMS, CodeQL)
