### PR TITLE
ci(release): wait for both matrix Build Release checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,12 +34,14 @@ jobs:
           fi
 
       # ── 3. Wait for CI to pass on this commit (gates on existing CI results) ──
+      # The CI build-release job is a per-flavor matrix, so the checks are named
+      # "Build Release - GMS" and "Build Release - FOSS"; the regexp waits for both.
       - name: Wait for CI to pass
         uses: lewagon/wait-on-check-action@v1.8.1
         with:
           ref: ${{ github.sha }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          check-name: 'Build Release'
+          check-regexp: '^Build Release - (GMS|FOSS)$'
           wait-interval: 30
           allowed-conclusions: success
           running-workflow-name: 'Create Draft Release'


### PR DESCRIPTION
## Summary

The v1.11.0 tag push failed the Release workflow at the "Wait for CI to pass" step: PR #133 split the CI build-release job into a per-flavor matrix, renaming the checks to **Build Release - GMS** / **Build Release - FOSS**, but the release workflow still waited on the old exact name `Build Release`. The check no longer exists, so the wait action exited with "The requested check was never run against this ref" after its 60s discovery window (run 31736910793) — before anything was built or drafted.

## Changes

- `.github/workflows/release.yml`: replace `check-name: 'Build Release'` with `check-regexp: '^Build Release - (GMS|FOSS)$'`. The lewagon action waits for **every** check matching the regexp to complete with an allowed conclusion, so both flavors gate the release.

This is the only reference to the old check name in the workflow.

## After merge

The tag will be moved to the new main head so the tag-triggered run picks up the fixed workflow definition (tag-push runs use the workflow file at the tagged commit).