### PR TITLE
fix(deps): force httpclient5 to 5.6.3 (CVE-2026-64607)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,6 +76,10 @@ allprojects {
                     useVersion("5.4.3")
                     because("CVE-2026-54399; ktor-server-test-host -> ktor-client-apache5 -> httpclient5 pulls vulnerable httpcore5 5.3.6 (test only)")
                 }
+                group == "org.apache.httpcomponents.client5" && name == "httpclient5" -> {
+                    useVersion("5.6.3")
+                    because("CVE-2026-64607; ktor-server-test-host -> ktor-client-apache5 pulls vulnerable httpclient5 < 5.6.3 (test only; 5.6.3 depends on the already-forced httpcore5 5.4.3)")
+                }
                 group == "org.apache.commons" && name == "commons-lang3" -> {
                     useVersion("3.18.0")
                     because("CVE-2025-48924; androidLintTool/UTP pull vulnerable commons-lang3 3.16.0 (tooling only)")


### PR DESCRIPTION
## Summary

Closes Dependabot alert #101: `org.apache.httpcomponents.client5:httpclient5` < 5.6.3 is vulnerable to **CVE-2026-64607** (GHSA-hjcp-jmpx-g3qm, medium) — a connection leak on Content-Encoding decode errors that can exhaust the connection pool (DoS).

The vulnerable 5.5.1 arrives through the test-only chain `ktor-server-test-host → ktor-client-apache5 → httpclient5` — the exact chain already handled for httpcore5 in #148. Nothing ships in the APK.

## Changes

- `build.gradle.kts` (root, `allprojects` resolution strategy): force `httpclient5` → **5.6.3** (first patched release), alongside the existing httpcore5 5.4.3 force.

## Compatibility

httpclient5 **5.6.3 itself depends on httpcore5 5.4.3** (verified against its parent POM) — the exact version already forced for CVE-2026-54399 — so the two pins are mutually consistent.

## Verification

- `dependencyInsight` on `gmsDebugUnitTestRuntimeClasspath`: `httpclient5:5.5.1 → 5.6.3`, selected by the new rule, via the expected ktor chain
- `ktlintCheck` + `detekt` — clean
- `assembleGmsDebug` + `assembleFossDebug` — build successfully