### PR TITLE
Plan 61: Fix list_files path filtering and make the camera roll reachable (DCIM)

### DIFF
--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/data/model/BuiltinStorageLocation.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/data/model/BuiltinStorageLocation.kt
@@ -5,65 +5,133 @@ import android.provider.MediaStore
 import com.danielealbano.androidremotecontrolmcp.mcp.McpToolException
 
 /**
+ * A MediaStore collection backing (part of) a built-in storage location.
+ *
+ * @property readMediaPermission Runtime permission for "all files" access to this
+ *   collection's rows, or null if unavailable (owned files only).
+ * @property mimeTypePrefix MIME prefix accepted for writes routed to this collection
+ *   (e.g. "image/"), or null to accept any MIME type.
+ * @property typeLabel Human-readable plural label used in display names and error messages.
+ */
+class MediaCollection(
+    private val collectionUriProvider: () -> Uri,
+    val readMediaPermission: String?,
+    val mimeTypePrefix: String?,
+    val typeLabel: String,
+) {
+    /** MediaStore collection content URI for queries/inserts. Resolved lazily. */
+    val uri: Uri by lazy { collectionUriProvider() }
+}
+
+/**
  * Defines the built-in storage locations backed by MediaStore.
  *
  * These are always available without user setup (no SAF picker needed).
  * The app can write to these locations without any runtime permissions.
- * Reading non-owned files requires the corresponding [readMediaPermission].
+ * Reading non-owned files requires the corresponding per-collection
+ * [MediaCollection.readMediaPermission].
  *
- * The [collectionUri] is resolved lazily to avoid loading Android framework
- * classes during enum initialization (which would fail in JVM unit tests).
+ * Each location maps to one physical top-level directory and is backed by the
+ * MediaStore collections whose content can live there (e.g. `DCIM/` holds both
+ * images and videos). Collection URIs are resolved lazily to avoid loading
+ * Android framework classes during enum initialization (which would fail in
+ * JVM unit tests).
  *
  * @property locationId Stable identifier used in MCP tool calls.
- * @property displayNameOwned Display name when only owned files are visible.
- * @property displayNameAll Display name when all files are visible (READ_MEDIA_* granted).
+ * @property displayBaseName Base display name; access-level suffix is appended at runtime.
  * @property baseRelativePath The MediaStore RELATIVE_PATH prefix (e.g., "Download/").
- * @property readMediaPermission Runtime permission for "all files" access, or null if unavailable.
+ * @property collections Backing MediaStore collections, in read-resolution and
+ *   MIME-routing order.
  */
 enum class BuiltinStorageLocation(
     val locationId: String,
-    val displayNameOwned: String,
-    val displayNameAll: String,
-    private val collectionUriProvider: () -> Uri,
+    val displayBaseName: String,
     val baseRelativePath: String,
-    val readMediaPermission: String?,
+    val collections: List<MediaCollection>,
 ) {
     DOWNLOADS(
         locationId = "builtin:downloads",
-        displayNameOwned = "Downloads - Only owned files",
-        displayNameAll = "Downloads - Only owned files",
-        collectionUriProvider = { MediaStore.Downloads.EXTERNAL_CONTENT_URI },
+        displayBaseName = "Downloads",
         baseRelativePath = "Download/",
-        readMediaPermission = null,
+        collections =
+            listOf(
+                MediaCollection(
+                    collectionUriProvider = { MediaStore.Downloads.EXTERNAL_CONTENT_URI },
+                    readMediaPermission = null,
+                    mimeTypePrefix = null,
+                    typeLabel = "files",
+                ),
+            ),
     ),
     PICTURES(
         locationId = "builtin:pictures",
-        displayNameOwned = "Pictures - Only owned files",
-        displayNameAll = "Pictures - All files",
-        collectionUriProvider = { MediaStore.Images.Media.EXTERNAL_CONTENT_URI },
+        displayBaseName = "Pictures",
         baseRelativePath = "Pictures/",
-        readMediaPermission = android.Manifest.permission.READ_MEDIA_IMAGES,
+        collections =
+            listOf(
+                MediaCollection(
+                    collectionUriProvider = { MediaStore.Images.Media.EXTERNAL_CONTENT_URI },
+                    readMediaPermission = android.Manifest.permission.READ_MEDIA_IMAGES,
+                    mimeTypePrefix = "image/",
+                    typeLabel = "images",
+                ),
+                MediaCollection(
+                    collectionUriProvider = { MediaStore.Video.Media.EXTERNAL_CONTENT_URI },
+                    readMediaPermission = android.Manifest.permission.READ_MEDIA_VIDEO,
+                    mimeTypePrefix = "video/",
+                    typeLabel = "videos",
+                ),
+            ),
     ),
     MOVIES(
         locationId = "builtin:movies",
-        displayNameOwned = "Movies - Only owned files",
-        displayNameAll = "Movies - All files",
-        collectionUriProvider = { MediaStore.Video.Media.EXTERNAL_CONTENT_URI },
+        displayBaseName = "Movies",
         baseRelativePath = "Movies/",
-        readMediaPermission = android.Manifest.permission.READ_MEDIA_VIDEO,
+        collections =
+            listOf(
+                MediaCollection(
+                    collectionUriProvider = { MediaStore.Video.Media.EXTERNAL_CONTENT_URI },
+                    readMediaPermission = android.Manifest.permission.READ_MEDIA_VIDEO,
+                    mimeTypePrefix = "video/",
+                    typeLabel = "videos",
+                ),
+            ),
     ),
     MUSIC(
         locationId = "builtin:music",
-        displayNameOwned = "Music - Only owned files",
-        displayNameAll = "Music - All files",
-        collectionUriProvider = { MediaStore.Audio.Media.EXTERNAL_CONTENT_URI },
+        displayBaseName = "Music",
         baseRelativePath = "Music/",
-        readMediaPermission = android.Manifest.permission.READ_MEDIA_AUDIO,
+        collections =
+            listOf(
+                MediaCollection(
+                    collectionUriProvider = { MediaStore.Audio.Media.EXTERNAL_CONTENT_URI },
+                    readMediaPermission = android.Manifest.permission.READ_MEDIA_AUDIO,
+                    mimeTypePrefix = "audio/",
+                    typeLabel = "audio",
+                ),
+            ),
+    ),
+    DCIM(
+        locationId = "builtin:dcim",
+        displayBaseName = "Camera (DCIM)",
+        baseRelativePath = "DCIM/",
+        collections =
+            listOf(
+                MediaCollection(
+                    collectionUriProvider = { MediaStore.Images.Media.EXTERNAL_CONTENT_URI },
+                    readMediaPermission = android.Manifest.permission.READ_MEDIA_IMAGES,
+                    mimeTypePrefix = "image/",
+                    typeLabel = "images",
+                ),
+                MediaCollection(
+                    collectionUriProvider = { MediaStore.Video.Media.EXTERNAL_CONTENT_URI },
+                    readMediaPermission = android.Manifest.permission.READ_MEDIA_VIDEO,
+                    mimeTypePrefix = "video/",
+                    typeLabel = "videos",
+                ),
+            ),
     ),
     ;
-
-    /** MediaStore collection content URI for queries/inserts. Resolved lazily. */
-    val collectionUri: Uri by lazy { collectionUriProvider() }
 
     companion object {
         /** Prefix for all built-in location IDs. */

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/MediaStoreDownloader.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/MediaStoreDownloader.kt
@@ -18,7 +18,7 @@ import javax.net.ssl.HttpsURLConnection
 internal class MediaStoreDownloader(
     private val context: Context,
 ) {
-    @Suppress("LongMethod", "CyclomaticComplexMethod", "ThrowsCount", "NestedBlockDepth", "TooGenericExceptionCaught")
+    @Suppress("TooGenericExceptionCaught")
     fun downloadToPendingUri(
         insertUri: Uri,
         parsedUrl: URL,
@@ -26,63 +26,13 @@ internal class MediaStoreDownloader(
         config: ServerConfig,
         logContext: String,
     ): Long {
-        val timeoutMs = (config.downloadTimeoutSeconds * MILLIS_PER_SECOND).toInt()
-        val limitBytes = config.fileSizeLimitMb.toLong() * BYTES_PER_MB
         var connection: HttpURLConnection? = null
         try {
-            connection = parsedUrl.openConnection() as HttpURLConnection
-            connection.connectTimeout = timeoutMs
-            connection.readTimeout = timeoutMs
-            connection.instanceFollowRedirects = true
-
-            if (config.allowUnverifiedHttpsCerts && connection is HttpsURLConnection) {
-                SslUtils.configurePermissiveSsl(connection)
-            }
-
+            connection = prepareConnection(parsedUrl, config)
             connection.connect()
-
-            val responseCode = connection.responseCode
-            if (responseCode !in HTTP_SUCCESS_RANGE) {
-                throw McpToolException.ActionFailed(
-                    "Download failed with HTTP status $responseCode for URL: $url",
-                )
-            }
-
-            val contentLength = connection.contentLengthLong
-            if (contentLength > 0 && contentLength > limitBytes) {
-                throw McpToolException.ActionFailed(
-                    "Server reports file size of $contentLength bytes, exceeds limit of " +
-                        "${config.fileSizeLimitMb} MB.",
-                )
-            }
-
-            var totalBytesWritten = 0L
-            context.contentResolver.openOutputStream(insertUri, "wt")?.use { outputStream ->
-                connection.inputStream.use { inputStream ->
-                    val buffer = ByteArray(DOWNLOAD_BUFFER_SIZE)
-                    var bytesRead: Int
-                    while (inputStream.read(buffer).also { bytesRead = it } != -1) {
-                        totalBytesWritten += bytesRead
-                        if (totalBytesWritten > limitBytes) {
-                            throw McpToolException.ActionFailed(
-                                "Download exceeds the configured file size limit of " +
-                                    "${config.fileSizeLimitMb} MB.",
-                            )
-                        }
-                        outputStream.write(buffer, 0, bytesRead)
-                    }
-                }
-            } ?: throw McpToolException.ActionFailed(
-                "Failed to open download destination for writing",
-            )
-
-            // Clear IS_PENDING on success
-            val updateValues =
-                ContentValues().apply {
-                    put(MediaStore.MediaColumns.IS_PENDING, 0)
-                }
-            context.contentResolver.update(insertUri, updateValues, null, null)
-
+            validateResponse(connection, url, config)
+            val totalBytesWritten = streamToDestination(connection, insertUri, config)
+            markDownloadComplete(insertUri)
             Log.i(TAG, "Downloaded $totalBytesWritten bytes from $url to $logContext")
             return totalBytesWritten
         } catch (e: McpToolException) {
@@ -97,6 +47,83 @@ internal class MediaStoreDownloader(
         } finally {
             connection?.disconnect()
         }
+    }
+
+    /** Configures (but does not connect) so a failing connect() can still be disconnected. */
+    private fun prepareConnection(
+        parsedUrl: URL,
+        config: ServerConfig,
+    ): HttpURLConnection {
+        val timeoutMs = (config.downloadTimeoutSeconds * MILLIS_PER_SECOND).toInt()
+        val connection = parsedUrl.openConnection() as HttpURLConnection
+        connection.connectTimeout = timeoutMs
+        connection.readTimeout = timeoutMs
+        connection.instanceFollowRedirects = true
+
+        if (config.allowUnverifiedHttpsCerts && connection is HttpsURLConnection) {
+            SslUtils.configurePermissiveSsl(connection)
+        }
+
+        return connection
+    }
+
+    private fun validateResponse(
+        connection: HttpURLConnection,
+        url: String,
+        config: ServerConfig,
+    ) {
+        val responseCode = connection.responseCode
+        if (responseCode !in HTTP_SUCCESS_RANGE) {
+            throw McpToolException.ActionFailed(
+                "Download failed with HTTP status $responseCode for URL: $url",
+            )
+        }
+
+        val limitBytes = config.fileSizeLimitMb.toLong() * BYTES_PER_MB
+        val contentLength = connection.contentLengthLong
+        if (contentLength > 0 && contentLength > limitBytes) {
+            throw McpToolException.ActionFailed(
+                "Server reports file size of $contentLength bytes, exceeds limit of " +
+                    "${config.fileSizeLimitMb} MB.",
+            )
+        }
+    }
+
+    private fun streamToDestination(
+        connection: HttpURLConnection,
+        insertUri: Uri,
+        config: ServerConfig,
+    ): Long {
+        val limitBytes = config.fileSizeLimitMb.toLong() * BYTES_PER_MB
+        var totalBytesWritten = 0L
+        context.contentResolver.openOutputStream(insertUri, "wt")?.use { outputStream ->
+            connection.inputStream.use { inputStream ->
+                val buffer = ByteArray(DOWNLOAD_BUFFER_SIZE)
+                var bytesRead: Int
+                while (inputStream.read(buffer).also { bytesRead = it } != -1) {
+                    totalBytesWritten += bytesRead
+                    if (totalBytesWritten > limitBytes) {
+                        throw McpToolException.ActionFailed(
+                            "Download exceeds the configured file size limit of " +
+                                "${config.fileSizeLimitMb} MB.",
+                        )
+                    }
+                    outputStream.write(buffer, 0, bytesRead)
+                }
+            }
+        } ?: throw McpToolException.ActionFailed(
+            "Failed to open download destination for writing",
+        )
+        return totalBytesWritten
+    }
+
+    private fun markDownloadComplete(insertUri: Uri) {
+        // Clear IS_PENDING on success
+        val updateValues =
+            ContentValues().apply {
+                put(MediaStore.MediaColumns.IS_PENDING, 0)
+            }
+        context.contentResolver.update(insertUri, updateValues, null, null)
     }
 
     companion object {

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/MediaStoreDownloader.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/MediaStoreDownloader.kt
@@ -1,0 +1,109 @@
+package com.danielealbano.androidremotecontrolmcp.services.storage
+
+import android.content.ContentValues
+import android.content.Context
+import android.net.Uri
+import android.provider.MediaStore
+import android.util.Log
+import com.danielealbano.androidremotecontrolmcp.data.model.ServerConfig
+import com.danielealbano.androidremotecontrolmcp.mcp.McpToolException
+import java.net.HttpURLConnection
+import java.net.URL
+import javax.net.ssl.HttpsURLConnection
+
+/**
+ * Streams an HTTP(S) download into a pending MediaStore entry, clearing IS_PENDING on
+ * success and deleting the entry on any failure.
+ */
+internal class MediaStoreDownloader(
+    private val context: Context,
+) {
+    @Suppress("LongMethod", "CyclomaticComplexMethod", "ThrowsCount", "NestedBlockDepth", "TooGenericExceptionCaught")
+    fun downloadToPendingUri(
+        insertUri: Uri,
+        parsedUrl: URL,
+        url: String,
+        config: ServerConfig,
+        logContext: String,
+    ): Long {
+        val timeoutMs = (config.downloadTimeoutSeconds * MILLIS_PER_SECOND).toInt()
+        val limitBytes = config.fileSizeLimitMb.toLong() * BYTES_PER_MB
+        var connection: HttpURLConnection? = null
+        try {
+            connection = parsedUrl.openConnection() as HttpURLConnection
+            connection.connectTimeout = timeoutMs
+            connection.readTimeout = timeoutMs
+            connection.instanceFollowRedirects = true
+
+            if (config.allowUnverifiedHttpsCerts && connection is HttpsURLConnection) {
+                SslUtils.configurePermissiveSsl(connection)
+            }
+
+            connection.connect()
+
+            val responseCode = connection.responseCode
+            if (responseCode !in HTTP_SUCCESS_RANGE) {
+                throw McpToolException.ActionFailed(
+                    "Download failed with HTTP status $responseCode for URL: $url",
+                )
+            }
+
+            val contentLength = connection.contentLengthLong
+            if (contentLength > 0 && contentLength > limitBytes) {
+                throw McpToolException.ActionFailed(
+                    "Server reports file size of $contentLength bytes, exceeds limit of " +
+                        "${config.fileSizeLimitMb} MB.",
+                )
+            }
+
+            var totalBytesWritten = 0L
+            context.contentResolver.openOutputStream(insertUri, "wt")?.use { outputStream ->
+                connection.inputStream.use { inputStream ->
+                    val buffer = ByteArray(DOWNLOAD_BUFFER_SIZE)
+                    var bytesRead: Int
+                    while (inputStream.read(buffer).also { bytesRead = it } != -1) {
+                        totalBytesWritten += bytesRead
+                        if (totalBytesWritten > limitBytes) {
+                            throw McpToolException.ActionFailed(
+                                "Download exceeds the configured file size limit of " +
+                                    "${config.fileSizeLimitMb} MB.",
+                            )
+                        }
+                        outputStream.write(buffer, 0, bytesRead)
+                    }
+                }
+            } ?: throw McpToolException.ActionFailed(
+                "Failed to open download destination for writing",
+            )
+
+            // Clear IS_PENDING on success
+            val updateValues =
+                ContentValues().apply {
+                    put(MediaStore.MediaColumns.IS_PENDING, 0)
+                }
+            context.contentResolver.update(insertUri, updateValues, null, null)
+
+            Log.i(TAG, "Downloaded $totalBytesWritten bytes from $url to $logContext")
+            return totalBytesWritten
+        } catch (e: McpToolException) {
+            context.contentResolver.delete(insertUri, null, null)
+            throw e
+        } catch (e: Exception) {
+            context.contentResolver.delete(insertUri, null, null)
+            throw McpToolException.ActionFailed(
+                "Download failed: ${e.message ?: "Unknown error"}",
+                e,
+            )
+        } finally {
+            connection?.disconnect()
+        }
+    }
+
+    companion object {
+        private const val TAG = "MCP:MediaStoreDownload"
+        private const val BYTES_PER_MB = 1024L * 1024L
+        private const val MILLIS_PER_SECOND = 1000L
+        private const val DOWNLOAD_BUFFER_SIZE = 8192
+        private val HTTP_SUCCESS_RANGE = 200..299
+    }
+}

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/MediaStoreFileOperationsImpl.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/MediaStoreFileOperationsImpl.kt
@@ -17,9 +17,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.BufferedReader
 import java.io.InputStreamReader
-import java.net.HttpURLConnection
 import javax.inject.Inject
-import javax.net.ssl.HttpsURLConnection
 
 @Suppress("TooGenericExceptionCaught", "SwallowedException")
 class MediaStoreFileOperationsImpl
@@ -30,6 +28,8 @@ class MediaStoreFileOperationsImpl
         private val settingsRepository: SettingsRepository,
         private val permissionChecker: PermissionChecker,
     ) : MediaStoreFileOperations {
+        private val downloader = MediaStoreDownloader(context)
+
         // ─── listFiles ──────────────────────────────────────────────────────
 
         override suspend fun listFiles(
@@ -381,7 +381,6 @@ class MediaStoreFileOperationsImpl
 
         // ─── downloadFromUrl ────────────────────────────────────────────────
 
-        @Suppress("LongMethod", "CyclomaticComplexMethod", "ThrowsCount", "NestedBlockDepth")
         override suspend fun downloadFromUrl(
             locationId: String,
             path: String,
@@ -398,8 +397,6 @@ class MediaStoreFileOperationsImpl
                 val displayName = extractDisplayName(path)
                 val mimeType = MimeTypeUtils.guessMimeType(displayName)
                 val collection = selectCollectionForMimeType(builtin, mimeType)
-                val timeoutMs = (config.downloadTimeoutSeconds * MILLIS_PER_SECOND).toInt()
-                val limitBytes = config.fileSizeLimitMb.toLong() * BYTES_PER_MB
 
                 // Create MediaStore entry with IS_PENDING = 1
                 val values =
@@ -413,74 +410,7 @@ class MediaStoreFileOperationsImpl
                     context.contentResolver.insert(collection.uri, values)
                         ?: throw McpToolException.ActionFailed("Failed to create download destination: $path")
 
-                var connection: HttpURLConnection? = null
-                try {
-                    connection = parsedUrl.openConnection() as HttpURLConnection
-                    connection.connectTimeout = timeoutMs
-                    connection.readTimeout = timeoutMs
-                    connection.instanceFollowRedirects = true
-
-                    if (config.allowUnverifiedHttpsCerts && connection is HttpsURLConnection) {
-                        SslUtils.configurePermissiveSsl(connection)
-                    }
-
-                    connection.connect()
-
-                    val responseCode = connection.responseCode
-                    if (responseCode !in HTTP_SUCCESS_RANGE) {
-                        throw McpToolException.ActionFailed(
-                            "Download failed with HTTP status $responseCode for URL: $url",
-                        )
-                    }
-
-                    val contentLength = connection.contentLengthLong
-                    if (contentLength > 0 && contentLength > limitBytes) {
-                        throw McpToolException.ActionFailed(
-                            "Server reports file size of $contentLength bytes, exceeds limit of " +
-                                "${config.fileSizeLimitMb} MB.",
-                        )
-                    }
-
-                    var totalBytesWritten = 0L
-                    context.contentResolver.openOutputStream(insertUri, "wt")?.use { outputStream ->
-                        connection.inputStream.use { inputStream ->
-                            val buffer = ByteArray(DOWNLOAD_BUFFER_SIZE)
-                            var bytesRead: Int
-                            while (inputStream.read(buffer).also { bytesRead = it } != -1) {
-                                totalBytesWritten += bytesRead
-                                if (totalBytesWritten > limitBytes) {
-                                    throw McpToolException.ActionFailed(
-                                        "Download exceeds the configured file size limit of " +
-                                            "${config.fileSizeLimitMb} MB.",
-                                    )
-                                }
-                                outputStream.write(buffer, 0, bytesRead)
-                            }
-                        }
-                    } ?: throw McpToolException.ActionFailed(
-                        "Failed to open download destination for writing",
-                    )
-
-                    // Clear IS_PENDING on success
-                    val updateValues =
-                        ContentValues().apply {
-                            put(MediaStore.MediaColumns.IS_PENDING, 0)
-                        }
-                    context.contentResolver.update(insertUri, updateValues, null, null)
-
-                    Log.i(TAG, "Downloaded $totalBytesWritten bytes from $url to $locationId/$path")
-                    totalBytesWritten
-                } catch (e: McpToolException) {
-                    context.contentResolver.delete(insertUri, null, null)
-                    throw e
-                } catch (e: Exception) {
-                    context.contentResolver.delete(insertUri, null, null)
-                    throw McpToolException.ActionFailed(
-                        "Download failed: ${e.message ?: "Unknown error"}",
-                    )
-                } finally {
-                    connection?.disconnect()
-                }
+                downloader.downloadToPendingUri(insertUri, parsedUrl, url, config, "$locationId/$path")
             }
 
         // ─── deleteFile ─────────────────────────────────────────────────────
@@ -767,7 +697,5 @@ class MediaStoreFileOperationsImpl
             private const val TAG = "MCP:MediaStoreFileOps"
             private const val BYTES_PER_MB = 1024L * 1024L
             private const val MILLIS_PER_SECOND = 1000L
-            private const val DOWNLOAD_BUFFER_SIZE = 8192
-            private val HTTP_SUCCESS_RANGE = 200..299
         }
     }

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/MediaStoreFileOperationsImpl.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/MediaStoreFileOperationsImpl.kt
@@ -19,7 +19,7 @@ import java.io.BufferedReader
 import java.io.InputStreamReader
 import javax.inject.Inject
 
-@Suppress("TooGenericExceptionCaught", "SwallowedException")
+@Suppress("SwallowedException")
 class MediaStoreFileOperationsImpl
     @Inject
     constructor(

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/MediaStoreFileOperationsImpl.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/MediaStoreFileOperationsImpl.kt
@@ -39,7 +39,7 @@ class MediaStoreFileOperationsImpl
             withContext(Dispatchers.IO) {
                 val builtin = resolveBuiltin(locationId)
                 BuiltinStorageLocation.validatePath(path)
-                val targetRelativePath = buildRelativePathForDir(builtin, path)
+                val targetRelativePath = buildRelativePathForListing(builtin, path)
                 val isAllFiles = storageLocationProvider.isAllFilesMode(locationId)
                 val cappedLimit = limit.coerceAtMost(FileOperationProvider.MAX_LIST_ENTRIES)
 
@@ -160,7 +160,7 @@ class MediaStoreFileOperationsImpl
         }
 
         private fun buildListSelection(isAllFiles: Boolean): String {
-            val pathFilter = "${MediaStore.MediaColumns.RELATIVE_PATH} LIKE ?"
+            val pathFilter = "${MediaStore.MediaColumns.RELATIVE_PATH} LIKE ? ESCAPE '\\'"
             return if (isAllFiles) {
                 pathFilter
             } else {
@@ -172,8 +172,8 @@ class MediaStoreFileOperationsImpl
             targetRelativePath: String,
             isAllFiles: Boolean,
         ): Array<String> {
-            // LIKE pattern: match exact dir and all children
-            val pattern = "$targetRelativePath%"
+            // LIKE pattern: match exact dir and all children; escape the literal prefix only
+            val pattern = "${escapeLikePattern(targetRelativePath)}%"
             return if (isAllFiles) arrayOf(pattern) else arrayOf(pattern, context.packageName)
         }
 
@@ -556,6 +556,27 @@ class MediaStoreFileOperationsImpl
                 "${builtin.baseRelativePath}${parentSegments.joinToString("/")}/"
             }
         }
+
+        /**
+         * Builds the MediaStore RELATIVE_PATH for a directory itself (all segments kept).
+         * E.g., builtin=PICTURES, path="DCIM/Camera" → "Pictures/DCIM/Camera/"
+         * E.g., builtin=PICTURES, path="" → "Pictures/"
+         */
+        private fun buildRelativePathForListing(
+            builtin: BuiltinStorageLocation,
+            path: String,
+        ): String {
+            if (path.isEmpty()) return builtin.baseRelativePath
+            val segments = path.split("/").filter { it.isNotEmpty() }
+            return "${builtin.baseRelativePath}${segments.joinToString("/")}/"
+        }
+
+        /** Escapes LIKE wildcards so the target path matches literally ('\' MUST be replaced first). */
+        private fun escapeLikePattern(value: String): String =
+            value
+                .replace("\\", "\\\\")
+                .replace("%", "\\%")
+                .replace("_", "\\_")
 
         /**
          * Extracts the file name (last segment) from a relative path.

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/MediaStoreFileOperationsImpl.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/MediaStoreFileOperationsImpl.kt
@@ -9,6 +9,7 @@ import android.provider.MediaStore
 import android.util.Log
 import com.danielealbano.androidremotecontrolmcp.data.model.BuiltinStorageLocation
 import com.danielealbano.androidremotecontrolmcp.data.model.FileInfo
+import com.danielealbano.androidremotecontrolmcp.data.model.MediaCollection
 import com.danielealbano.androidremotecontrolmcp.data.repository.SettingsRepository
 import com.danielealbano.androidremotecontrolmcp.mcp.McpToolException
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -27,6 +28,7 @@ class MediaStoreFileOperationsImpl
         @param:ApplicationContext private val context: Context,
         private val storageLocationProvider: StorageLocationProvider,
         private val settingsRepository: SettingsRepository,
+        private val permissionChecker: PermissionChecker,
     ) : MediaStoreFileOperations {
         // ─── listFiles ──────────────────────────────────────────────────────
 
@@ -40,7 +42,6 @@ class MediaStoreFileOperationsImpl
                 val builtin = resolveBuiltin(locationId)
                 BuiltinStorageLocation.validatePath(path)
                 val targetRelativePath = buildRelativePathForListing(builtin, path)
-                val isAllFiles = storageLocationProvider.isAllFilesMode(locationId)
                 val cappedLimit = limit.coerceAtMost(FileOperationProvider.MAX_LIST_ENTRIES)
 
                 // Query files in the target directory and children (for directory synthesis)
@@ -54,42 +55,44 @@ class MediaStoreFileOperationsImpl
                         MediaStore.MediaColumns.MIME_TYPE,
                     )
 
-                val selection = buildListSelection(isAllFiles)
-                val selectionArgs = buildListSelectionArgs(targetRelativePath, isAllFiles)
-
                 val entries = mutableListOf<FileInfo>()
                 val seenDirs = mutableSetOf<String>()
 
-                context.contentResolver
-                    .query(
-                        builtin.collectionUri,
-                        projection,
-                        selection,
-                        selectionArgs,
-                        null,
-                    )?.use { cursor ->
-                        val nameIdx = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DISPLAY_NAME)
-                        val relPathIdx = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.RELATIVE_PATH)
-                        val sizeIdx = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.SIZE)
-                        val dateIdx = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DATE_MODIFIED)
-                        val mimeIdx = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.MIME_TYPE)
+                for (collection in builtin.collections) {
+                    val isAllFiles = hasAllFilesAccess(collection)
+                    val selection = buildListSelection(isAllFiles)
+                    val selectionArgs = buildListSelectionArgs(targetRelativePath, isAllFiles)
+                    context.contentResolver
+                        .query(
+                            collection.uri,
+                            projection,
+                            selection,
+                            selectionArgs,
+                            null,
+                        )?.use { cursor ->
+                            val nameIdx = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DISPLAY_NAME)
+                            val relPathIdx = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.RELATIVE_PATH)
+                            val sizeIdx = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.SIZE)
+                            val dateIdx = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DATE_MODIFIED)
+                            val mimeIdx = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.MIME_TYPE)
 
-                        while (cursor.moveToNext()) {
-                            processCursorRow(
-                                cursor,
-                                nameIdx,
-                                relPathIdx,
-                                sizeIdx,
-                                dateIdx,
-                                mimeIdx,
-                                targetRelativePath,
-                                locationId,
-                                path,
-                                entries,
-                                seenDirs,
-                            )
+                            while (cursor.moveToNext()) {
+                                processCursorRow(
+                                    cursor,
+                                    nameIdx,
+                                    relPathIdx,
+                                    sizeIdx,
+                                    dateIdx,
+                                    mimeIdx,
+                                    targetRelativePath,
+                                    locationId,
+                                    path,
+                                    entries,
+                                    seenDirs,
+                                )
+                            }
                         }
-                    }
+                }
 
                 // Sort: directories first, then by name
                 val sorted =
@@ -193,7 +196,7 @@ class MediaStoreFileOperationsImpl
                 val builtin = resolveBuiltin(locationId)
                 BuiltinStorageLocation.validatePath(path)
 
-                val uri = findFileOrThrow(locationId, builtin, path)
+                val uri = findFileOrThrow(builtin, path)
                 checkFileSizeByUri(uri)
 
                 val cappedLimit = limit.coerceAtMost(FileOperationProvider.MAX_READ_LINES)
@@ -236,7 +239,7 @@ class MediaStoreFileOperationsImpl
             withContext(Dispatchers.IO) {
                 val builtin = resolveBuiltin(locationId)
                 BuiltinStorageLocation.validatePath(path)
-                val uri = findFileOrThrow(locationId, builtin, path)
+                val uri = findFileOrThrow(builtin, path)
                 readFileBytesFromUri(
                     context.contentResolver,
                     uri,
@@ -268,7 +271,9 @@ class MediaStoreFileOperationsImpl
 
             val relativePath = buildRelativePathForDir(builtin, path)
             val displayName = extractDisplayName(path)
-            val existingUri = findOwnedFile(builtin, relativePath, displayName)
+            val mimeType = MimeTypeUtils.guessMimeType(displayName)
+            val collection = selectCollectionForMimeType(builtin, mimeType)
+            val existingUri = findFileInCollection(collection, relativePath, displayName, ownedOnly = true)
 
             if (existingUri != null) {
                 context.contentResolver.openOutputStream(existingUri, "wt")?.use { it.write(contentBytes) }
@@ -278,10 +283,10 @@ class MediaStoreFileOperationsImpl
                     ContentValues().apply {
                         put(MediaStore.MediaColumns.DISPLAY_NAME, displayName)
                         put(MediaStore.MediaColumns.RELATIVE_PATH, relativePath)
-                        put(MediaStore.MediaColumns.MIME_TYPE, MimeTypeUtils.guessMimeType(displayName))
+                        put(MediaStore.MediaColumns.MIME_TYPE, mimeType)
                     }
                 val insertUri =
-                    context.contentResolver.insert(builtin.collectionUri, values)
+                    context.contentResolver.insert(collection.uri, values)
                         ?: throw McpToolException.ActionFailed("Failed to create file: $path")
                 context.contentResolver.openOutputStream(insertUri, "wt")?.use { it.write(contentBytes) }
                     ?: throw McpToolException.ActionFailed("Failed to write to new file: $path")
@@ -391,6 +396,8 @@ class MediaStoreFileOperationsImpl
                 val parsedUrl = parseAndValidateDownloadUrl(url, config)
                 val relativePath = buildRelativePathForDir(builtin, path)
                 val displayName = extractDisplayName(path)
+                val mimeType = MimeTypeUtils.guessMimeType(displayName)
+                val collection = selectCollectionForMimeType(builtin, mimeType)
                 val timeoutMs = (config.downloadTimeoutSeconds * MILLIS_PER_SECOND).toInt()
                 val limitBytes = config.fileSizeLimitMb.toLong() * BYTES_PER_MB
 
@@ -399,11 +406,11 @@ class MediaStoreFileOperationsImpl
                     ContentValues().apply {
                         put(MediaStore.MediaColumns.DISPLAY_NAME, displayName)
                         put(MediaStore.MediaColumns.RELATIVE_PATH, relativePath)
-                        put(MediaStore.MediaColumns.MIME_TYPE, MimeTypeUtils.guessMimeType(displayName))
+                        put(MediaStore.MediaColumns.MIME_TYPE, mimeType)
                         put(MediaStore.MediaColumns.IS_PENDING, 1)
                     }
                 val insertUri =
-                    context.contentResolver.insert(builtin.collectionUri, values)
+                    context.contentResolver.insert(collection.uri, values)
                         ?: throw McpToolException.ActionFailed("Failed to create download destination: $path")
 
                 var connection: HttpURLConnection? = null
@@ -512,9 +519,11 @@ class MediaStoreFileOperationsImpl
 
                 val relativePath = buildRelativePathForDir(builtin, path)
                 val displayName = extractDisplayName(path)
+                val collection = selectCollectionForMimeType(builtin, mimeType)
 
                 // Return existing if found
-                findOwnedFile(builtin, relativePath, displayName)?.let { return@withContext it }
+                findFileInCollection(collection, relativePath, displayName, ownedOnly = true)
+                    ?.let { return@withContext it }
 
                 val values =
                     ContentValues().apply {
@@ -522,7 +531,7 @@ class MediaStoreFileOperationsImpl
                         put(MediaStore.MediaColumns.RELATIVE_PATH, relativePath)
                         put(MediaStore.MediaColumns.MIME_TYPE, mimeType)
                     }
-                context.contentResolver.insert(builtin.collectionUri, values)
+                context.contentResolver.insert(collection.uri, values)
                     ?: throw McpToolException.ActionFailed("Failed to create file: $path")
             }
 
@@ -536,6 +545,41 @@ class MediaStoreFileOperationsImpl
                 ?: throw McpToolException.PermissionDenied(
                     "Storage location '$locationId' not found.",
                 )
+
+        private fun hasAllFilesAccess(collection: MediaCollection): Boolean =
+            collection.readMediaPermission?.let { permissionChecker.hasPermission(it) } == true
+
+        private fun selectCollectionForMimeType(
+            builtin: BuiltinStorageLocation,
+            mimeType: String,
+        ): MediaCollection =
+            builtin.collections.firstOrNull { collection ->
+                collection.mimeTypePrefix == null || mimeType.startsWith(collection.mimeTypePrefix)
+            } ?: throw McpToolException.InvalidParams(
+                "File type '$mimeType' is not supported by location '${builtin.locationId}'. " +
+                    "Accepted types: ${builtin.collections.joinToString(", ") { it.typeLabel }}.",
+            )
+
+        private fun findFileInCollection(
+            collection: MediaCollection,
+            relativePath: String,
+            displayName: String,
+            ownedOnly: Boolean,
+        ): Uri? {
+            val selection =
+                buildString {
+                    append("${MediaStore.MediaColumns.RELATIVE_PATH} = ? AND ")
+                    append("${MediaStore.MediaColumns.DISPLAY_NAME} = ?")
+                    if (ownedOnly) append(" AND ${MediaStore.MediaColumns.OWNER_PACKAGE_NAME} = ?")
+                }
+            val args =
+                if (ownedOnly) {
+                    arrayOf(relativePath, displayName, context.packageName)
+                } else {
+                    arrayOf(relativePath, displayName)
+                }
+            return queryForUri(collection.uri, selection, args)
+        }
 
         /**
          * Builds the MediaStore RELATIVE_PATH for the directory containing the file.
@@ -594,49 +638,34 @@ class MediaStoreFileOperationsImpl
             builtin: BuiltinStorageLocation,
             relativePath: String,
             displayName: String,
-        ): Uri? {
-            val selection =
-                "${MediaStore.MediaColumns.RELATIVE_PATH} = ? AND " +
-                    "${MediaStore.MediaColumns.DISPLAY_NAME} = ? AND " +
-                    "${MediaStore.MediaColumns.OWNER_PACKAGE_NAME} = ?"
-            val args = arrayOf(relativePath, displayName, context.packageName)
-            return queryForUri(builtin.collectionUri, selection, args)
-        }
+        ): Uri? =
+            builtin.collections.firstNotNullOfOrNull { collection ->
+                findFileInCollection(collection, relativePath, displayName, ownedOnly = true)
+            }
 
-        private fun findAnyFile(
-            builtin: BuiltinStorageLocation,
-            relativePath: String,
-            displayName: String,
-        ): Uri? {
-            val selection =
-                "${MediaStore.MediaColumns.RELATIVE_PATH} = ? AND " +
-                    "${MediaStore.MediaColumns.DISPLAY_NAME} = ?"
-            val args = arrayOf(relativePath, displayName)
-            return queryForUri(builtin.collectionUri, selection, args)
-        }
-
-        private suspend fun findFile(
-            locationId: String,
+        private fun findFile(
             builtin: BuiltinStorageLocation,
             relativePath: String,
             displayName: String,
         ): Uri? =
-            if (storageLocationProvider.isAllFilesMode(locationId)) {
-                findAnyFile(builtin, relativePath, displayName)
-            } else {
-                findOwnedFile(builtin, relativePath, displayName)
+            builtin.collections.firstNotNullOfOrNull { collection ->
+                findFileInCollection(
+                    collection,
+                    relativePath,
+                    displayName,
+                    ownedOnly = !hasAllFilesAccess(collection),
+                )
             }
 
-        private suspend fun findFileOrThrow(
-            locationId: String,
+        private fun findFileOrThrow(
             builtin: BuiltinStorageLocation,
             path: String,
         ): Uri {
             val relativePath = buildRelativePathForDir(builtin, path)
             val displayName = extractDisplayName(path)
-            return findFile(locationId, builtin, relativePath, displayName)
+            return findFile(builtin, relativePath, displayName)
                 ?: throw McpToolException.ActionFailed(
-                    "File not found: $path in location '$locationId'",
+                    "File not found: $path in location '${builtin.locationId}'",
                 )
         }
 

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/StorageLocationProvider.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/StorageLocationProvider.kt
@@ -110,13 +110,6 @@ interface StorageLocationProvider {
      */
     suspend fun isDuplicateTreeUri(treeUri: Uri): Boolean
 
-    /**
-     * Checks whether the given location is in "all files" mode (has READ_MEDIA_* permission).
-     * Only applicable to built-in MediaStore locations that have an optional read permission.
-     * Returns false for SAF locations and for built-in locations without "all files" support.
-     */
-    suspend fun isAllFilesMode(locationId: String): Boolean
-
     companion object {
         /** Maximum allowed length for location descriptions. */
         const val MAX_DESCRIPTION_LENGTH = 500

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/StorageLocationProviderImpl.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/StorageLocationProviderImpl.kt
@@ -221,13 +221,6 @@ class StorageLocationProviderImpl
             return settingsRepository.getStoredLocations().any { it.treeUri == treeUriString }
         }
 
-        @Suppress("ReturnCount")
-        override suspend fun isAllFilesMode(locationId: String): Boolean {
-            val builtin = BuiltinStorageLocation.fromLocationId(locationId) ?: return false
-            val permission = builtin.readMediaPermission ?: return false
-            return permissionChecker.hasPermission(permission)
-        }
-
         // ─────────────────────────────────────────────────────────────────────
         // Private helpers — built-in locations
         // ─────────────────────────────────────────────────────────────────────
@@ -237,13 +230,9 @@ class StorageLocationProviderImpl
             val availableBytes = querySharedStorageAvailableBytes()
             return BuiltinStorageLocation.entries.map { entry ->
                 val perms = permOverrides[entry.locationId] ?: BuiltinPermissions()
-                val allFilesMode =
-                    entry.readMediaPermission != null &&
-                        permissionChecker.hasPermission(entry.readMediaPermission)
-                val displayName = if (allFilesMode) entry.displayNameAll else entry.displayNameOwned
                 StorageLocation(
                     id = entry.locationId,
-                    name = displayName,
+                    name = buildBuiltinDisplayName(entry),
                     path = "/${entry.baseRelativePath.trimEnd('/')}",
                     description = "",
                     treeUri = "",
@@ -253,6 +242,24 @@ class StorageLocationProviderImpl
                     backend = StorageBackend.MEDIA_STORE,
                     isBuiltin = true,
                 )
+            }
+        }
+
+        private fun buildBuiltinDisplayName(entry: BuiltinStorageLocation): String {
+            val permissioned = entry.collections.filter { it.readMediaPermission != null }
+            if (permissioned.isEmpty()) return "${entry.displayBaseName} - Only owned files"
+            val granted =
+                permissioned.filter { collection ->
+                    collection.readMediaPermission?.let(permissionChecker::hasPermission) == true
+                }
+            return when {
+                granted.size == permissioned.size -> "${entry.displayBaseName} - All files"
+                granted.isEmpty() -> "${entry.displayBaseName} - Only owned files"
+                else -> {
+                    val grantedLabels = granted.joinToString(", ") { it.typeLabel }
+                    val ownedLabels = (permissioned - granted.toSet()).joinToString(", ") { it.typeLabel }
+                    "${entry.displayBaseName} - All $grantedLabels, owned $ownedLabels"
+                }
             }
         }
 

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/StorageLocationProviderImpl.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/StorageLocationProviderImpl.kt
@@ -253,8 +253,14 @@ class StorageLocationProviderImpl
                     collection.readMediaPermission?.let(permissionChecker::hasPermission) == true
                 }
             return when {
-                granted.size == permissioned.size -> "${entry.displayBaseName} - All files"
-                granted.isEmpty() -> "${entry.displayBaseName} - Only owned files"
+                granted.size == permissioned.size -> {
+                    "${entry.displayBaseName} - All files"
+                }
+
+                granted.isEmpty() -> {
+                    "${entry.displayBaseName} - Only owned files"
+                }
+
                 else -> {
                     val grantedLabels = granted.joinToString(", ") { it.typeLabel }
                     val ownedLabels = (permissioned - granted.toSet()).joinToString(", ") { it.typeLabel }

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/settings/StorageSettingsScreen.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/settings/StorageSettingsScreen.kt
@@ -109,7 +109,7 @@ fun StorageSettingsScreen(
 
     val permissionLauncher =
         rememberLauncherForActivityResult(
-            contract = ActivityResultContracts.RequestPermission(),
+            contract = ActivityResultContracts.RequestMultiplePermissions(),
         ) { _ -> viewModel.refreshStorageLocations() }
 
     val documentTreeLauncher =
@@ -165,23 +165,26 @@ fun StorageSettingsScreen(
 
                 builtinLocations.forEach { location ->
                     val builtin = BuiltinStorageLocation.fromLocationId(location.id)
+                    val readMediaPermissions =
+                        builtin?.collections?.mapNotNull { it.readMediaPermission }?.distinct().orEmpty()
                     val hasAllFiles =
-                        builtin?.readMediaPermission?.let {
-                            ContextCompat.checkSelfPermission(context, it) ==
-                                PackageManager.PERMISSION_GRANTED
-                        } ?: false
+                        readMediaPermissions.isNotEmpty() &&
+                            readMediaPermissions.all {
+                                ContextCompat.checkSelfPermission(context, it) ==
+                                    PackageManager.PERMISSION_GRANTED
+                            }
                     BuiltinStorageLocationRow(
                         location = location,
                         hasAllFilesPermission = hasAllFiles,
-                        readMediaPermission = builtin?.readMediaPermission,
+                        readMediaPermissions = readMediaPermissions,
                         onAllowWriteChange = { enabled ->
                             viewModel.updateLocationAllowWrite(location.id, enabled)
                         },
                         onAllowDeleteChange = { enabled ->
                             viewModel.updateLocationAllowDelete(location.id, enabled)
                         },
-                        onRequestPermission = { permission ->
-                            permissionLauncher.launch(permission)
+                        onRequestPermission = { permissions ->
+                            permissionLauncher.launch(permissions.toTypedArray())
                         },
                     )
                 }
@@ -607,10 +610,10 @@ private fun StorageLocationRow(
 private fun BuiltinStorageLocationRow(
     location: StorageLocation,
     hasAllFilesPermission: Boolean,
-    readMediaPermission: String?,
+    readMediaPermissions: List<String>,
     onAllowWriteChange: (Boolean) -> Unit,
     onAllowDeleteChange: (Boolean) -> Unit,
-    onRequestPermission: (String) -> Unit,
+    onRequestPermission: (List<String>) -> Unit,
 ) {
     Column(
         modifier =
@@ -677,9 +680,9 @@ private fun BuiltinStorageLocationRow(
                 )
             }
         }
-        if (readMediaPermission != null) {
+        if (readMediaPermissions.isNotEmpty()) {
             OutlinedButton(
-                onClick = { onRequestPermission(readMediaPermission) },
+                onClick = { onRequestPermission(readMediaPermissions) },
                 enabled = !hasAllFilesPermission,
                 modifier = Modifier.fillMaxWidth(),
             ) {

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/settings/StorageSettingsScreen.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/settings/StorageSettingsScreen.kt
@@ -166,7 +166,11 @@ fun StorageSettingsScreen(
                 builtinLocations.forEach { location ->
                     val builtin = BuiltinStorageLocation.fromLocationId(location.id)
                     val readMediaPermissions =
-                        builtin?.collections?.mapNotNull { it.readMediaPermission }?.distinct().orEmpty()
+                        builtin
+                            ?.collections
+                            ?.mapNotNull { it.readMediaPermission }
+                            ?.distinct()
+                            .orEmpty()
                     val hasAllFiles =
                         readMediaPermissions.isNotEmpty() &&
                             readMediaPermissions.all {

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/data/model/BuiltinStorageLocationTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/data/model/BuiltinStorageLocationTest.kt
@@ -37,7 +37,7 @@ class BuiltinStorageLocationTest {
         }
 
         @Test
-        fun `fromLocationId returns DCIM for builtin:dcim`() {
+        fun `fromLocationId returns DCIM for dcim builtin id`() {
             assertEquals(
                 BuiltinStorageLocation.DCIM,
                 BuiltinStorageLocation.fromLocationId("builtin:dcim"),

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/data/model/BuiltinStorageLocationTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/data/model/BuiltinStorageLocationTest.kt
@@ -37,6 +37,14 @@ class BuiltinStorageLocationTest {
         }
 
         @Test
+        fun `fromLocationId returns DCIM for builtin:dcim`() {
+            assertEquals(
+                BuiltinStorageLocation.DCIM,
+                BuiltinStorageLocation.fromLocationId("builtin:dcim"),
+            )
+        }
+
+        @Test
         fun `fromLocationId returns null for unknown ID`() {
             assertNull(BuiltinStorageLocation.fromLocationId("builtin:documents"))
         }
@@ -67,18 +75,43 @@ class BuiltinStorageLocationTest {
     }
 
     @Nested
-    @DisplayName("readMediaPermission")
-    inner class ReadMediaPermissionTest {
+    @DisplayName("collections")
+    inner class CollectionsTest {
         @Test
-        fun `downloads has no readMediaPermission`() {
-            assertNull(BuiltinStorageLocation.DOWNLOADS.readMediaPermission)
+        fun `DCIM entry has DCIM base path and Camera display name`() {
+            assertEquals("DCIM/", BuiltinStorageLocation.DCIM.baseRelativePath)
+            assertEquals("Camera (DCIM)", BuiltinStorageLocation.DCIM.displayBaseName)
         }
 
         @Test
-        fun `pictures movies music have readMediaPermission`() {
-            assertNotNull(BuiltinStorageLocation.PICTURES.readMediaPermission)
-            assertNotNull(BuiltinStorageLocation.MOVIES.readMediaPermission)
-            assertNotNull(BuiltinStorageLocation.MUSIC.readMediaPermission)
+        fun `DCIM and PICTURES have images then videos collections`() {
+            for (entry in listOf(BuiltinStorageLocation.DCIM, BuiltinStorageLocation.PICTURES)) {
+                assertEquals(2, entry.collections.size)
+                assertEquals(
+                    android.Manifest.permission.READ_MEDIA_IMAGES,
+                    entry.collections[0].readMediaPermission,
+                )
+                assertEquals("image/", entry.collections[0].mimeTypePrefix)
+                assertEquals(
+                    android.Manifest.permission.READ_MEDIA_VIDEO,
+                    entry.collections[1].readMediaPermission,
+                )
+                assertEquals("video/", entry.collections[1].mimeTypePrefix)
+            }
+        }
+
+        @Test
+        fun `DOWNLOADS collection accepts any mime and has no permission`() {
+            assertEquals(1, BuiltinStorageLocation.DOWNLOADS.collections.size)
+            assertNull(BuiltinStorageLocation.DOWNLOADS.collections[0].mimeTypePrefix)
+            assertNull(BuiltinStorageLocation.DOWNLOADS.collections[0].readMediaPermission)
+        }
+
+        @Test
+        fun `pictures movies music collections have readMediaPermission`() {
+            assertNotNull(BuiltinStorageLocation.PICTURES.collections[0].readMediaPermission)
+            assertNotNull(BuiltinStorageLocation.MOVIES.collections[0].readMediaPermission)
+            assertNotNull(BuiltinStorageLocation.MUSIC.collections[0].readMediaPermission)
         }
     }
 

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/MediaStoreDownloaderTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/MediaStoreDownloaderTest.kt
@@ -1,0 +1,174 @@
+package com.danielealbano.androidremotecontrolmcp.services.storage
+
+import android.content.ContentResolver
+import android.content.Context
+import android.net.Uri
+import android.util.Log
+import com.danielealbano.androidremotecontrolmcp.data.model.ServerConfig
+import com.danielealbano.androidremotecontrolmcp.mcp.McpToolException
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.net.HttpURLConnection
+import java.net.URL
+import java.net.URLConnection
+import java.net.URLStreamHandler
+
+@ExtendWith(MockKExtension::class)
+@DisplayName("MediaStoreDownloader")
+class MediaStoreDownloaderTest {
+    @MockK(relaxed = true)
+    private lateinit var mockContext: Context
+
+    @MockK(relaxed = true)
+    private lateinit var mockContentResolver: ContentResolver
+
+    @MockK(relaxed = true)
+    private lateinit var mockConnection: HttpURLConnection
+
+    private val insertUri: Uri = mockk(relaxed = true)
+
+    private lateinit var downloader: MediaStoreDownloader
+
+    @BeforeEach
+    fun setUp() {
+        mockkStatic(Log::class)
+        every { Log.d(any(), any()) } returns 0
+        every { Log.i(any(), any()) } returns 0
+        every { Log.w(any<String>(), any<String>()) } returns 0
+        every { Log.e(any(), any()) } returns 0
+
+        every { mockContext.contentResolver } returns mockContentResolver
+        every { mockContentResolver.delete(any(), any(), any()) } returns 1
+        every { mockContentResolver.update(any(), any(), any(), any()) } returns 1
+
+        downloader = MediaStoreDownloader(mockContext)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(Log::class)
+    }
+
+    /** Builds a real URL whose openConnection() returns the given mock (URL is not mockable). */
+    private fun urlFor(connection: HttpURLConnection): URL =
+        URL(
+            "http",
+            "example.com",
+            80,
+            "/file.bin",
+            object : URLStreamHandler() {
+                override fun openConnection(u: URL): URLConnection = connection
+            },
+        )
+
+    private fun download(config: ServerConfig = ServerConfig()): Long =
+        downloader.downloadToPendingUri(
+            insertUri,
+            urlFor(mockConnection),
+            "http://example.com/file.bin",
+            config,
+            "builtin:downloads/file.bin",
+        )
+
+    @Test
+    fun `downloadToPendingUri streams bytes and clears IS_PENDING`() {
+        every { mockConnection.responseCode } returns 200
+        every { mockConnection.contentLengthLong } returns 5L
+        every { mockConnection.inputStream } returns ByteArrayInputStream("hello".toByteArray())
+        val output = ByteArrayOutputStream()
+        every { mockContentResolver.openOutputStream(eq(insertUri), eq("wt")) } returns output
+
+        val result = download()
+
+        assertEquals(5L, result)
+        assertEquals("hello", output.toString(Charsets.UTF_8.name()))
+        verify { mockContentResolver.update(eq(insertUri), any(), any(), any()) }
+        verify(exactly = 0) { mockContentResolver.delete(any(), any(), any()) }
+        verify { mockConnection.disconnect() }
+    }
+
+    @Test
+    fun `downloadToPendingUri deletes entry on http error status`() {
+        every { mockConnection.responseCode } returns 404
+
+        val exception = assertThrows<McpToolException.ActionFailed> { download() }
+
+        assertTrue(exception.message!!.contains("HTTP status 404"))
+        verify { mockContentResolver.delete(eq(insertUri), any(), any()) }
+        verify(exactly = 0) { mockContentResolver.update(any(), any(), any(), any()) }
+        verify { mockConnection.disconnect() }
+    }
+
+    @Test
+    fun `downloadToPendingUri rejects oversized reported content length`() {
+        every { mockConnection.responseCode } returns 200
+        every { mockConnection.contentLengthLong } returns 2L * 1024 * 1024
+
+        val exception =
+            assertThrows<McpToolException.ActionFailed> {
+                download(ServerConfig(fileSizeLimitMb = 1))
+            }
+
+        assertTrue(exception.message!!.contains("exceeds limit"))
+        verify { mockContentResolver.delete(eq(insertUri), any(), any()) }
+    }
+
+    @Test
+    fun `downloadToPendingUri rejects stream exceeding size limit`() {
+        every { mockConnection.responseCode } returns 200
+        every { mockConnection.contentLengthLong } returns -1L
+        every { mockConnection.inputStream } returns
+            ByteArrayInputStream(ByteArray(1024 * 1024 + 1))
+        every { mockContentResolver.openOutputStream(eq(insertUri), eq("wt")) } returns
+            ByteArrayOutputStream()
+
+        val exception =
+            assertThrows<McpToolException.ActionFailed> {
+                download(ServerConfig(fileSizeLimitMb = 1))
+            }
+
+        assertTrue(exception.message!!.contains("file size limit"))
+        verify { mockContentResolver.delete(eq(insertUri), any(), any()) }
+        verify(exactly = 0) { mockContentResolver.update(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `downloadToPendingUri throws when destination cannot be opened`() {
+        every { mockConnection.responseCode } returns 200
+        every { mockConnection.contentLengthLong } returns 5L
+        every { mockContentResolver.openOutputStream(eq(insertUri), eq("wt")) } returns null
+
+        val exception = assertThrows<McpToolException.ActionFailed> { download() }
+
+        assertTrue(exception.message!!.contains("Failed to open download destination"))
+        verify { mockContentResolver.delete(eq(insertUri), any(), any()) }
+    }
+
+    @Test
+    fun `downloadToPendingUri wraps connect failure with cause and deletes entry`() {
+        every { mockConnection.connect() } throws IOException("boom")
+
+        val exception = assertThrows<McpToolException.ActionFailed> { download() }
+
+        assertTrue(exception.message!!.contains("Download failed: boom"))
+        assertTrue(exception.cause is IOException)
+        verify { mockContentResolver.delete(eq(insertUri), any(), any()) }
+        verify { mockConnection.disconnect() }
+    }
+}

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/MediaStoreFileOperationsTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/MediaStoreFileOperationsTest.kt
@@ -483,7 +483,7 @@ class MediaStoreFileOperationsTest {
                     mockContentResolver.query(any(), any(), any(), any(), any())
                 } answers {
                     when (arg<Uri>(0)) {
-                        fakeImagesUri ->
+                        fakeImagesUri -> {
                             createMockCursor(
                                 listOf(
                                     mapOf(
@@ -496,8 +496,9 @@ class MediaStoreFileOperationsTest {
                                     ),
                                 ),
                             )
+                        }
 
-                        fakeVideoUri ->
+                        fakeVideoUri -> {
                             createMockCursor(
                                 listOf(
                                     mapOf(
@@ -510,8 +511,11 @@ class MediaStoreFileOperationsTest {
                                     ),
                                 ),
                             )
+                        }
 
-                        else -> createMockCursor(emptyList())
+                        else -> {
+                            createMockCursor(emptyList())
+                        }
                     }
                 }
 
@@ -529,7 +533,7 @@ class MediaStoreFileOperationsTest {
                     mockContentResolver.query(any(), any(), any(), any(), any())
                 } answers {
                     when (arg<Uri>(0)) {
-                        fakeImagesUri, fakeVideoUri ->
+                        fakeImagesUri, fakeVideoUri -> {
                             createMockCursor(
                                 listOf(
                                     mapOf(
@@ -542,8 +546,11 @@ class MediaStoreFileOperationsTest {
                                     ),
                                 ),
                             )
+                        }
 
-                        else -> createMockCursor(emptyList())
+                        else -> {
+                            createMockCursor(emptyList())
+                        }
                     }
                 }
 

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/MediaStoreFileOperationsTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/MediaStoreFileOperationsTest.kt
@@ -9,6 +9,7 @@ import android.net.Uri
 import android.provider.MediaStore
 import android.util.Log
 import com.danielealbano.androidremotecontrolmcp.data.model.BuiltinStorageLocation
+import com.danielealbano.androidremotecontrolmcp.data.model.MediaCollection
 import com.danielealbano.androidremotecontrolmcp.data.model.ServerConfig
 import com.danielealbano.androidremotecontrolmcp.data.repository.SettingsRepository
 import com.danielealbano.androidremotecontrolmcp.mcp.McpToolException
@@ -52,10 +53,15 @@ class MediaStoreFileOperationsTest {
     @MockK
     private lateinit var mockSettingsRepository: SettingsRepository
 
+    @MockK
+    private lateinit var mockPermissionChecker: PermissionChecker
+
     private lateinit var operations: MediaStoreFileOperationsImpl
 
     private val fakeCollectionUri: Uri = mockk(relaxed = true)
     private val fakeFileUri: Uri = mockk(relaxed = true)
+    private val fakeImagesUri: Uri = mockk(relaxed = true)
+    private val fakeVideoUri: Uri = mockk(relaxed = true)
 
     @BeforeEach
     fun setUp() {
@@ -74,22 +80,56 @@ class MediaStoreFileOperationsTest {
         every { mockContext.contentResolver } returns mockContentResolver
         every { mockContext.packageName } returns "com.test.app"
 
-        coEvery { mockStorageLocationProvider.isAllFilesMode(any()) } returns false
         coEvery { mockStorageLocationProvider.isWriteAllowed(any()) } returns true
         coEvery { mockStorageLocationProvider.isDeleteAllowed(any()) } returns true
         coEvery { mockSettingsRepository.getServerConfig() } returns ServerConfig()
+        every { mockPermissionChecker.hasPermission(any()) } returns false
 
         mockkObject(BuiltinStorageLocation.DOWNLOADS)
-        every { BuiltinStorageLocation.DOWNLOADS.collectionUri } returns fakeCollectionUri
+        every { BuiltinStorageLocation.DOWNLOADS.collections } returns listOf(testCollection(fakeCollectionUri))
 
-        operations = MediaStoreFileOperationsImpl(mockContext, mockStorageLocationProvider, mockSettingsRepository)
+        operations =
+            MediaStoreFileOperationsImpl(
+                mockContext,
+                mockStorageLocationProvider,
+                mockSettingsRepository,
+                mockPermissionChecker,
+            )
     }
 
     @AfterEach
     fun tearDown() {
         unmockkObject(BuiltinStorageLocation.DOWNLOADS)
+        unmockkObject(BuiltinStorageLocation.PICTURES)
+        unmockkObject(BuiltinStorageLocation.MUSIC)
         unmockkStatic(Log::class)
         unmockkStatic(Uri::class)
+    }
+
+    private fun testCollection(
+        uri: Uri,
+        permission: String? = null,
+        mimePrefix: String? = null,
+        label: String = "files",
+    ) = MediaCollection({ uri }, permission, mimePrefix, label)
+
+    private fun stubPicturesCollections() {
+        mockkObject(BuiltinStorageLocation.PICTURES)
+        every { BuiltinStorageLocation.PICTURES.collections } returns
+            listOf(
+                testCollection(
+                    fakeImagesUri,
+                    permission = android.Manifest.permission.READ_MEDIA_IMAGES,
+                    mimePrefix = "image/",
+                    label = "images",
+                ),
+                testCollection(
+                    fakeVideoUri,
+                    permission = android.Manifest.permission.READ_MEDIA_VIDEO,
+                    mimePrefix = "video/",
+                    label = "videos",
+                ),
+            )
     }
 
     private fun createMockCursor(rows: List<Map<String, Any?>>): Cursor {
@@ -267,7 +307,16 @@ class MediaStoreFileOperationsTest {
         @Test
         fun `listFiles returns all files in all-files mode`() =
             runTest {
-                coEvery { mockStorageLocationProvider.isAllFilesMode("builtin:downloads") } returns true
+                every { BuiltinStorageLocation.DOWNLOADS.collections } returns
+                    listOf(
+                        testCollection(
+                            fakeCollectionUri,
+                            permission = android.Manifest.permission.READ_MEDIA_IMAGES,
+                        ),
+                    )
+                every {
+                    mockPermissionChecker.hasPermission(android.Manifest.permission.READ_MEDIA_IMAGES)
+                } returns true
 
                 val rows =
                     listOf(
@@ -303,6 +352,227 @@ class MediaStoreFileOperationsTest {
                         operations.listFiles("builtin:nonexistent", "", 0, 50)
                     }
                 assertTrue(exception.message!!.contains("not found"))
+            }
+
+        @Test
+        fun `listFiles filters by single-segment path`() =
+            runTest {
+                var capturedArgs: Array<String>? = null
+                every {
+                    mockContentResolver.query(any(), any(), any(), any(), any())
+                } answers {
+                    capturedArgs = arg(3)
+                    createMockCursor(emptyList())
+                }
+
+                operations.listFiles("builtin:downloads", "subdir", 0, 50)
+
+                assertEquals("Download/subdir/%", capturedArgs!![0])
+            }
+
+        @Test
+        fun `listFiles filters by nested path`() =
+            runTest {
+                var capturedArgs: Array<String>? = null
+                every {
+                    mockContentResolver.query(any(), any(), any(), any(), any())
+                } answers {
+                    capturedArgs = arg(3)
+                    createMockCursor(emptyList())
+                }
+
+                operations.listFiles("builtin:downloads", "a/b", 0, 50)
+
+                assertEquals("Download/a/b/%", capturedArgs!![0])
+            }
+
+        @Test
+        fun `listFiles returns empty for non-matching directory`() =
+            runTest {
+                val rows =
+                    listOf(
+                        mapOf(
+                            "id" to 1L,
+                            "name" to "root.txt",
+                            "relPath" to "Download/",
+                            "size" to 1L,
+                            "dateModified" to 1700000000L,
+                            "mimeType" to "text/plain",
+                        ),
+                        mapOf(
+                            "id" to 2L,
+                            "name" to "other.txt",
+                            "relPath" to "Download/other/",
+                            "size" to 1L,
+                            "dateModified" to 1700000000L,
+                            "mimeType" to "text/plain",
+                        ),
+                    )
+                stubQueryReturning(createMockCursor(rows))
+
+                val result = operations.listFiles("builtin:downloads", "subdir", 0, 50)
+
+                assertEquals(0, result.totalCount)
+                assertTrue(result.files.isEmpty())
+            }
+
+        @Test
+        fun `listFiles synthesizes directories under non-root path`() =
+            runTest {
+                val rows =
+                    listOf(
+                        mapOf(
+                            "id" to 1L,
+                            "name" to "x.jpg",
+                            "relPath" to "Download/a/b/",
+                            "size" to 10L,
+                            "dateModified" to 1700000000L,
+                            "mimeType" to "image/jpeg",
+                        ),
+                    )
+                stubQueryReturning(createMockCursor(rows))
+
+                val result = operations.listFiles("builtin:downloads", "a", 0, 50)
+
+                assertEquals(1, result.totalCount)
+                assertTrue(result.files[0].isDirectory)
+                assertEquals("b", result.files[0].name)
+                assertEquals("builtin:downloads/a/b", result.files[0].path)
+            }
+
+        @Test
+        fun `listFiles escapes LIKE wildcards in path`() =
+            runTest {
+                var capturedSelection: String? = null
+                var capturedArgs: Array<String>? = null
+                every {
+                    mockContentResolver.query(any(), any(), any(), any(), any())
+                } answers {
+                    capturedSelection = arg(2)
+                    capturedArgs = arg(3)
+                    createMockCursor(emptyList())
+                }
+
+                operations.listFiles("builtin:downloads", "My_Files", 0, 50)
+
+                assertEquals("Download/My\\_Files/%", capturedArgs!![0])
+                assertTrue(capturedSelection!!.contains("ESCAPE '\\'"))
+            }
+
+        @Test
+        fun `listFiles escapes percent in path`() =
+            runTest {
+                var capturedArgs: Array<String>? = null
+                every {
+                    mockContentResolver.query(any(), any(), any(), any(), any())
+                } answers {
+                    capturedArgs = arg(3)
+                    createMockCursor(emptyList())
+                }
+
+                operations.listFiles("builtin:downloads", "100%", 0, 50)
+
+                assertEquals("Download/100\\%/%", capturedArgs!![0])
+            }
+
+        @Test
+        fun `listFiles merges rows from all collections`() =
+            runTest {
+                stubPicturesCollections()
+                every {
+                    mockContentResolver.query(any(), any(), any(), any(), any())
+                } answers {
+                    when (arg<Uri>(0)) {
+                        fakeImagesUri ->
+                            createMockCursor(
+                                listOf(
+                                    mapOf(
+                                        "id" to 1L,
+                                        "name" to "photo.jpg",
+                                        "relPath" to "Pictures/",
+                                        "size" to 10L,
+                                        "dateModified" to 1700000000L,
+                                        "mimeType" to "image/jpeg",
+                                    ),
+                                ),
+                            )
+
+                        fakeVideoUri ->
+                            createMockCursor(
+                                listOf(
+                                    mapOf(
+                                        "id" to 2L,
+                                        "name" to "clip.mp4",
+                                        "relPath" to "Pictures/",
+                                        "size" to 20L,
+                                        "dateModified" to 1700000001L,
+                                        "mimeType" to "video/mp4",
+                                    ),
+                                ),
+                            )
+
+                        else -> createMockCursor(emptyList())
+                    }
+                }
+
+                val result = operations.listFiles("builtin:pictures", "", 0, 50)
+
+                assertEquals(2, result.totalCount)
+                assertEquals(listOf("clip.mp4", "photo.jpg"), result.files.map { it.name })
+            }
+
+        @Test
+        fun `listFiles dedupes synthesized dirs across collections`() =
+            runTest {
+                stubPicturesCollections()
+                every {
+                    mockContentResolver.query(any(), any(), any(), any(), any())
+                } answers {
+                    when (arg<Uri>(0)) {
+                        fakeImagesUri, fakeVideoUri ->
+                            createMockCursor(
+                                listOf(
+                                    mapOf(
+                                        "id" to 1L,
+                                        "name" to "media.bin",
+                                        "relPath" to "Pictures/sub/",
+                                        "size" to 10L,
+                                        "dateModified" to 1700000000L,
+                                        "mimeType" to "application/octet-stream",
+                                    ),
+                                ),
+                            )
+
+                        else -> createMockCursor(emptyList())
+                    }
+                }
+
+                val result = operations.listFiles("builtin:pictures", "", 0, 50)
+
+                assertEquals(1, result.totalCount)
+                assertTrue(result.files[0].isDirectory)
+                assertEquals("sub", result.files[0].name)
+            }
+
+        @Test
+        fun `listFiles applies owner filter per collection`() =
+            runTest {
+                stubPicturesCollections()
+                every {
+                    mockPermissionChecker.hasPermission(android.Manifest.permission.READ_MEDIA_IMAGES)
+                } returns true
+                val selections = mutableMapOf<Uri, String>()
+                every {
+                    mockContentResolver.query(any(), any(), any(), any(), any())
+                } answers {
+                    selections[arg(0)] = arg(2)
+                    createMockCursor(emptyList())
+                }
+
+                operations.listFiles("builtin:pictures", "", 0, 50)
+
+                assertFalse(selections[fakeImagesUri]!!.contains(MediaStore.MediaColumns.OWNER_PACKAGE_NAME))
+                assertTrue(selections[fakeVideoUri]!!.contains(MediaStore.MediaColumns.OWNER_PACKAGE_NAME))
             }
     }
 
@@ -364,7 +634,16 @@ class MediaStoreFileOperationsTest {
         @Test
         fun `readFile works in all-files mode for non-owned file`() =
             runTest {
-                coEvery { mockStorageLocationProvider.isAllFilesMode("builtin:downloads") } returns true
+                every { BuiltinStorageLocation.DOWNLOADS.collections } returns
+                    listOf(
+                        testCollection(
+                            fakeCollectionUri,
+                            permission = android.Manifest.permission.READ_MEDIA_IMAGES,
+                        ),
+                    )
+                every {
+                    mockPermissionChecker.hasPermission(android.Manifest.permission.READ_MEDIA_IMAGES)
+                } returns true
 
                 val findCursor = createMockCursor(listOf(mapOf("id" to 1L)))
                 every {
@@ -381,6 +660,29 @@ class MediaStoreFileOperationsTest {
                 val result = operations.readFile("builtin:downloads", "other.txt", 1, 200)
 
                 assertEquals("Non-owned content", result.content)
+            }
+
+        @Test
+        fun `readFile resolves file from second collection`() =
+            runTest {
+                stubPicturesCollections()
+                every {
+                    mockContentResolver.query(any(), any(), any(), any(), any())
+                } answers {
+                    when (arg<Uri>(0)) {
+                        fakeImagesUri -> createMockCursor(emptyList())
+                        fakeVideoUri -> createMockCursor(listOf(mapOf("id" to 5L)))
+                        else -> createMockCursor(listOf(mapOf("size" to 20L)))
+                    }
+                }
+                every {
+                    mockContentResolver.openInputStream(any())
+                } returns ByteArrayInputStream("video content".toByteArray())
+
+                val result = operations.readFile("builtin:pictures", "clip.mp4", 1, 200)
+
+                assertEquals("video content", result.content)
+                verify { mockContentResolver.query(eq(fakeVideoUri), any(), any(), any(), any()) }
             }
     }
 
@@ -502,6 +804,91 @@ class MediaStoreFileOperationsTest {
                     }
                 assertTrue(exception.message!!.contains("file size limit"))
             }
+
+        @Test
+        fun `writeFile routes image mime to images collection`() =
+            runTest {
+                stubPicturesCollections()
+                every {
+                    mockContentResolver.query(any(), any(), any(), any(), any())
+                } answers { createMockCursor(emptyList()) }
+                val insertedUri = mockk<Uri>(relaxed = true)
+                every { mockContentResolver.insert(any(), any()) } returns insertedUri
+                val outputStream = ByteArrayOutputStream()
+                every { mockContentResolver.openOutputStream(eq(insertedUri), eq("wt")) } returns outputStream
+
+                operations.writeFile("builtin:pictures", "x.jpg", "img")
+
+                verify { mockContentResolver.insert(eq(fakeImagesUri), any()) }
+            }
+
+        @Test
+        fun `writeFile routes video mime to video collection`() =
+            runTest {
+                stubPicturesCollections()
+                every {
+                    mockContentResolver.query(any(), any(), any(), any(), any())
+                } answers { createMockCursor(emptyList()) }
+                val insertedUri = mockk<Uri>(relaxed = true)
+                every { mockContentResolver.insert(any(), any()) } returns insertedUri
+                val outputStream = ByteArrayOutputStream()
+                every { mockContentResolver.openOutputStream(eq(insertedUri), eq("wt")) } returns outputStream
+
+                operations.writeFile("builtin:pictures", "x.mp4", "vid")
+
+                verify { mockContentResolver.insert(eq(fakeVideoUri), any()) }
+            }
+
+        @Test
+        fun `writeFile rejects unsupported mime with InvalidParams`() =
+            runTest {
+                stubPicturesCollections()
+
+                val exception =
+                    assertThrows<McpToolException.InvalidParams> {
+                        operations.writeFile("builtin:pictures", "x.txt", "text")
+                    }
+
+                assertTrue(exception.message!!.contains("images, videos"))
+                verify(exactly = 0) { mockContentResolver.insert(any(), any()) }
+            }
+
+        @Test
+        fun `writeFile rejects non-audio on music`() =
+            runTest {
+                mockkObject(BuiltinStorageLocation.MUSIC)
+                every { BuiltinStorageLocation.MUSIC.collections } returns
+                    listOf(
+                        testCollection(
+                            fakeCollectionUri,
+                            permission = android.Manifest.permission.READ_MEDIA_AUDIO,
+                            mimePrefix = "audio/",
+                            label = "audio",
+                        ),
+                    )
+
+                val exception =
+                    assertThrows<McpToolException.InvalidParams> {
+                        operations.writeFile("builtin:music", "x.txt", "text")
+                    }
+
+                assertTrue(exception.message!!.contains("audio"))
+                verify(exactly = 0) { mockContentResolver.insert(any(), any()) }
+            }
+
+        @Test
+        fun `writeFile accepts any mime on downloads`() =
+            runTest {
+                stubFindOwnedFile(found = false)
+                val insertedUri = mockk<Uri>(relaxed = true)
+                every { mockContentResolver.insert(any(), any()) } returns insertedUri
+                val outputStream = ByteArrayOutputStream()
+                every { mockContentResolver.openOutputStream(eq(insertedUri), eq("wt")) } returns outputStream
+
+                operations.writeFile("builtin:downloads", "x.txt", "text")
+
+                verify { mockContentResolver.insert(eq(fakeCollectionUri), any()) }
+            }
     }
 
     // ─── appendFile ─────────────────────────────────────────────────────
@@ -618,6 +1005,26 @@ class MediaStoreFileOperationsTest {
                     }
                 assertTrue(exception.message!!.contains("Delete not allowed"))
             }
+
+        @Test
+        fun `deleteFile resolves owned file across collections`() =
+            runTest {
+                stubPicturesCollections()
+                every {
+                    mockContentResolver.query(any(), any(), any(), any(), any())
+                } answers {
+                    when (arg<Uri>(0)) {
+                        fakeImagesUri -> createMockCursor(emptyList())
+                        fakeVideoUri -> createMockCursor(listOf(mapOf("id" to 3L)))
+                        else -> createMockCursor(emptyList())
+                    }
+                }
+                every { mockContentResolver.delete(any(), any(), any()) } returns 1
+
+                operations.deleteFile("builtin:pictures", "clip.mp4")
+
+                verify { mockContentResolver.delete(eq(fakeFileUri), any(), any()) }
+            }
     }
 
     // ─── createFileUri ──────────────────────────────────────────────────
@@ -649,6 +1056,46 @@ class MediaStoreFileOperationsTest {
                     operations.createFileUri("builtin:downloads", "existing.jpg", "image/jpeg")
 
                 assertEquals(fakeFileUri, result)
+                verify(exactly = 0) { mockContentResolver.insert(any(), any()) }
+            }
+
+        @Test
+        fun `createFileUri routes by explicit mime type`() =
+            runTest {
+                stubPicturesCollections()
+                every {
+                    mockContentResolver.query(any(), any(), any(), any(), any())
+                } answers { createMockCursor(emptyList()) }
+                val insertedUri = mockk<Uri>(relaxed = true)
+                every { mockContentResolver.insert(any(), any()) } returns insertedUri
+
+                val result = operations.createFileUri("builtin:pictures", "clip.mp4", "video/mp4")
+
+                assertEquals(insertedUri, result)
+                verify { mockContentResolver.insert(eq(fakeVideoUri), any()) }
+            }
+    }
+
+    // ─── downloadFromUrl ────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("downloadFromUrl")
+    inner class DownloadFromUrl {
+        @Test
+        fun `downloadFromUrl rejects unsupported mime before insert`() =
+            runTest {
+                stubPicturesCollections()
+
+                val exception =
+                    assertThrows<McpToolException.InvalidParams> {
+                        operations.downloadFromUrl(
+                            "builtin:pictures",
+                            "notes.txt",
+                            "https://example.com/f",
+                        )
+                    }
+
+                assertTrue(exception.message!!.contains("Accepted types"))
                 verify(exactly = 0) { mockContentResolver.insert(any(), any()) }
             }
     }

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/StorageLocationProviderTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/StorageLocationProviderTest.kt
@@ -144,8 +144,8 @@ class StorageLocationProviderTest {
                 // Act
                 val result = provider.getAllLocations()
 
-                // Assert — 4 builtins + 1 SAF location
-                assertEquals(5, result.size)
+                // Assert — 5 builtins + 1 SAF location
+                assertEquals(6, result.size)
                 val location = result.last()
                 assertEquals("com.test.provider/primary:Documents", location.id)
                 assertEquals("Documents", location.name)
@@ -169,8 +169,8 @@ class StorageLocationProviderTest {
                 // Act
                 val result = provider.getAllLocations()
 
-                // Assert — only 4 builtins, no SAF locations
-                assertEquals(4, result.size)
+                // Assert — only 5 builtins, no SAF locations
+                assertEquals(5, result.size)
                 assertTrue(result.all { it.isBuiltin })
             }
 
@@ -210,8 +210,8 @@ class StorageLocationProviderTest {
                 // Act
                 val result = provider.getAllLocations()
 
-                // Assert — 4 builtins + 1 SAF location
-                assertEquals(5, result.size)
+                // Assert — 5 builtins + 1 SAF location
+                assertEquals(6, result.size)
                 val location = result.last()
                 assertEquals("com.test.provider/primary:Documents", location.id)
                 assertEquals("Documents", location.name)
@@ -1189,19 +1189,20 @@ class StorageLocationProviderTest {
                 val result = provider.getAllLocations()
 
                 // Assert — builtins come first
-                assertEquals(5, result.size)
+                assertEquals(6, result.size)
                 assertTrue(result[0].isBuiltin)
                 assertTrue(result[1].isBuiltin)
                 assertTrue(result[2].isBuiltin)
                 assertTrue(result[3].isBuiltin)
-                assertFalse(result[4].isBuiltin)
-                assertEquals("com.test.provider/primary:Documents", result[4].id)
+                assertTrue(result[4].isBuiltin)
+                assertFalse(result[5].isBuiltin)
+                assertEquals("com.test.provider/primary:Documents", result[5].id)
 
                 unmockkStatic(Uri::class)
             }
 
         @Test
-        fun `getAllLocations returns 4 builtins when no SAF locations`() =
+        fun `getAllLocations returns five builtin locations`() =
             runTest {
                 // Arrange
                 coEvery { mockSettingsRepository.getStoredLocations() } returns emptyList()
@@ -1210,12 +1211,13 @@ class StorageLocationProviderTest {
                 val result = provider.getAllLocations()
 
                 // Assert
-                assertEquals(4, result.size)
+                assertEquals(5, result.size)
                 assertTrue(result.all { it.isBuiltin })
                 assertEquals("builtin:downloads", result[0].id)
                 assertEquals("builtin:pictures", result[1].id)
                 assertEquals("builtin:movies", result[2].id)
                 assertEquals("builtin:music", result[3].id)
+                assertEquals("builtin:dcim", result[4].id)
             }
 
         @Test
@@ -1311,43 +1313,7 @@ class StorageLocationProviderTest {
             }
 
         @Test
-        fun `isAllFilesMode returns false when permission not granted`() =
-            runTest {
-                // Arrange — pictures has readMediaPermission
-                every { mockPermissionChecker.hasPermission(any()) } returns false
-
-                // Act
-                val result = provider.isAllFilesMode("builtin:pictures")
-
-                // Assert
-                assertFalse(result)
-            }
-
-        @Test
-        fun `isAllFilesMode returns true when permission granted`() =
-            runTest {
-                // Arrange
-                every {
-                    mockPermissionChecker.hasPermission(android.Manifest.permission.READ_MEDIA_IMAGES)
-                } returns true
-
-                // Act
-                val result = provider.isAllFilesMode("builtin:pictures")
-
-                // Assert
-                assertTrue(result)
-            }
-
-        @Test
-        fun `isAllFilesMode returns false for downloads`() =
-            runTest {
-                // Downloads has no readMediaPermission
-                val result = provider.isAllFilesMode("builtin:downloads")
-                assertFalse(result)
-            }
-
-        @Test
-        fun `builtin name shows Only owned files when permission not granted`() =
+        fun `builtin name is Only owned files when no permission granted`() =
             runTest {
                 // Arrange
                 coEvery { mockSettingsRepository.getStoredLocations() } returns emptyList()
@@ -1359,13 +1325,34 @@ class StorageLocationProviderTest {
                 // Assert
                 val pictures = result.find { it.id == "builtin:pictures" }
                 assertNotNull(pictures)
-                assertTrue(pictures!!.name.contains("Only owned files"))
+                assertEquals("Pictures - Only owned files", pictures!!.name)
             }
 
         @Test
-        fun `builtin name shows All files when permission granted`() =
+        fun `builtin name is All files when all permissions granted`() =
             runTest {
                 // Arrange
+                coEvery { mockSettingsRepository.getStoredLocations() } returns emptyList()
+                every {
+                    mockPermissionChecker.hasPermission(android.Manifest.permission.READ_MEDIA_IMAGES)
+                } returns true
+                every {
+                    mockPermissionChecker.hasPermission(android.Manifest.permission.READ_MEDIA_VIDEO)
+                } returns true
+
+                // Act
+                val result = provider.getAllLocations()
+
+                // Assert
+                val pictures = result.find { it.id == "builtin:pictures" }
+                assertNotNull(pictures)
+                assertEquals("Pictures - All files", pictures!!.name)
+            }
+
+        @Test
+        fun `builtin name enumerates types on partial grant`() =
+            runTest {
+                // Arrange — images granted, videos not
                 coEvery { mockSettingsRepository.getStoredLocations() } returns emptyList()
                 every {
                     mockPermissionChecker.hasPermission(android.Manifest.permission.READ_MEDIA_IMAGES)
@@ -1377,7 +1364,39 @@ class StorageLocationProviderTest {
                 // Assert
                 val pictures = result.find { it.id == "builtin:pictures" }
                 assertNotNull(pictures)
-                assertTrue(pictures!!.name.contains("All files"))
+                assertEquals("Pictures - All images, owned videos", pictures!!.name)
+            }
+
+        @Test
+        fun `downloads name is always Only owned files`() =
+            runTest {
+                // Arrange — even with every permission granted
+                coEvery { mockSettingsRepository.getStoredLocations() } returns emptyList()
+                every { mockPermissionChecker.hasPermission(any()) } returns true
+
+                // Act
+                val result = provider.getAllLocations()
+
+                // Assert
+                val downloads = result.find { it.id == "builtin:downloads" }
+                assertNotNull(downloads)
+                assertEquals("Downloads - Only owned files", downloads!!.name)
+            }
+
+        @Test
+        fun `dcim location present with Camera display base`() =
+            runTest {
+                // Arrange
+                coEvery { mockSettingsRepository.getStoredLocations() } returns emptyList()
+
+                // Act
+                val result = provider.getAllLocations()
+
+                // Assert
+                val dcim = result.find { it.id == "builtin:dcim" }
+                assertNotNull(dcim)
+                assertTrue(dcim!!.name.startsWith("Camera (DCIM)"))
+                assertEquals("/DCIM", dcim.path)
             }
 
         @Test

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -2693,7 +2693,7 @@ Captures a photo from the specified camera and saves it to a storage location. R
 
 **Error Cases** (returned as `CallToolResult(isError = true)`):
 - **Invalid params**: Missing `camera_id`, `location_id`, or `path`; invalid resolution format; quality out of range; invalid flash mode
-- **Invalid params**: File MIME type not accepted by the built-in storage location (e.g. writing a text file to `builtin:pictures`; error lists the accepted types)
+- **Invalid params**: File MIME type not accepted by the built-in storage location (e.g. saving a photo to `builtin:music`; error lists the accepted types)
 - **Permission denied**: CAMERA permission not granted; storage location not authorized; write not permitted
 - **Action failed**: Camera not found, capture failed
 
@@ -2769,7 +2769,7 @@ Records a video from the specified camera and saves it to a storage location. Ma
 
 **Error Cases** (returned as `CallToolResult(isError = true)`):
 - **Invalid params**: Missing `camera_id`, `location_id`, `path`, or `duration`; duration out of range (1-30); invalid resolution format; invalid flash mode
-- **Invalid params**: File MIME type not accepted by the built-in storage location (e.g. writing a text file to `builtin:pictures`; error lists the accepted types)
+- **Invalid params**: File MIME type not accepted by the built-in storage location (e.g. saving a video to `builtin:music`; error lists the accepted types)
 - **Permission denied**: CAMERA permission not granted; RECORD_AUDIO permission not granted (when audio=true); storage location not authorized; write not permitted
 - **Action failed**: Camera not found, recording failed
 

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -1798,7 +1798,16 @@ File operations on user-added storage locations. Storage locations must be added
 
 ### `android_list_storage_locations`
 
-Lists user-added storage locations with their metadata. Each location represents a directory the user granted access to via the app settings. Use the location ID from this list for all file operations.
+Lists all available storage locations: built-in MediaStore locations (always present, no setup required) and user-added locations granted via the app settings. Use the location ID from this list for all file operations. The `name` of a built-in location reflects the current read-access level per media type, e.g. `"Pictures - All files"`, `"Pictures - Only owned files"`, or `"Pictures - All images, owned videos"` when permissions are partially granted.
+
+**Built-in locations**:
+| ID | Directory | Content types | "All files" permission(s) |
+|----|-----------|---------------|---------------------------|
+| `builtin:downloads` | `Download/` | any (owned files only) | — |
+| `builtin:pictures` | `Pictures/` | images, videos | `READ_MEDIA_IMAGES`, `READ_MEDIA_VIDEO` |
+| `builtin:movies` | `Movies/` | videos | `READ_MEDIA_VIDEO` |
+| `builtin:music` | `Music/` | audio | `READ_MEDIA_AUDIO` |
+| `builtin:dcim` | `DCIM/` | images, videos (camera roll) | `READ_MEDIA_IMAGES`, `READ_MEDIA_VIDEO` |
 
 **Input Schema**:
 ```json
@@ -2018,6 +2027,7 @@ Writes text content to a file. Creates the file if it doesn't exist, creates par
 
 **Error Cases** (returned as `CallToolResult(isError = true)`):
 - **Invalid params**: Missing `location_id`, `path`, or `content`
+- **Invalid params**: File MIME type not accepted by the built-in storage location (e.g. writing a text file to `builtin:pictures`; error lists the accepted types)
 - **Permission denied**: Write not allowed
 - **Action failed**: Storage location not found, content exceeds file size limit, write operation failed
 
@@ -2190,6 +2200,7 @@ Downloads a file from a URL and saves it to a storage location.
 
 **Error Cases** (returned as `CallToolResult(isError = true)`):
 - **Invalid params**: Missing `location_id`, `path`, or `url`; invalid URL format
+- **Invalid params**: File MIME type not accepted by the built-in storage location (e.g. writing a text file to `builtin:pictures`; error lists the accepted types)
 - **Permission denied**: Write not allowed
 - **Action failed**: Storage location not found, download failed (network error, timeout, HTTP error status), file exceeds size limit, HTTP not allowed, unverified HTTPS not allowed
 
@@ -2682,6 +2693,7 @@ Captures a photo from the specified camera and saves it to a storage location. R
 
 **Error Cases** (returned as `CallToolResult(isError = true)`):
 - **Invalid params**: Missing `camera_id`, `location_id`, or `path`; invalid resolution format; quality out of range; invalid flash mode
+- **Invalid params**: File MIME type not accepted by the built-in storage location (e.g. writing a text file to `builtin:pictures`; error lists the accepted types)
 - **Permission denied**: CAMERA permission not granted; storage location not authorized; write not permitted
 - **Action failed**: Camera not found, capture failed
 
@@ -2757,6 +2769,7 @@ Records a video from the specified camera and saves it to a storage location. Ma
 
 **Error Cases** (returned as `CallToolResult(isError = true)`):
 - **Invalid params**: Missing `camera_id`, `location_id`, `path`, or `duration`; duration out of range (1-30); invalid resolution format; invalid flash mode
+- **Invalid params**: File MIME type not accepted by the built-in storage location (e.g. writing a text file to `builtin:pictures`; error lists the accepted types)
 - **Permission denied**: CAMERA permission not granted; RECORD_AUDIO permission not granted (when audio=true); storage location not authorized; write not permitted
 - **Action failed**: Camera not found, recording failed
 

--- a/docs/plans/61_mediastore_list_path_and_dcim_coverage_20260814191457.md
+++ b/docs/plans/61_mediastore_list_path_and_dcim_coverage_20260814191457.md
@@ -1,0 +1,541 @@
+<!-- SACRED DOCUMENT — DO NOT MODIFY except for checkmarks ([ ] → [x]) and review findings. -->
+<!-- You MUST NEVER alter, revert, or delete files outside the scope of this plan. -->
+<!-- Plans in docs/plans/ are PERMANENT artifacts. There are ZERO exceptions. -->
+
+# Plan 61 — Fix MediaStore list_files path filtering (#154) and DCIM/multi-collection coverage (#155)
+
+**Issues**: [#154](https://github.com/danielealbano/android-remote-control-mcp/issues/154), [#155](https://github.com/danielealbano/android-remote-control-mcp/issues/155)
+**Branch**: `fix/mediastore-list-path-and-dcim-coverage` (from latest `main`). PR closes both issues.
+
+**Agreed decisions (MUST NOT deviate)**:
+- Separate builtin location per physical top-level directory; NO unified location.
+- New `builtin:dcim` backed by Images + Video collections; `builtin:pictures` extended to Images + Video.
+- Writes/creates routed by MIME type; MIME validation is UNIFORM across all builtin locations (Downloads accepts any type). Rejection error is `McpToolException.InvalidParams` listing accepted type labels.
+- Read/delete/append/replace resolve files across the location's collections in declaration order (Images before Video).
+- All-files visibility is per collection (its own `READ_MEDIA_*` permission). Partial grants degrade gracefully.
+- Display names enumerate types on partial grant: `"<Base> - All files"` (all granted), `"<Base> - Only owned files"` (none granted or no permissioned collection), `"<Base> - All <granted labels>, owned <ungranted labels>"` (partial). DCIM base name is `"Camera (DCIM)"`.
+- `Recordings/` coverage is OUT OF SCOPE (issue #156, separate PR).
+
+---
+
+## User Story 1 — Fix `list_files` directory path filtering (#154)
+
+Why: `listFiles` reuses `buildRelativePathForDir` (a file-path helper that drops the last segment), so the `path` parameter is ignored for single-segment paths and off-by-one for deeper paths. The `LIKE` argument is also unescaped (`%`/`_` act as wildcards).
+
+Acceptance criteria:
+- [ ] `listFiles` queries `RELATIVE_PATH LIKE '<base><full path>/%' ESCAPE '\'` with all path segments kept.
+- [ ] `%`, `_`, and `\` in the target path are escaped in the `LIKE` argument; the trailing `%` wildcard is NOT escaped.
+- [ ] `buildRelativePathForDir` is unchanged (still correct for its file-path callers).
+
+### Task 1.1 — Listing path builder and LIKE escaping
+
+- [ ] **Action 1.1.1** — Modify `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/MediaStoreFileOperationsImpl.kt`: add the two helpers next to `buildRelativePathForDir`:
+
+```kotlin
+/**
+ * Builds the MediaStore RELATIVE_PATH for a directory itself (all segments kept).
+ * E.g., builtin=PICTURES, path="DCIM/Camera" → "Pictures/DCIM/Camera/"
+ * E.g., builtin=PICTURES, path="" → "Pictures/"
+ */
+private fun buildRelativePathForListing(
+    builtin: BuiltinStorageLocation,
+    path: String,
+): String {
+    if (path.isEmpty()) return builtin.baseRelativePath
+    val segments = path.split("/").filter { it.isNotEmpty() }
+    return "${builtin.baseRelativePath}${segments.joinToString("/")}/"
+}
+
+/** Escapes LIKE wildcards so the target path matches literally ('\' MUST be replaced first). */
+private fun escapeLikePattern(value: String): String =
+    value
+        .replace("\\", "\\\\")
+        .replace("%", "\\%")
+        .replace("_", "\\_")
+```
+
+- [ ] **Action 1.1.2** — Modify same file, `listFiles`: replace `val targetRelativePath = buildRelativePathForDir(builtin, path)` with `val targetRelativePath = buildRelativePathForListing(builtin, path)`.
+
+- [ ] **Action 1.1.3** — Modify same file, `buildListSelection` and `buildListSelectionArgs`:
+
+```kotlin
+private fun buildListSelection(isAllFiles: Boolean): String {
+    val pathFilter = "${MediaStore.MediaColumns.RELATIVE_PATH} LIKE ? ESCAPE '\\'"
+    return if (isAllFiles) {
+        pathFilter
+    } else {
+        "$pathFilter AND ${MediaStore.MediaColumns.OWNER_PACKAGE_NAME} = ?"
+    }
+}
+
+private fun buildListSelectionArgs(
+    targetRelativePath: String,
+    isAllFiles: Boolean,
+): Array<String> {
+    // LIKE pattern: match exact dir and all children; escape the literal prefix only
+    val pattern = "${escapeLikePattern(targetRelativePath)}%"
+    return if (isAllFiles) arrayOf(pattern) else arrayOf(pattern, context.packageName)
+}
+```
+
+Definition of Done:
+- [ ] All three actions applied; no other behavior of `listFiles` changed in this task.
+
+---
+
+## User Story 2 — Multi-collection builtin locations + `builtin:dcim` (#155)
+
+Why: each MediaStore collection spans multiple top-level directories and each directory (DCIM, Pictures) can hold multiple media types. One location per directory, each backed by the collections whose content can live there, makes the camera roll reachable and keeps writes routable.
+
+Acceptance criteria:
+- [ ] `builtin:dcim` exists (base `DCIM/`, Images + Video, display base `"Camera (DCIM)"`).
+- [ ] `builtin:pictures` covers Images + Video; `builtin:downloads`/`builtin:movies`/`builtin:music` behavior preserved via single-entry collection lists.
+- [ ] Listing merges rows from all collections of the location; owner filter applied per collection based on its own permission.
+- [ ] Read/bytes/delete/append/replace resolve across collections in declaration order.
+- [ ] Write/create/download route by MIME with uniform validation (`InvalidParams` on mismatch, before any network I/O for downloads).
+- [ ] Display names follow the agreed three-state enumerated scheme.
+- [ ] Settings UI grant button requests all missing `READ_MEDIA_*` permissions of the location.
+
+### Task 2.1 — Model: `MediaCollection` + `BuiltinStorageLocation` refactor
+
+- [ ] **Action 2.1.1** — Modify `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/data/model/BuiltinStorageLocation.kt`: add `MediaCollection` (same file, above the enum) and replace the enum's `displayNameOwned`/`displayNameAll`/`collectionUriProvider`/`readMediaPermission` properties with `displayBaseName` and `collections`. The companion object (`ID_PREFIX`, `fromLocationId`, `isBuiltinId`, `validatePath`, `findPathValidationError`, `CONTROL_CHAR_REGEX`) is unchanged. Remove the now-unused `collectionUri` lazy val.
+
+```kotlin
+/**
+ * A MediaStore collection backing (part of) a built-in storage location.
+ *
+ * @property readMediaPermission Runtime permission for "all files" access to this
+ *   collection's rows, or null if unavailable (owned files only).
+ * @property mimeTypePrefix MIME prefix accepted for writes routed to this collection
+ *   (e.g. "image/"), or null to accept any MIME type.
+ * @property typeLabel Human-readable plural label used in display names and error messages.
+ */
+class MediaCollection(
+    private val collectionUriProvider: () -> Uri,
+    val readMediaPermission: String?,
+    val mimeTypePrefix: String?,
+    val typeLabel: String,
+) {
+    /** MediaStore collection content URI for queries/inserts. Resolved lazily. */
+    val uri: Uri by lazy { collectionUriProvider() }
+}
+```
+
+Enum entries (declaration order of `collections` is the read-resolution and MIME-routing order):
+
+```kotlin
+DOWNLOADS(
+    locationId = "builtin:downloads",
+    displayBaseName = "Downloads",
+    baseRelativePath = "Download/",
+    collections =
+        listOf(
+            MediaCollection(
+                collectionUriProvider = { MediaStore.Downloads.EXTERNAL_CONTENT_URI },
+                readMediaPermission = null,
+                mimeTypePrefix = null,
+                typeLabel = "files",
+            ),
+        ),
+),
+PICTURES(
+    locationId = "builtin:pictures",
+    displayBaseName = "Pictures",
+    baseRelativePath = "Pictures/",
+    collections =
+        listOf(
+            MediaCollection(
+                collectionUriProvider = { MediaStore.Images.Media.EXTERNAL_CONTENT_URI },
+                readMediaPermission = android.Manifest.permission.READ_MEDIA_IMAGES,
+                mimeTypePrefix = "image/",
+                typeLabel = "images",
+            ),
+            MediaCollection(
+                collectionUriProvider = { MediaStore.Video.Media.EXTERNAL_CONTENT_URI },
+                readMediaPermission = android.Manifest.permission.READ_MEDIA_VIDEO,
+                mimeTypePrefix = "video/",
+                typeLabel = "videos",
+            ),
+        ),
+),
+MOVIES(
+    locationId = "builtin:movies",
+    displayBaseName = "Movies",
+    baseRelativePath = "Movies/",
+    collections =
+        listOf(
+            MediaCollection(
+                collectionUriProvider = { MediaStore.Video.Media.EXTERNAL_CONTENT_URI },
+                readMediaPermission = android.Manifest.permission.READ_MEDIA_VIDEO,
+                mimeTypePrefix = "video/",
+                typeLabel = "videos",
+            ),
+        ),
+),
+MUSIC(
+    locationId = "builtin:music",
+    displayBaseName = "Music",
+    baseRelativePath = "Music/",
+    collections =
+        listOf(
+            MediaCollection(
+                collectionUriProvider = { MediaStore.Audio.Media.EXTERNAL_CONTENT_URI },
+                readMediaPermission = android.Manifest.permission.READ_MEDIA_AUDIO,
+                mimeTypePrefix = "audio/",
+                typeLabel = "audio",
+            ),
+        ),
+),
+DCIM(
+    locationId = "builtin:dcim",
+    displayBaseName = "Camera (DCIM)",
+    baseRelativePath = "DCIM/",
+    collections =
+        listOf(
+            MediaCollection(
+                collectionUriProvider = { MediaStore.Images.Media.EXTERNAL_CONTENT_URI },
+                readMediaPermission = android.Manifest.permission.READ_MEDIA_IMAGES,
+                mimeTypePrefix = "image/",
+                typeLabel = "images",
+            ),
+            MediaCollection(
+                collectionUriProvider = { MediaStore.Video.Media.EXTERNAL_CONTENT_URI },
+                readMediaPermission = android.Manifest.permission.READ_MEDIA_VIDEO,
+                mimeTypePrefix = "video/",
+                typeLabel = "videos",
+            ),
+        ),
+),
+```
+
+Definition of Done:
+- [ ] Enum has 5 entries; `collectionUri`, `displayNameOwned`, `displayNameAll`, `readMediaPermission` no longer exist on the enum; KDoc updated to describe the new properties.
+
+### Task 2.2 — `MediaStoreFileOperationsImpl`: multi-collection queries and MIME routing
+
+- [ ] **Action 2.2.1** — Modify `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/MediaStoreFileOperationsImpl.kt`, constructor: add `private val permissionChecker: PermissionChecker` parameter (Hilt constructor injection; binding already exists in `AppModule`). Keep `storageLocationProvider` (still used for `isWriteAllowed`/`isDeleteAllowed`). Add `import com.danielealbano.androidremotecontrolmcp.data.model.MediaCollection` to the file's imports.
+
+- [ ] **Action 2.2.2** — Add per-collection helpers:
+
+```kotlin
+private fun hasAllFilesAccess(collection: MediaCollection): Boolean =
+    collection.readMediaPermission?.let { permissionChecker.hasPermission(it) } == true
+
+private fun selectCollectionForMimeType(
+    builtin: BuiltinStorageLocation,
+    mimeType: String,
+): MediaCollection =
+    builtin.collections.firstOrNull { collection ->
+        collection.mimeTypePrefix == null || mimeType.startsWith(collection.mimeTypePrefix)
+    } ?: throw McpToolException.InvalidParams(
+        "File type '$mimeType' is not supported by location '${builtin.locationId}'. " +
+            "Accepted types: ${builtin.collections.joinToString(", ") { it.typeLabel }}.",
+    )
+
+private fun findFileInCollection(
+    collection: MediaCollection,
+    relativePath: String,
+    displayName: String,
+    ownedOnly: Boolean,
+): Uri? {
+    val selection =
+        buildString {
+            append("${MediaStore.MediaColumns.RELATIVE_PATH} = ? AND ")
+            append("${MediaStore.MediaColumns.DISPLAY_NAME} = ?")
+            if (ownedOnly) append(" AND ${MediaStore.MediaColumns.OWNER_PACKAGE_NAME} = ?")
+        }
+    val args =
+        if (ownedOnly) {
+            arrayOf(relativePath, displayName, context.packageName)
+        } else {
+            arrayOf(relativePath, displayName)
+        }
+    return queryForUri(collection.uri, selection, args)
+}
+```
+
+- [ ] **Action 2.2.3** — Rework `listFiles`: remove the `isAllFiles = storageLocationProvider.isAllFilesMode(...)` line; wrap the query in a loop over `builtin.collections`, sharing `entries`/`seenDirs` across iterations (sort/pagination unchanged):
+
+```kotlin
+for (collection in builtin.collections) {
+    val isAllFiles = hasAllFilesAccess(collection)
+    val selection = buildListSelection(isAllFiles)
+    val selectionArgs = buildListSelectionArgs(targetRelativePath, isAllFiles)
+    context.contentResolver
+        .query(collection.uri, projection, selection, selectionArgs, null)
+        ?.use { cursor ->
+            // existing column-index lookup + processCursorRow loop, unchanged
+        }
+}
+```
+
+- [ ] **Action 2.2.4** — Replace the file-resolution helpers `findOwnedFile`/`findAnyFile`/`findFile`/`findFileOrThrow` with cross-collection versions (`processCursorRow`, `queryForUri`, `queryFileSize` unchanged):
+
+```kotlin
+private fun findOwnedFile(
+    builtin: BuiltinStorageLocation,
+    relativePath: String,
+    displayName: String,
+): Uri? =
+    builtin.collections.firstNotNullOfOrNull { collection ->
+        findFileInCollection(collection, relativePath, displayName, ownedOnly = true)
+    }
+
+private fun findFile(
+    builtin: BuiltinStorageLocation,
+    relativePath: String,
+    displayName: String,
+): Uri? =
+    builtin.collections.firstNotNullOfOrNull { collection ->
+        findFileInCollection(
+            collection,
+            relativePath,
+            displayName,
+            ownedOnly = !hasAllFilesAccess(collection),
+        )
+    }
+
+private fun findFileOrThrow(
+    builtin: BuiltinStorageLocation,
+    path: String,
+): Uri {
+    val relativePath = buildRelativePathForDir(builtin, path)
+    val displayName = extractDisplayName(path)
+    return findFile(builtin, relativePath, displayName)
+        ?: throw McpToolException.ActionFailed(
+            "File not found: $path in location '${builtin.locationId}'",
+        )
+}
+```
+
+`findFile`/`findFileOrThrow` lose the `locationId` parameter and the `suspend` modifier (no repository call remains) — update call sites in `readFile` and `readFileBytes` to `findFileOrThrow(builtin, path)`. `findOwnedFileOrThrow` keeps its signature.
+
+- [ ] **Action 2.2.5** — `writeFile`: after computing `relativePath`/`displayName`, route and use the matched collection for both the existing-file lookup and the insert:
+
+```kotlin
+val mimeType = MimeTypeUtils.guessMimeType(displayName)
+val collection = selectCollectionForMimeType(builtin, mimeType)
+val existingUri = findFileInCollection(collection, relativePath, displayName, ownedOnly = true)
+```
+
+Insert path: `MIME_TYPE` value is `mimeType`; `context.contentResolver.insert(collection.uri, values)`.
+
+- [ ] **Action 2.2.6** — `createFileUri`: route by the explicit `mimeType` parameter: `val collection = selectCollectionForMimeType(builtin, mimeType)`; existing-file lookup via `findFileInCollection(collection, relativePath, displayName, ownedOnly = true)`; insert into `collection.uri`.
+
+- [ ] **Action 2.2.7** — `downloadFromUrl`: immediately after `checkWritePermission(locationId)` and computing `relativePath`/`displayName`, add `val collection = selectCollectionForMimeType(builtin, MimeTypeUtils.guessMimeType(displayName))` (validation fails BEFORE any MediaStore insert or network connection); insert into `collection.uri`; `MIME_TYPE` value from the same guessed type.
+
+- [ ] **Action 2.2.8** — `appendFile`, `replaceInFile`, `deleteFile`: no signature changes; they keep using `findOwnedFileOrThrow`, which now resolves across collections via Action 2.2.4.
+
+Definition of Done:
+- [ ] No reference to `builtin.collectionUri` or `storageLocationProvider.isAllFilesMode` remains in `MediaStoreFileOperationsImpl`; every operation uses the multi-collection model; behavior for single-collection locations is identical except uniform MIME validation.
+
+### Task 2.3 — `StorageLocationProvider`: display naming, remove `isAllFilesMode`
+
+- [ ] **Action 2.3.1** — Modify `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/StorageLocationProvider.kt`: delete the `isAllFilesMode(locationId: String): Boolean` declaration and its KDoc (its only caller was removed in Task 2.2).
+
+- [ ] **Action 2.3.2** — Modify `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/StorageLocationProviderImpl.kt`: delete the `isAllFilesMode` override; in `buildBuiltinLocations`, replace the `allFilesMode`/`displayName` computation with `name = buildBuiltinDisplayName(entry)` and add:
+
+```kotlin
+private fun buildBuiltinDisplayName(entry: BuiltinStorageLocation): String {
+    val permissioned = entry.collections.filter { it.readMediaPermission != null }
+    if (permissioned.isEmpty()) return "${entry.displayBaseName} - Only owned files"
+    val granted =
+        permissioned.filter { collection ->
+            collection.readMediaPermission?.let(permissionChecker::hasPermission) == true
+        }
+    return when {
+        granted.size == permissioned.size -> "${entry.displayBaseName} - All files"
+        granted.isEmpty() -> "${entry.displayBaseName} - Only owned files"
+        else -> {
+            val grantedLabels = granted.joinToString(", ") { it.typeLabel }
+            val ownedLabels = (permissioned - granted.toSet()).joinToString(", ") { it.typeLabel }
+            "${entry.displayBaseName} - All $grantedLabels, owned $ownedLabels"
+        }
+    }
+}
+```
+
+Definition of Done:
+- [ ] No `isAllFilesMode` anywhere in `main` sources; naming produces the three agreed states.
+
+### Task 2.4 — Settings UI: multi-permission grant button
+
+- [ ] **Action 2.4.1** — Modify `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/settings/StorageSettingsScreen.kt`, `permissionLauncher`: change contract to `ActivityResultContracts.RequestMultiplePermissions()` (callback body unchanged: `{ _ -> viewModel.refreshStorageLocations() }`).
+
+- [ ] **Action 2.4.2** — Same file, builtin rows loop: replace the single-permission computation with:
+
+```kotlin
+builtinLocations.forEach { location ->
+    val builtin = BuiltinStorageLocation.fromLocationId(location.id)
+    val readMediaPermissions =
+        builtin?.collections?.mapNotNull { it.readMediaPermission }?.distinct().orEmpty()
+    val hasAllFiles =
+        readMediaPermissions.isNotEmpty() &&
+            readMediaPermissions.all {
+                ContextCompat.checkSelfPermission(context, it) ==
+                    PackageManager.PERMISSION_GRANTED
+            }
+    BuiltinStorageLocationRow(
+        location = location,
+        hasAllFilesPermission = hasAllFiles,
+        readMediaPermissions = readMediaPermissions,
+        onAllowWriteChange = { enabled ->
+            viewModel.updateLocationAllowWrite(location.id, enabled)
+        },
+        onAllowDeleteChange = { enabled ->
+            viewModel.updateLocationAllowDelete(location.id, enabled)
+        },
+        onRequestPermission = { permissions ->
+            permissionLauncher.launch(permissions.toTypedArray())
+        },
+    )
+}
+```
+
+- [ ] **Action 2.4.3** — Same file, `BuiltinStorageLocationRow`: change parameters `readMediaPermission: String?` → `readMediaPermissions: List<String>` and `onRequestPermission: (String) -> Unit` → `onRequestPermission: (List<String>) -> Unit`; button block becomes `if (readMediaPermissions.isNotEmpty())` with `onClick = { onRequestPermission(readMediaPermissions) }` (enabled/label logic unchanged — the button remains enabled until ALL permissions are granted, so partial grants can be completed).
+
+Definition of Done:
+- [ ] Grant button requests every missing `READ_MEDIA_*` permission of the location in one launch; single-permission locations behave as before; `builtin:dcim` row appears automatically (read-only defaults from `BuiltinPermissions()`).
+
+---
+
+## User Story 3 — Tests
+
+Why: #154 escaped because no listing test used a non-empty path; #155 needs coverage for merge, routing, and per-collection permissions.
+
+Acceptance criteria:
+- [ ] Every new/changed behavior in US1–US2 has a unit test; all existing tests updated to the new model, none deleted without replacement.
+
+### Task 3.1 — `BuiltinStorageLocationTest`
+
+**File**: `app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/data/model/BuiltinStorageLocationTest.kt`
+
+**Setup**: update existing assertions from removed properties (`displayNameOwned`/`displayNameAll`/`readMediaPermission`) to `displayBaseName`/`collections`.
+
+- [ ] | Test | Verifies |
+      |------|----------|
+      | `fromLocationId returns DCIM for builtin:dcim` | New entry resolvable |
+      | `DCIM entry has DCIM base path and Camera display name` | `baseRelativePath == "DCIM/"`, `displayBaseName == "Camera (DCIM)"` |
+      | `DCIM and PICTURES have images then videos collections` | Order Images→Video; permissions `READ_MEDIA_IMAGES`/`READ_MEDIA_VIDEO`; mime prefixes `image/`/`video/` |
+      | `DOWNLOADS collection accepts any mime and has no permission` | `mimeTypePrefix == null`, `readMediaPermission == null` |
+      | `all entries have unique locationIds` | Existing test still passes with 5 entries |
+
+### Task 3.2 — `StorageLocationProviderTest`
+
+**File**: `app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/StorageLocationProviderTest.kt`
+
+**Setup**: remove the three `isAllFilesMode` tests (method deleted); mock `PermissionChecker.hasPermission` per permission string. Update the existing assertions that break with 5 builtins and the new naming:
+- `getAllLocations returns stored locations with enriched metadata`: total count 5 → 6 (SAF entry remains last).
+- `getAllLocations returns empty list when no locations stored`: count 4 → 5.
+- `getAllLocations returns locations with null availableBytes...`: count 5 → 6.
+- `getAllLocations returns builtins before SAF locations`: size 5 → 6; builtin/SAF boundary index 4 → 5 (`result[4]` is now the DCIM builtin, `result[5]` is SAF).
+- `builtin name shows All files when permission granted`: grant BOTH `READ_MEDIA_IMAGES` and `READ_MEDIA_VIDEO` so the PICTURES name is `"Pictures - All files"` (single-permission grant is covered by the new partial-grant test below).
+
+- [ ] | Test | Verifies |
+      |------|----------|
+      | `builtin name is All files when all permissions granted` | PICTURES with both perms granted → `"Pictures - All files"` |
+      | `builtin name is Only owned files when no permission granted` | PICTURES with none → `"Pictures - Only owned files"` |
+      | `builtin name enumerates types on partial grant` | Images granted, Video not → `"Pictures - All images, owned videos"` |
+      | `downloads name is always Only owned files` | No permissioned collection → owned-only name regardless of grants |
+      | `dcim location present with Camera display base` | `getAllLocations` contains `builtin:dcim`; name starts with `"Camera (DCIM)"` |
+      | `getAllLocations returns five builtin locations` | Count updated from 4 to 5 (plus SAF entries) |
+
+### Task 3.3 — `MediaStoreFileOperationsTest`
+
+**File**: `app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/MediaStoreFileOperationsTest.kt`
+
+**Setup**: add `@MockK PermissionChecker` (default `hasPermission(any()) returns false`) and pass to constructor; add `import com.danielealbano.androidremotecontrolmcp.data.model.MediaCollection`; remove `isAllFilesMode` stubs. Replace `every { BuiltinStorageLocation.DOWNLOADS.collectionUri } returns fakeCollectionUri` with stubbing `collections`; add a helper building real `MediaCollection` instances around fake URIs:
+
+```kotlin
+private fun testCollection(
+    uri: Uri,
+    permission: String? = null,
+    mimePrefix: String? = null,
+    label: String = "files",
+) = MediaCollection({ uri }, permission, mimePrefix, label)
+```
+
+For multi-collection cases, `mockkObject(BuiltinStorageLocation.PICTURES)` with `every { BuiltinStorageLocation.PICTURES.collections } returns listOf(imagesCollection, videoCollection)` (two distinct fake URIs); capture `query(...)` selection/args per URI. Every additionally mocked enum entry (PICTURES, MUSIC) MUST be released with `unmockkObject` in `tearDown`. The existing tests `listFiles returns all files in all-files mode` AND `readFile works in all-files mode for non-owned file` (both previously driven by `isAllFilesMode` returning true) MUST be adapted to stub a collection with a `readMediaPermission` and `permissionChecker.hasPermission` returning true for it, so they keep exercising non-owned resolution (with the stub merely removed they would silently stop testing the all-files path).
+
+- [ ] Existing `listFiles`/read/write/append/replace/delete/`createFileUri`/`downloadFromUrl` tests: adapt setup only (same assertions).
+- [ ] | Test | Verifies |
+      |------|----------|
+      | `listFiles filters by single-segment path` | Captured LIKE arg == `"Download/subdir/%"` for `path="subdir"` (#154 core) |
+      | `listFiles filters by nested path` | `path="a/b"` → LIKE arg `"Download/a/b/%"` |
+      | `listFiles returns empty for non-matching directory` | Rows with `relPath` outside the target prefix are excluded by the row loop (defense in depth over the SQL filter); result empty. **Setup**: `path="subdir"`, cursor returns rows with `relPath="Download/"` and `relPath="Download/other/"` |
+      | `listFiles synthesizes directories under non-root path` | `path="a"`, row `relPath="Download/a/b/"` → dir `b`, path `builtin:downloads/a/b` |
+      | `listFiles escapes LIKE wildcards in path` | `path="My_Files"` → LIKE arg `"Download/My\_Files/%"`; selection contains `ESCAPE '\'` |
+      | `listFiles escapes percent in path` | `path="100%"` → LIKE arg `"Download/100\%/%"` |
+      | `listFiles merges rows from all collections` | PICTURES two-collection stub: file from each collection URI both present |
+      | `listFiles dedupes synthesized dirs across collections` | Same subdir from both collections appears once |
+      | `listFiles applies owner filter per collection` | Images perm granted, Video not → Images query has no `OWNER_PACKAGE_NAME`, Video query has it |
+      | `readFile resolves file from second collection` | Lookup misses Images, hits Video → content read via Video URI |
+      | `writeFile routes image mime to images collection` | `x.jpg` on PICTURES → insert on Images URI |
+      | `writeFile routes video mime to video collection` | `x.mp4` on PICTURES → insert on Video URI |
+      | `writeFile rejects unsupported mime with InvalidParams` | `x.txt` on PICTURES → `InvalidParams` listing `images, videos`; no insert |
+      | `writeFile rejects non-audio on music` | Uniform validation: `x.txt` on MUSIC (stubbed audio collection) → `InvalidParams` |
+      | `writeFile accepts any mime on downloads` | `x.txt` on DOWNLOADS → insert proceeds (null prefix) |
+      | `createFileUri routes by explicit mime type` | `mimeType="video/mp4"` on PICTURES → insert on Video URI |
+      | `downloadFromUrl rejects unsupported mime before insert` | Bad extension on PICTURES → `InvalidParams`, `insert` never called |
+      | `deleteFile resolves owned file across collections` | Owned lookup misses Images, hits Video → delete on Video-derived URI |
+
+### Task 3.4 — Integration test touch-up
+
+**File**: `app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/FileToolsIntegrationTest.kt`
+
+- [ ] Verify (and only if needed, adapt) the builtin-location tests: they mock `FileOperationProvider`/`StorageLocationProvider` interfaces directly, so no change is expected; run confirms.
+
+Definition of Done (US3):
+- [ ] All tables implemented; `FileOperationProviderTest` (routing-only, interface mocks) requires no changes — confirmed by the full suite run in US5.
+
+---
+
+## User Story 4 — Documentation (`docs/MCP_TOOLS.md`)
+
+Why: the tool docs describe only user-added locations and don't state builtin scope or MIME acceptance.
+
+Acceptance criteria:
+- [ ] Built-in locations documented with directory scope, content types, and permissions; MIME-rejection error cases documented for the affected tools.
+
+### Task 4.1 — Update tool documentation
+
+- [ ] **Action 4.1.1** — `android_list_storage_locations` section: replace the description paragraph with:
+
+> Lists all available storage locations: built-in MediaStore locations (always present, no setup required) and user-added locations granted via the app settings. Use the location ID from this list for all file operations. The `name` of a built-in location reflects the current read-access level per media type, e.g. `"Pictures - All files"`, `"Pictures - Only owned files"`, or `"Pictures - All images, owned videos"` when permissions are partially granted.
+
+and add below it:
+
+```markdown
+**Built-in locations**:
+| ID | Directory | Content types | "All files" permission(s) |
+|----|-----------|---------------|---------------------------|
+| `builtin:downloads` | `Download/` | any (owned files only) | — |
+| `builtin:pictures` | `Pictures/` | images, videos | `READ_MEDIA_IMAGES`, `READ_MEDIA_VIDEO` |
+| `builtin:movies` | `Movies/` | videos | `READ_MEDIA_VIDEO` |
+| `builtin:music` | `Music/` | audio | `READ_MEDIA_AUDIO` |
+| `builtin:dcim` | `DCIM/` | images, videos (camera roll) | `READ_MEDIA_IMAGES`, `READ_MEDIA_VIDEO` |
+```
+
+- [ ] **Action 4.1.2** — Add to the **Error Cases** lists of `android_write_file`, `android_download_from_url`, `android_save_camera_photo`, and `android_save_camera_video`:
+
+> - **Invalid params**: File MIME type not accepted by the built-in storage location (e.g. writing a text file to `builtin:pictures`; error lists the accepted types)
+
+Definition of Done:
+- [ ] Both actions applied; no Mermaid charts involved; no other doc sections touched.
+
+---
+
+## User Story 5 — Quality gates and ground-up verification
+
+Acceptance criteria:
+- [ ] Lint, full unit+integration test suite, and build pass with zero warnings/errors; entire implementation re-verified against this plan and issues #154/#155.
+
+### Task 5.1 — Quality gates
+
+- [ ] **Action 5.1.1** — `make lint 2>&1 | tee /tmp/p61-lint.log | tail -20`; fix ALL findings (no suppressions).
+- [ ] **Action 5.1.2** — `make test-unit 2>&1 | tee /tmp/p61-test-unit.log | tail -20` and `make test-integration 2>&1 | tee /tmp/p61-test-integration.log | tail -20`; fix ALL failures (including pre-existing unrelated ones per project rules). Inspect the captured logs, never re-run to grep.
+- [ ] **Action 5.1.3** — `./gradlew build 2>&1 | tee /tmp/p61-build.log | tail -30`; zero errors and zero warnings.
+
+### Task 5.2 — Double check everything implemented, from the ground up (LAST ITEM)
+
+- [ ] **Action 5.2.1** — Re-read the FULL diff (`git diff main...HEAD`) file by file and verify, from first principles: every action of this plan applied exactly as written; every acceptance criterion holds; each symptom from issues #154 and #155 is resolved by the code as written (path filtering per segment, LIKE escaping, DCIM reachable for photos AND videos, Pictures shows videos, MIME-routed writes, per-collection all-files, three-state naming, UI multi-permission grant); NO file outside this plan's scope was touched; no TODOs/placeholders/suppressions introduced; all plan checkboxes are `[x]`.

--- a/docs/plans/61_mediastore_list_path_and_dcim_coverage_20260814191457.md
+++ b/docs/plans/61_mediastore_list_path_and_dcim_coverage_20260814191457.md
@@ -404,7 +404,7 @@ Definition of Done:
 Why: #154 escaped because no listing test used a non-empty path; #155 needs coverage for merge, routing, and per-collection permissions.
 
 Acceptance criteria:
-- [ ] Every new/changed behavior in US1–US2 has a unit test; all existing tests updated to the new model, none deleted without replacement.
+- [x] Every new/changed behavior in US1–US2 has a unit test; all existing tests updated to the new model, none deleted without replacement.
 
 ### Task 3.1 — `BuiltinStorageLocationTest`
 
@@ -412,7 +412,7 @@ Acceptance criteria:
 
 **Setup**: update existing assertions from removed properties (`displayNameOwned`/`displayNameAll`/`readMediaPermission`) to `displayBaseName`/`collections`.
 
-- [ ] | Test | Verifies |
+- [x] | Test | Verifies |
       |------|----------|
       | `fromLocationId returns DCIM for builtin:dcim` | New entry resolvable |
       | `DCIM entry has DCIM base path and Camera display name` | `baseRelativePath == "DCIM/"`, `displayBaseName == "Camera (DCIM)"` |
@@ -431,7 +431,7 @@ Acceptance criteria:
 - `getAllLocations returns builtins before SAF locations`: size 5 → 6; builtin/SAF boundary index 4 → 5 (`result[4]` is now the DCIM builtin, `result[5]` is SAF).
 - `builtin name shows All files when permission granted`: grant BOTH `READ_MEDIA_IMAGES` and `READ_MEDIA_VIDEO` so the PICTURES name is `"Pictures - All files"` (single-permission grant is covered by the new partial-grant test below).
 
-- [ ] | Test | Verifies |
+- [x] | Test | Verifies |
       |------|----------|
       | `builtin name is All files when all permissions granted` | PICTURES with both perms granted → `"Pictures - All files"` |
       | `builtin name is Only owned files when no permission granted` | PICTURES with none → `"Pictures - Only owned files"` |
@@ -457,8 +457,8 @@ private fun testCollection(
 
 For multi-collection cases, `mockkObject(BuiltinStorageLocation.PICTURES)` with `every { BuiltinStorageLocation.PICTURES.collections } returns listOf(imagesCollection, videoCollection)` (two distinct fake URIs); capture `query(...)` selection/args per URI. Every additionally mocked enum entry (PICTURES, MUSIC) MUST be released with `unmockkObject` in `tearDown`. The existing tests `listFiles returns all files in all-files mode` AND `readFile works in all-files mode for non-owned file` (both previously driven by `isAllFilesMode` returning true) MUST be adapted to stub a collection with a `readMediaPermission` and `permissionChecker.hasPermission` returning true for it, so they keep exercising non-owned resolution (with the stub merely removed they would silently stop testing the all-files path).
 
-- [ ] Existing `listFiles`/read/write/append/replace/delete/`createFileUri`/`downloadFromUrl` tests: adapt setup only (same assertions).
-- [ ] | Test | Verifies |
+- [x] Existing `listFiles`/read/write/append/replace/delete/`createFileUri`/`downloadFromUrl` tests: adapt setup only (same assertions).
+- [x] | Test | Verifies |
       |------|----------|
       | `listFiles filters by single-segment path` | Captured LIKE arg == `"Download/subdir/%"` for `path="subdir"` (#154 core) |
       | `listFiles filters by nested path` | `path="a/b"` → LIKE arg `"Download/a/b/%"` |
@@ -483,10 +483,10 @@ For multi-collection cases, `mockkObject(BuiltinStorageLocation.PICTURES)` with 
 
 **File**: `app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/integration/FileToolsIntegrationTest.kt`
 
-- [ ] Verify (and only if needed, adapt) the builtin-location tests: they mock `FileOperationProvider`/`StorageLocationProvider` interfaces directly, so no change is expected; run confirms.
+- [x] Verify (and only if needed, adapt) the builtin-location tests: they mock `FileOperationProvider`/`StorageLocationProvider` interfaces directly, so no change is expected; run confirms.
 
 Definition of Done (US3):
-- [ ] All tables implemented; `FileOperationProviderTest` (routing-only, interface mocks) requires no changes — confirmed by the full suite run in US5.
+- [x] All tables implemented; `FileOperationProviderTest` (routing-only, interface mocks) requires no changes — confirmed by the full suite run in US5.
 
 ---
 

--- a/docs/plans/61_mediastore_list_path_and_dcim_coverage_20260814191457.md
+++ b/docs/plans/61_mediastore_list_path_and_dcim_coverage_20260814191457.md
@@ -528,7 +528,7 @@ Definition of Done:
 ## User Story 5 — Quality gates and ground-up verification
 
 Acceptance criteria:
-- [ ] Lint, full unit+integration test suite, and build pass with zero warnings/errors; entire implementation re-verified against this plan and issues #154/#155.
+- [x] Lint, full unit+integration test suite, and build pass with zero warnings/errors; entire implementation re-verified against this plan and issues #154/#155.
 
 ### Task 5.1 — Quality gates
 
@@ -538,4 +538,4 @@ Acceptance criteria:
 
 ### Task 5.2 — Double check everything implemented, from the ground up (LAST ITEM)
 
-- [ ] **Action 5.2.1** — Re-read the FULL diff (`git diff main...HEAD`) file by file and verify, from first principles: every action of this plan applied exactly as written; every acceptance criterion holds; each symptom from issues #154 and #155 is resolved by the code as written (path filtering per segment, LIKE escaping, DCIM reachable for photos AND videos, Pictures shows videos, MIME-routed writes, per-collection all-files, three-state naming, UI multi-permission grant); NO file outside this plan's scope was touched; no TODOs/placeholders/suppressions introduced; all plan checkboxes are `[x]`.
+- [x] **Action 5.2.1** — Re-read the FULL diff (`git diff main...HEAD`) file by file and verify, from first principles: every action of this plan applied exactly as written; every acceptance criterion holds; each symptom from issues #154 and #155 is resolved by the code as written (path filtering per segment, LIKE escaping, DCIM reachable for photos AND videos, Pictures shows videos, MIME-routed writes, per-collection all-files, three-state naming, UI multi-permission grant); NO file outside this plan's scope was touched; no TODOs/placeholders/suppressions introduced; all plan checkboxes are `[x]`.

--- a/docs/plans/61_mediastore_list_path_and_dcim_coverage_20260814191457.md
+++ b/docs/plans/61_mediastore_list_path_and_dcim_coverage_20260814191457.md
@@ -88,17 +88,17 @@ Definition of Done:
 Why: each MediaStore collection spans multiple top-level directories and each directory (DCIM, Pictures) can hold multiple media types. One location per directory, each backed by the collections whose content can live there, makes the camera roll reachable and keeps writes routable.
 
 Acceptance criteria:
-- [ ] `builtin:dcim` exists (base `DCIM/`, Images + Video, display base `"Camera (DCIM)"`).
-- [ ] `builtin:pictures` covers Images + Video; `builtin:downloads`/`builtin:movies`/`builtin:music` behavior preserved via single-entry collection lists.
-- [ ] Listing merges rows from all collections of the location; owner filter applied per collection based on its own permission.
-- [ ] Read/bytes/delete/append/replace resolve across collections in declaration order.
-- [ ] Write/create/download route by MIME with uniform validation (`InvalidParams` on mismatch, before any network I/O for downloads).
-- [ ] Display names follow the agreed three-state enumerated scheme.
-- [ ] Settings UI grant button requests all missing `READ_MEDIA_*` permissions of the location.
+- [x] `builtin:dcim` exists (base `DCIM/`, Images + Video, display base `"Camera (DCIM)"`).
+- [x] `builtin:pictures` covers Images + Video; `builtin:downloads`/`builtin:movies`/`builtin:music` behavior preserved via single-entry collection lists.
+- [x] Listing merges rows from all collections of the location; owner filter applied per collection based on its own permission.
+- [x] Read/bytes/delete/append/replace resolve across collections in declaration order.
+- [x] Write/create/download route by MIME with uniform validation (`InvalidParams` on mismatch, before any network I/O for downloads).
+- [x] Display names follow the agreed three-state enumerated scheme.
+- [x] Settings UI grant button requests all missing `READ_MEDIA_*` permissions of the location.
 
 ### Task 2.1 — Model: `MediaCollection` + `BuiltinStorageLocation` refactor
 
-- [ ] **Action 2.1.1** — Modify `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/data/model/BuiltinStorageLocation.kt`: add `MediaCollection` (same file, above the enum) and replace the enum's `displayNameOwned`/`displayNameAll`/`collectionUriProvider`/`readMediaPermission` properties with `displayBaseName` and `collections`. The companion object (`ID_PREFIX`, `fromLocationId`, `isBuiltinId`, `validatePath`, `findPathValidationError`, `CONTROL_CHAR_REGEX`) is unchanged. Remove the now-unused `collectionUri` lazy val.
+- [x] **Action 2.1.1** — Modify `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/data/model/BuiltinStorageLocation.kt`: add `MediaCollection` (same file, above the enum) and replace the enum's `displayNameOwned`/`displayNameAll`/`collectionUriProvider`/`readMediaPermission` properties with `displayBaseName` and `collections`. The companion object (`ID_PREFIX`, `fromLocationId`, `isBuiltinId`, `validatePath`, `findPathValidationError`, `CONTROL_CHAR_REGEX`) is unchanged. Remove the now-unused `collectionUri` lazy val.
 
 ```kotlin
 /**
@@ -209,13 +209,13 @@ DCIM(
 ```
 
 Definition of Done:
-- [ ] Enum has 5 entries; `collectionUri`, `displayNameOwned`, `displayNameAll`, `readMediaPermission` no longer exist on the enum; KDoc updated to describe the new properties.
+- [x] Enum has 5 entries; `collectionUri`, `displayNameOwned`, `displayNameAll`, `readMediaPermission` no longer exist on the enum; KDoc updated to describe the new properties.
 
 ### Task 2.2 — `MediaStoreFileOperationsImpl`: multi-collection queries and MIME routing
 
-- [ ] **Action 2.2.1** — Modify `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/MediaStoreFileOperationsImpl.kt`, constructor: add `private val permissionChecker: PermissionChecker` parameter (Hilt constructor injection; binding already exists in `AppModule`). Keep `storageLocationProvider` (still used for `isWriteAllowed`/`isDeleteAllowed`). Add `import com.danielealbano.androidremotecontrolmcp.data.model.MediaCollection` to the file's imports.
+- [x] **Action 2.2.1** — Modify `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/MediaStoreFileOperationsImpl.kt`, constructor: add `private val permissionChecker: PermissionChecker` parameter (Hilt constructor injection; binding already exists in `AppModule`). Keep `storageLocationProvider` (still used for `isWriteAllowed`/`isDeleteAllowed`). Add `import com.danielealbano.androidremotecontrolmcp.data.model.MediaCollection` to the file's imports.
 
-- [ ] **Action 2.2.2** — Add per-collection helpers:
+- [x] **Action 2.2.2** — Add per-collection helpers:
 
 ```kotlin
 private fun hasAllFilesAccess(collection: MediaCollection): Boolean =
@@ -254,7 +254,7 @@ private fun findFileInCollection(
 }
 ```
 
-- [ ] **Action 2.2.3** — Rework `listFiles`: remove the `isAllFiles = storageLocationProvider.isAllFilesMode(...)` line; wrap the query in a loop over `builtin.collections`, sharing `entries`/`seenDirs` across iterations (sort/pagination unchanged):
+- [x] **Action 2.2.3** — Rework `listFiles`: remove the `isAllFiles = storageLocationProvider.isAllFilesMode(...)` line; wrap the query in a loop over `builtin.collections`, sharing `entries`/`seenDirs` across iterations (sort/pagination unchanged):
 
 ```kotlin
 for (collection in builtin.collections) {
@@ -269,7 +269,7 @@ for (collection in builtin.collections) {
 }
 ```
 
-- [ ] **Action 2.2.4** — Replace the file-resolution helpers `findOwnedFile`/`findAnyFile`/`findFile`/`findFileOrThrow` with cross-collection versions (`processCursorRow`, `queryForUri`, `queryFileSize` unchanged):
+- [x] **Action 2.2.4** — Replace the file-resolution helpers `findOwnedFile`/`findAnyFile`/`findFile`/`findFileOrThrow` with cross-collection versions (`processCursorRow`, `queryForUri`, `queryFileSize` unchanged):
 
 ```kotlin
 private fun findOwnedFile(
@@ -310,7 +310,7 @@ private fun findFileOrThrow(
 
 `findFile`/`findFileOrThrow` lose the `locationId` parameter and the `suspend` modifier (no repository call remains) — update call sites in `readFile` and `readFileBytes` to `findFileOrThrow(builtin, path)`. `findOwnedFileOrThrow` keeps its signature.
 
-- [ ] **Action 2.2.5** — `writeFile`: after computing `relativePath`/`displayName`, route and use the matched collection for both the existing-file lookup and the insert:
+- [x] **Action 2.2.5** — `writeFile`: after computing `relativePath`/`displayName`, route and use the matched collection for both the existing-file lookup and the insert:
 
 ```kotlin
 val mimeType = MimeTypeUtils.guessMimeType(displayName)
@@ -320,20 +320,20 @@ val existingUri = findFileInCollection(collection, relativePath, displayName, ow
 
 Insert path: `MIME_TYPE` value is `mimeType`; `context.contentResolver.insert(collection.uri, values)`.
 
-- [ ] **Action 2.2.6** — `createFileUri`: route by the explicit `mimeType` parameter: `val collection = selectCollectionForMimeType(builtin, mimeType)`; existing-file lookup via `findFileInCollection(collection, relativePath, displayName, ownedOnly = true)`; insert into `collection.uri`.
+- [x] **Action 2.2.6** — `createFileUri`: route by the explicit `mimeType` parameter: `val collection = selectCollectionForMimeType(builtin, mimeType)`; existing-file lookup via `findFileInCollection(collection, relativePath, displayName, ownedOnly = true)`; insert into `collection.uri`.
 
-- [ ] **Action 2.2.7** — `downloadFromUrl`: immediately after `checkWritePermission(locationId)` and computing `relativePath`/`displayName`, add `val collection = selectCollectionForMimeType(builtin, MimeTypeUtils.guessMimeType(displayName))` (validation fails BEFORE any MediaStore insert or network connection); insert into `collection.uri`; `MIME_TYPE` value from the same guessed type.
+- [x] **Action 2.2.7** — `downloadFromUrl`: immediately after `checkWritePermission(locationId)` and computing `relativePath`/`displayName`, add `val collection = selectCollectionForMimeType(builtin, MimeTypeUtils.guessMimeType(displayName))` (validation fails BEFORE any MediaStore insert or network connection); insert into `collection.uri`; `MIME_TYPE` value from the same guessed type.
 
-- [ ] **Action 2.2.8** — `appendFile`, `replaceInFile`, `deleteFile`: no signature changes; they keep using `findOwnedFileOrThrow`, which now resolves across collections via Action 2.2.4.
+- [x] **Action 2.2.8** — `appendFile`, `replaceInFile`, `deleteFile`: no signature changes; they keep using `findOwnedFileOrThrow`, which now resolves across collections via Action 2.2.4.
 
 Definition of Done:
-- [ ] No reference to `builtin.collectionUri` or `storageLocationProvider.isAllFilesMode` remains in `MediaStoreFileOperationsImpl`; every operation uses the multi-collection model; behavior for single-collection locations is identical except uniform MIME validation.
+- [x] No reference to `builtin.collectionUri` or `storageLocationProvider.isAllFilesMode` remains in `MediaStoreFileOperationsImpl`; every operation uses the multi-collection model; behavior for single-collection locations is identical except uniform MIME validation.
 
 ### Task 2.3 — `StorageLocationProvider`: display naming, remove `isAllFilesMode`
 
-- [ ] **Action 2.3.1** — Modify `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/StorageLocationProvider.kt`: delete the `isAllFilesMode(locationId: String): Boolean` declaration and its KDoc (its only caller was removed in Task 2.2).
+- [x] **Action 2.3.1** — Modify `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/StorageLocationProvider.kt`: delete the `isAllFilesMode(locationId: String): Boolean` declaration and its KDoc (its only caller was removed in Task 2.2).
 
-- [ ] **Action 2.3.2** — Modify `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/StorageLocationProviderImpl.kt`: delete the `isAllFilesMode` override; in `buildBuiltinLocations`, replace the `allFilesMode`/`displayName` computation with `name = buildBuiltinDisplayName(entry)` and add:
+- [x] **Action 2.3.2** — Modify `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/StorageLocationProviderImpl.kt`: delete the `isAllFilesMode` override; in `buildBuiltinLocations`, replace the `allFilesMode`/`displayName` computation with `name = buildBuiltinDisplayName(entry)` and add:
 
 ```kotlin
 private fun buildBuiltinDisplayName(entry: BuiltinStorageLocation): String {
@@ -356,13 +356,13 @@ private fun buildBuiltinDisplayName(entry: BuiltinStorageLocation): String {
 ```
 
 Definition of Done:
-- [ ] No `isAllFilesMode` anywhere in `main` sources; naming produces the three agreed states.
+- [x] No `isAllFilesMode` anywhere in `main` sources; naming produces the three agreed states.
 
 ### Task 2.4 — Settings UI: multi-permission grant button
 
-- [ ] **Action 2.4.1** — Modify `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/settings/StorageSettingsScreen.kt`, `permissionLauncher`: change contract to `ActivityResultContracts.RequestMultiplePermissions()` (callback body unchanged: `{ _ -> viewModel.refreshStorageLocations() }`).
+- [x] **Action 2.4.1** — Modify `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/settings/StorageSettingsScreen.kt`, `permissionLauncher`: change contract to `ActivityResultContracts.RequestMultiplePermissions()` (callback body unchanged: `{ _ -> viewModel.refreshStorageLocations() }`).
 
-- [ ] **Action 2.4.2** — Same file, builtin rows loop: replace the single-permission computation with:
+- [x] **Action 2.4.2** — Same file, builtin rows loop: replace the single-permission computation with:
 
 ```kotlin
 builtinLocations.forEach { location ->
@@ -392,10 +392,10 @@ builtinLocations.forEach { location ->
 }
 ```
 
-- [ ] **Action 2.4.3** — Same file, `BuiltinStorageLocationRow`: change parameters `readMediaPermission: String?` → `readMediaPermissions: List<String>` and `onRequestPermission: (String) -> Unit` → `onRequestPermission: (List<String>) -> Unit`; button block becomes `if (readMediaPermissions.isNotEmpty())` with `onClick = { onRequestPermission(readMediaPermissions) }` (enabled/label logic unchanged — the button remains enabled until ALL permissions are granted, so partial grants can be completed).
+- [x] **Action 2.4.3** — Same file, `BuiltinStorageLocationRow`: change parameters `readMediaPermission: String?` → `readMediaPermissions: List<String>` and `onRequestPermission: (String) -> Unit` → `onRequestPermission: (List<String>) -> Unit`; button block becomes `if (readMediaPermissions.isNotEmpty())` with `onClick = { onRequestPermission(readMediaPermissions) }` (enabled/label logic unchanged — the button remains enabled until ALL permissions are granted, so partial grants can be completed).
 
 Definition of Done:
-- [ ] Grant button requests every missing `READ_MEDIA_*` permission of the location in one launch; single-permission locations behave as before; `builtin:dcim` row appears automatically (read-only defaults from `BuiltinPermissions()`).
+- [x] Grant button requests every missing `READ_MEDIA_*` permission of the location in one launch; single-permission locations behave as before; `builtin:dcim` row appears automatically (read-only defaults from `BuiltinPermissions()`).
 
 ---
 

--- a/docs/plans/61_mediastore_list_path_and_dcim_coverage_20260814191457.md
+++ b/docs/plans/61_mediastore_list_path_and_dcim_coverage_20260814191457.md
@@ -539,3 +539,10 @@ Acceptance criteria:
 ### Task 5.2 — Double check everything implemented, from the ground up (LAST ITEM)
 
 - [x] **Action 5.2.1** — Re-read the FULL diff (`git diff main...HEAD`) file by file and verify, from first principles: every action of this plan applied exactly as written; every acceptance criterion holds; each symptom from issues #154 and #155 is resolved by the code as written (path filtering per segment, LIKE escaping, DCIM reachable for photos AND videos, Pictures shows videos, MIME-routed writes, per-collection all-files, three-state naming, UI multi-permission grant); NO file outside this plan's scope was touched; no TODOs/placeholders/suppressions introduced; all plan checkboxes are `[x]`.
+
+---
+
+## Review Findings (post-implementation code review)
+
+- [x] **WARNING — `MediaStoreDownloader` had no unit tests for its core logic** (HTTP status validation, Content-Length pre-check, mid-stream limit enforcement, IS_PENDING clearing, delete-on-failure cleanup). Resolved: added `MediaStoreDownloaderTest` covering successful stream + IS_PENDING clear, non-2xx status, oversized reported Content-Length, mid-stream limit breach, unopenable destination, and generic-failure wrapping with cause propagation — each verifying the pending-entry cleanup and disconnect behavior. The new test exposed and led to fixing a connection leak introduced by the decomposition (connect() moved back to the orchestrator so a failing connect is still disconnected).
+- [x] **INFO — broad suppression cluster on `downloadToPendingUri`**. Resolved: decomposed into `prepareConnection`/`validateResponse`/`streamToDestination`/`markDownloadComplete`; only the justified `TooGenericExceptionCaught` suppression remains (cleanup-on-any-failure of the pending MediaStore entry). Also removed the stale class-level `TooGenericExceptionCaught` on `MediaStoreFileOperationsImpl` and corrected the camera-tool MIME-rejection doc examples in `MCP_TOOLS.md` to scenarios reachable by those tools.

--- a/docs/plans/61_mediastore_list_path_and_dcim_coverage_20260814191457.md
+++ b/docs/plans/61_mediastore_list_path_and_dcim_coverage_20260814191457.md
@@ -23,13 +23,13 @@
 Why: `listFiles` reuses `buildRelativePathForDir` (a file-path helper that drops the last segment), so the `path` parameter is ignored for single-segment paths and off-by-one for deeper paths. The `LIKE` argument is also unescaped (`%`/`_` act as wildcards).
 
 Acceptance criteria:
-- [ ] `listFiles` queries `RELATIVE_PATH LIKE '<base><full path>/%' ESCAPE '\'` with all path segments kept.
-- [ ] `%`, `_`, and `\` in the target path are escaped in the `LIKE` argument; the trailing `%` wildcard is NOT escaped.
-- [ ] `buildRelativePathForDir` is unchanged (still correct for its file-path callers).
+- [x] `listFiles` queries `RELATIVE_PATH LIKE '<base><full path>/%' ESCAPE '\'` with all path segments kept.
+- [x] `%`, `_`, and `\` in the target path are escaped in the `LIKE` argument; the trailing `%` wildcard is NOT escaped.
+- [x] `buildRelativePathForDir` is unchanged (still correct for its file-path callers).
 
 ### Task 1.1 — Listing path builder and LIKE escaping
 
-- [ ] **Action 1.1.1** — Modify `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/MediaStoreFileOperationsImpl.kt`: add the two helpers next to `buildRelativePathForDir`:
+- [x] **Action 1.1.1** — Modify `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/MediaStoreFileOperationsImpl.kt`: add the two helpers next to `buildRelativePathForDir`:
 
 ```kotlin
 /**
@@ -54,9 +54,9 @@ private fun escapeLikePattern(value: String): String =
         .replace("_", "\\_")
 ```
 
-- [ ] **Action 1.1.2** — Modify same file, `listFiles`: replace `val targetRelativePath = buildRelativePathForDir(builtin, path)` with `val targetRelativePath = buildRelativePathForListing(builtin, path)`.
+- [x] **Action 1.1.2** — Modify same file, `listFiles`: replace `val targetRelativePath = buildRelativePathForDir(builtin, path)` with `val targetRelativePath = buildRelativePathForListing(builtin, path)`.
 
-- [ ] **Action 1.1.3** — Modify same file, `buildListSelection` and `buildListSelectionArgs`:
+- [x] **Action 1.1.3** — Modify same file, `buildListSelection` and `buildListSelectionArgs`:
 
 ```kotlin
 private fun buildListSelection(isAllFiles: Boolean): String {
@@ -79,7 +79,7 @@ private fun buildListSelectionArgs(
 ```
 
 Definition of Done:
-- [ ] All three actions applied; no other behavior of `listFiles` changed in this task.
+- [x] All three actions applied; no other behavior of `listFiles` changed in this task.
 
 ---
 

--- a/docs/plans/61_mediastore_list_path_and_dcim_coverage_20260814191457.md
+++ b/docs/plans/61_mediastore_list_path_and_dcim_coverage_20260814191457.md
@@ -532,9 +532,9 @@ Acceptance criteria:
 
 ### Task 5.1 — Quality gates
 
-- [ ] **Action 5.1.1** — `make lint 2>&1 | tee /tmp/p61-lint.log | tail -20`; fix ALL findings (no suppressions).
-- [ ] **Action 5.1.2** — `make test-unit 2>&1 | tee /tmp/p61-test-unit.log | tail -20` and `make test-integration 2>&1 | tee /tmp/p61-test-integration.log | tail -20`; fix ALL failures (including pre-existing unrelated ones per project rules). Inspect the captured logs, never re-run to grep.
-- [ ] **Action 5.1.3** — `./gradlew build 2>&1 | tee /tmp/p61-build.log | tail -30`; zero errors and zero warnings.
+- [x] **Action 5.1.1** — `make lint 2>&1 | tee /tmp/p61-lint.log | tail -20`; fix ALL findings (no suppressions).
+- [x] **Action 5.1.2** — `make test-unit 2>&1 | tee /tmp/p61-test-unit.log | tail -20` and `make test-integration 2>&1 | tee /tmp/p61-test-integration.log | tail -20`; fix ALL failures (including pre-existing unrelated ones per project rules). Inspect the captured logs, never re-run to grep.
+- [x] **Action 5.1.3** — `./gradlew build 2>&1 | tee /tmp/p61-build.log | tail -30`; zero errors and zero warnings.
 
 ### Task 5.2 — Double check everything implemented, from the ground up (LAST ITEM)
 

--- a/docs/plans/61_mediastore_list_path_and_dcim_coverage_20260814191457.md
+++ b/docs/plans/61_mediastore_list_path_and_dcim_coverage_20260814191457.md
@@ -495,11 +495,11 @@ Definition of Done (US3):
 Why: the tool docs describe only user-added locations and don't state builtin scope or MIME acceptance.
 
 Acceptance criteria:
-- [ ] Built-in locations documented with directory scope, content types, and permissions; MIME-rejection error cases documented for the affected tools.
+- [x] Built-in locations documented with directory scope, content types, and permissions; MIME-rejection error cases documented for the affected tools.
 
 ### Task 4.1 — Update tool documentation
 
-- [ ] **Action 4.1.1** — `android_list_storage_locations` section: replace the description paragraph with:
+- [x] **Action 4.1.1** — `android_list_storage_locations` section: replace the description paragraph with:
 
 > Lists all available storage locations: built-in MediaStore locations (always present, no setup required) and user-added locations granted via the app settings. Use the location ID from this list for all file operations. The `name` of a built-in location reflects the current read-access level per media type, e.g. `"Pictures - All files"`, `"Pictures - Only owned files"`, or `"Pictures - All images, owned videos"` when permissions are partially granted.
 
@@ -516,12 +516,12 @@ and add below it:
 | `builtin:dcim` | `DCIM/` | images, videos (camera roll) | `READ_MEDIA_IMAGES`, `READ_MEDIA_VIDEO` |
 ```
 
-- [ ] **Action 4.1.2** — Add to the **Error Cases** lists of `android_write_file`, `android_download_from_url`, `android_save_camera_photo`, and `android_save_camera_video`:
+- [x] **Action 4.1.2** — Add to the **Error Cases** lists of `android_write_file`, `android_download_from_url`, `android_save_camera_photo`, and `android_save_camera_video`:
 
 > - **Invalid params**: File MIME type not accepted by the built-in storage location (e.g. writing a text file to `builtin:pictures`; error lists the accepted types)
 
 Definition of Done:
-- [ ] Both actions applied; no Mermaid charts involved; no other doc sections touched.
+- [x] Both actions applied; no Mermaid charts involved; no other doc sections touched.
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes the two MediaStore storage bugs reported against v1.11.0: `android_list_files` ignored or mis-applied its `path` parameter on built-in locations, and the camera roll (`DCIM/Camera`) was structurally unreachable because each built-in location covered only one top-level directory of its MediaStore collection. Built-in locations are now backed by all the collections whose content can live in their directory, and a new `builtin:dcim` ("Camera (DCIM)") location exposes camera photos and videos.

Closes #154
Closes #155

## Plan Reference

Implementation of Plan 61: MediaStore list path and DCIM coverage from `docs/plans/61_mediastore_list_path_and_dcim_coverage_20260814191457.md`.

## Changes

- `list_files` builds the `RELATIVE_PATH` filter from the full directory path (all segments kept) and escapes `LIKE` wildcards with an `ESCAPE` clause (#154)
- `BuiltinStorageLocation` entries now hold a list of `MediaCollection` descriptors (collection URI, read permission, MIME prefix, type label); new `builtin:dcim` entry, and `builtin:pictures` extended to Images + Video (#155)
- Listing merges rows across collections with a per-collection owner filter; read/bytes/delete/append/replace resolve files across collections in declaration order
- Writes, file-URI creation and URL downloads are routed by MIME type with uniform validation (`InvalidParams` listing accepted types; validation happens before any insert or network I/O)
- Display names reflect per-type access: "All files", "Only owned files", or enumerated partial grants (e.g. "Pictures - All images, owned videos")
- Settings UI grant button requests all missing `READ_MEDIA_*` permissions of a location in one launch
- Download streaming extracted into `MediaStoreDownloader` (class-size lint gate; behavior unchanged, original exception now chained as cause)
- `MCP_TOOLS.md` documents the built-in locations table, access-level naming, and the MIME-rejection error case

## Testing

- New unit tests: non-empty-path listing, wildcard escaping, non-matching-directory exclusion, directory synthesis under nested paths, cross-collection merge/dedupe, per-collection owner filtering, cross-collection read/delete resolution, MIME routing and rejection (pictures, music, downloads), explicit-MIME `createFileUri` routing, download rejection before insert
- New naming tests for the three access states including partial grants, plus the fifth builtin location in provider tests
- `make lint`, `make test-unit`, `make test-integration`, and `./gradlew build` all pass with zero warnings

## Checklist

- [x] All tests pass (`make test-unit`)
- [x] Lint passes (`make lint`)
- [x] Build succeeds (`make build`)
- [x] CI validated locally (`act --validate`)