### PR TITLE
build: force httpcore5 to 5.4.3 (CVE-2026-54399)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,6 +72,10 @@ allprojects {
                     useVersion("4.5.14")
                     because("CVE-2020-13956; androidLintTool/UTP pull vulnerable httpclient 4.5.6 (tooling only)")
                 }
+                group == "org.apache.httpcomponents.core5" && name in setOf("httpcore5", "httpcore5-h2") -> {
+                    useVersion("5.4.3")
+                    because("CVE-2026-54399; ktor-server-test-host -> ktor-client-apache5 -> httpclient5 pulls vulnerable httpcore5 5.3.6 (test only)")
+                }
                 group == "org.apache.commons" && name == "commons-lang3" -> {
                     useVersion("3.18.0")
                     because("CVE-2025-48924; androidLintTool/UTP pull vulnerable commons-lang3 3.16.0 (tooling only)")


### PR DESCRIPTION
## Summary

Resolves Dependabot alert #99 (HIGH). `httpcore5:5.3.6` is a **test-only** transitive vulnerable to [CVE-2026-54399](https://github.com/danielealbano/android-remote-control-mcp/security/dependabot/99) — an HTTP/1 header-parsing memory-exhaustion DoS in Apache HttpComponents Core.

**Dependency path:** `io.ktor:ktor-server-test-host` → `io.ktor:ktor-client-apache5` → `org.apache.httpcomponents.client5:httpclient5:5.5.1` → `httpcore5` / `httpcore5-h2:5.3.6`

It appears only in `*UnitTest*` compile/runtime/lint classpaths — it never ships in the APK and never runs at app runtime.

## Change

Force `httpcore5` and `httpcore5-h2` to the patched `5.4.3` in the existing `allprojects { resolutionStrategy.eachDependency }` block in `build.gradle.kts`, matching the established test/tooling-transitive force pattern already used for bouncycastle, httpclient, commons-lang3 and netty.

## Verification

- Resolution confirmed: `httpcore5` / `httpcore5-h2` now resolve `5.3.6 -> 5.4.3` in the test classpaths.
- `make test-unit test-integration` → BUILD SUCCESSFUL.
- `make lint` (ktlint + detekt) → BUILD SUCCESSFUL.