### PR TITLE
test: register sharing tools in integration helper to match production

### DIFF
--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/AuthIntegrationTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/AuthIntegrationTest.kt
@@ -106,6 +106,6 @@ class AuthIntegrationTest {
         }
 
     companion object {
-        private const val EXPECTED_TOOL_COUNT = 55
+        private const val EXPECTED_TOOL_COUNT = 57
     }
 }

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/McpIntegrationTestHelper.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/McpIntegrationTestHelper.kt
@@ -4,6 +4,7 @@ import android.view.accessibility.AccessibilityNodeInfo
 import android.view.accessibility.AccessibilityWindowInfo
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import com.danielealbano.androidremotecontrolmcp.data.model.PrivacyModeConfig
+import com.danielealbano.androidremotecontrolmcp.data.model.ServerConfig
 import com.danielealbano.androidremotecontrolmcp.data.model.ServerLogEntry
 import com.danielealbano.androidremotecontrolmcp.data.model.ToolPermissionsConfig
 import com.danielealbano.androidremotecontrolmcp.data.repository.OAuthClientRepository
@@ -32,6 +33,7 @@ import com.danielealbano.androidremotecontrolmcp.mcp.tools.registerLocationTools
 import com.danielealbano.androidremotecontrolmcp.mcp.tools.registerNodeActionTools
 import com.danielealbano.androidremotecontrolmcp.mcp.tools.registerNotificationTools
 import com.danielealbano.androidremotecontrolmcp.mcp.tools.registerScreenIntrospectionTools
+import com.danielealbano.androidremotecontrolmcp.mcp.tools.registerSharingTools
 import com.danielealbano.androidremotecontrolmcp.mcp.tools.registerSystemActionTools
 import com.danielealbano.androidremotecontrolmcp.mcp.tools.registerTextInputTools
 import com.danielealbano.androidremotecontrolmcp.mcp.tools.registerTouchActionTools
@@ -77,6 +79,7 @@ import com.danielealbano.androidremotecontrolmcp.services.screencapture.Screensh
 import com.danielealbano.androidremotecontrolmcp.services.screencapture.ScreenshotEncoder
 import com.danielealbano.androidremotecontrolmcp.services.screencapture.ScreenshotRedactor
 import com.danielealbano.androidremotecontrolmcp.services.sharing.EphemeralFileLinkService
+import com.danielealbano.androidremotecontrolmcp.services.sharing.SharedContentInbox
 import com.danielealbano.androidremotecontrolmcp.services.storage.FileOperationProvider
 import com.danielealbano.androidremotecontrolmcp.services.storage.StorageLocationProvider
 import com.danielealbano.androidremotecontrolmcp.testutil.RecordingServerLogRepository
@@ -108,6 +111,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
  */
 object McpIntegrationTestHelper {
     const val TEST_BEARER_TOKEN = "test-integration-token"
+    const val TEST_BASE_URL = "http://localhost:8080"
 
     /**
      * Configures multi-window mocking on the given [MockDependencies].
@@ -213,6 +217,8 @@ object McpIntegrationTestHelper {
             intentDispatcher = mockk(relaxed = true),
             notificationProvider = mockk(relaxed = true),
             locationProvider = mockk(relaxed = true),
+            sharedContentInbox = mockk(relaxed = true),
+            ephemeralFileLinkService = mockk(relaxed = true),
             privacyStatusFlow = statusFlow,
             privacyConfigFlow = configFlow,
             privacyModeManager = manager,
@@ -339,6 +345,17 @@ object McpIntegrationTestHelper {
             perms,
         )
         registerLocationTools(registrar, deps.locationProvider, deps.privacyToolGate, toolNamePrefix, perms)
+        registerSharingTools(
+            registrar,
+            deps.sharedContentInbox,
+            deps.ephemeralFileLinkService,
+            deps.fileOperationProvider,
+            ServerConfig.DEFAULT_FILE_SIZE_LIMIT_MB,
+            { TEST_BASE_URL },
+            deps.privacyToolGate,
+            toolNamePrefix,
+            perms,
+        )
     }
 
     /**
@@ -591,6 +608,8 @@ data class MockDependencies(
     val intentDispatcher: IntentDispatcher,
     val notificationProvider: NotificationProvider,
     val locationProvider: LocationProvider,
+    val sharedContentInbox: SharedContentInbox,
+    val ephemeralFileLinkService: EphemeralFileLinkService,
     val privacyStatusFlow: MutableStateFlow<PrivacyModeStatus>,
     val privacyConfigFlow: MutableStateFlow<PrivacyModeConfig>,
     val privacyModeManager: PrivacyModeManager,

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/McpProtocolIntegrationTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/McpProtocolIntegrationTest.kt
@@ -35,7 +35,7 @@ class McpProtocolIntegrationTest {
         }
 
     @Test
-    fun `listTools returns all 55 registered tools`() =
+    fun `listTools returns all 57 registered tools`() =
         runTest {
             McpIntegrationTestHelper.withTestApplication { client, _ ->
                 val result = client.listTools()
@@ -135,7 +135,7 @@ class McpProtocolIntegrationTest {
         }
 
     companion object {
-        private const val EXPECTED_TOOL_COUNT = 55
+        private const val EXPECTED_TOOL_COUNT = 57
 
         private val EXPECTED_TOOL_NAMES =
             setOf(
@@ -188,6 +188,13 @@ class McpProtocolIntegrationTest {
                 "android_open_app",
                 "android_list_apps",
                 "android_close_app",
+                // Camera tools
+                "android_list_cameras",
+                "android_list_camera_photo_resolutions",
+                "android_list_camera_video_resolutions",
+                "android_take_camera_photo",
+                "android_save_camera_photo",
+                "android_save_camera_video",
                 // Intent tools
                 "android_send_intent",
                 "android_open_uri",
@@ -200,6 +207,9 @@ class McpProtocolIntegrationTest {
                 "android_notification_reply",
                 // Location tools
                 "android_get_location",
+                // Sharing tools
+                "android_get_shared_content",
+                "android_share_file_via_web",
             )
     }
 }

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/ToolPermissionsIntegrationTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/ToolPermissionsIntegrationTest.kt
@@ -320,6 +320,8 @@ class ToolPermissionsIntegrationTest {
                 "notification_reply",
                 "get_screen_state",
                 "get_location",
+                "get_shared_content",
+                "share_file_via_web",
             )
     }
 }


### PR DESCRIPTION
## Summary

`McpIntegrationTestHelper` registered only 13 of the 14 production tool categories — the sharing tools (`android_get_shared_content`, `android_share_file_via_web`) were missing — so the protocol-level integration tests asserted **55** tools while the production server (`McpServerService.registerAllTools`) actually exposes **57**. The helper now mirrors the production registration exactly.

## Changes

- **McpIntegrationTestHelper.kt**
  - Added `sharedContentInbox` and `ephemeralFileLinkService` (relaxed mocks) to `MockDependencies`
  - `registerNonAccessibilityTools` now calls `registerSharingTools` last, mirroring the production registration order, using `ServerConfig.DEFAULT_FILE_SIZE_LIMIT_MB` and a new `TEST_BASE_URL` constant
- **McpProtocolIntegrationTest.kt**
  - `EXPECTED_TOOL_COUNT` 55 → 57; test renamed accordingly
  - `EXPECTED_TOOL_NAMES` is now exhaustive (57 names): added the 6 camera tools that were previously missing from the set, plus the 2 sharing tools
- **AuthIntegrationTest.kt**: `EXPECTED_TOOL_COUNT` 55 → 57
- **ToolPermissionsIntegrationTest.kt**: added the 2 sharing tool names to `ALL_TOOL_NAMES` (57 entries) so the all-tools-disabled test still yields an empty list

`SharingIntegrationTest` keeps its dedicated setup (real inbox/link-service implementations plus the capability-URL route), which the shared helper cannot host.

## Verification

- `./gradlew ktlintCheck detekt` — clean
- The 4 affected test classes — pass
- Full `make test-unit` — pass (all unit + JVM integration tests)
- Adversarial code review — PASS, zero findings (counts, production mirroring, mock safety, and regression scan of every helper consumer independently verified)