### PR TITLE
Plan 62: Add builtin:recordings storage location

### DIFF
--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/data/model/BuiltinStorageLocation.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/data/model/BuiltinStorageLocation.kt
@@ -131,6 +131,20 @@ enum class BuiltinStorageLocation(
                 ),
             ),
     ),
+    RECORDINGS(
+        locationId = "builtin:recordings",
+        displayBaseName = "Recordings",
+        baseRelativePath = "Recordings/",
+        collections =
+            listOf(
+                MediaCollection(
+                    collectionUriProvider = { MediaStore.Audio.Media.EXTERNAL_CONTENT_URI },
+                    readMediaPermission = android.Manifest.permission.READ_MEDIA_AUDIO,
+                    mimeTypePrefix = "audio/",
+                    typeLabel = "audio",
+                ),
+            ),
+    ),
     ;
 
     companion object {

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/data/model/BuiltinStorageLocationTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/data/model/BuiltinStorageLocationTest.kt
@@ -45,6 +45,14 @@ class BuiltinStorageLocationTest {
         }
 
         @Test
+        fun `fromLocationId returns RECORDINGS for recordings builtin id`() {
+            assertEquals(
+                BuiltinStorageLocation.RECORDINGS,
+                BuiltinStorageLocation.fromLocationId("builtin:recordings"),
+            )
+        }
+
+        @Test
         fun `fromLocationId returns null for unknown ID`() {
             assertNull(BuiltinStorageLocation.fromLocationId("builtin:documents"))
         }
@@ -112,6 +120,23 @@ class BuiltinStorageLocationTest {
             assertNotNull(BuiltinStorageLocation.PICTURES.collections[0].readMediaPermission)
             assertNotNull(BuiltinStorageLocation.MOVIES.collections[0].readMediaPermission)
             assertNotNull(BuiltinStorageLocation.MUSIC.collections[0].readMediaPermission)
+        }
+
+        @Test
+        fun `RECORDINGS entry has Recordings base path and display name`() {
+            assertEquals("Recordings/", BuiltinStorageLocation.RECORDINGS.baseRelativePath)
+            assertEquals("Recordings", BuiltinStorageLocation.RECORDINGS.displayBaseName)
+        }
+
+        @Test
+        fun `RECORDINGS has single audio collection`() {
+            assertEquals(1, BuiltinStorageLocation.RECORDINGS.collections.size)
+            assertEquals(
+                android.Manifest.permission.READ_MEDIA_AUDIO,
+                BuiltinStorageLocation.RECORDINGS.collections[0].readMediaPermission,
+            )
+            assertEquals("audio/", BuiltinStorageLocation.RECORDINGS.collections[0].mimeTypePrefix)
+            assertEquals("audio", BuiltinStorageLocation.RECORDINGS.collections[0].typeLabel)
         }
     }
 

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/MediaStoreFileOperationsTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/MediaStoreFileOperationsTest.kt
@@ -102,6 +102,7 @@ class MediaStoreFileOperationsTest {
         unmockkObject(BuiltinStorageLocation.DOWNLOADS)
         unmockkObject(BuiltinStorageLocation.PICTURES)
         unmockkObject(BuiltinStorageLocation.MUSIC)
+        unmockkObject(BuiltinStorageLocation.RECORDINGS)
         unmockkStatic(Log::class)
         unmockkStatic(Uri::class)
     }
@@ -128,6 +129,19 @@ class MediaStoreFileOperationsTest {
                     permission = android.Manifest.permission.READ_MEDIA_VIDEO,
                     mimePrefix = "video/",
                     label = "videos",
+                ),
+            )
+    }
+
+    private fun stubRecordingsCollections() {
+        mockkObject(BuiltinStorageLocation.RECORDINGS)
+        every { BuiltinStorageLocation.RECORDINGS.collections } returns
+            listOf(
+                testCollection(
+                    fakeCollectionUri,
+                    permission = android.Manifest.permission.READ_MEDIA_AUDIO,
+                    mimePrefix = "audio/",
+                    label = "audio",
                 ),
             )
     }
@@ -339,6 +353,74 @@ class MediaStoreFileOperationsTest {
                 }
 
                 val result = operations.listFiles("builtin:downloads", "", 0, 50)
+
+                assertEquals(1, result.totalCount)
+                assertFalse(capturedSelection.orEmpty().contains("OWNER_PACKAGE_NAME"))
+            }
+
+        @Test
+        fun `listFiles lists recordings root`() =
+            runTest {
+                stubRecordingsCollections()
+                val rows =
+                    listOf(
+                        mapOf(
+                            "id" to 1L,
+                            "name" to "memo.mp3",
+                            "relPath" to "Recordings/",
+                            "size" to 4096L,
+                            "dateModified" to 1700000000L,
+                            "mimeType" to "audio/mpeg",
+                        ),
+                    )
+
+                var capturedUri: Uri? = null
+                var capturedArgs: Array<String>? = null
+                every {
+                    mockContentResolver.query(any(), any(), any(), any(), any())
+                } answers {
+                    capturedUri = arg(0)
+                    capturedArgs = arg(3)
+                    createMockCursor(rows)
+                }
+
+                val result = operations.listFiles("builtin:recordings", "", 0, 200)
+
+                assertEquals(1, result.totalCount)
+                assertEquals("memo.mp3", result.files[0].name)
+                assertEquals(fakeCollectionUri, capturedUri)
+                assertEquals("Recordings/%", capturedArgs!![0])
+            }
+
+        @Test
+        fun `listFiles returns all recordings in all-files mode`() =
+            runTest {
+                stubRecordingsCollections()
+                every {
+                    mockPermissionChecker.hasPermission(android.Manifest.permission.READ_MEDIA_AUDIO)
+                } returns true
+
+                val rows =
+                    listOf(
+                        mapOf(
+                            "id" to 1L,
+                            "name" to "other.mp3",
+                            "relPath" to "Recordings/",
+                            "size" to 100L,
+                            "dateModified" to 1700000000L,
+                            "mimeType" to "audio/mpeg",
+                        ),
+                    )
+
+                var capturedSelection: String? = null
+                every {
+                    mockContentResolver.query(any(), any(), any(), any(), any())
+                } answers {
+                    capturedSelection = arg(2)
+                    createMockCursor(rows)
+                }
+
+                val result = operations.listFiles("builtin:recordings", "", 0, 200)
 
                 assertEquals(1, result.totalCount)
                 assertFalse(capturedSelection.orEmpty().contains("OWNER_PACKAGE_NAME"))
@@ -602,6 +684,25 @@ class MediaStoreFileOperationsTest {
                 val result = operations.readFile("builtin:downloads", "test.txt", 1, 200)
 
                 assertEquals("Hello, World!\nSecond line", result.content)
+                assertEquals(2, result.totalLines)
+                assertFalse(result.hasMore)
+            }
+
+        @Test
+        fun `readFile reads owned recording content`() =
+            runTest {
+                stubRecordingsCollections()
+                stubFindOwnedFile(id = 1L, found = true)
+                stubFileSizeQuery(size = 100L)
+
+                val content = "Voice memo line one\nline two"
+                every {
+                    mockContentResolver.openInputStream(any())
+                } returns ByteArrayInputStream(content.toByteArray())
+
+                val result = operations.readFile("builtin:recordings", "memo.txt", 1, 200)
+
+                assertEquals("Voice memo line one\nline two", result.content)
                 assertEquals(2, result.totalLines)
                 assertFalse(result.hasMore)
             }
@@ -881,6 +982,37 @@ class MediaStoreFileOperationsTest {
 
                 assertTrue(exception.message!!.contains("audio"))
                 verify(exactly = 0) { mockContentResolver.insert(any(), any()) }
+            }
+
+        @Test
+        fun `writeFile rejects non-audio on recordings`() =
+            runTest {
+                stubRecordingsCollections()
+
+                val exception =
+                    assertThrows<McpToolException.InvalidParams> {
+                        operations.writeFile("builtin:recordings", "x.txt", "text")
+                    }
+
+                assertTrue(exception.message!!.contains("audio"))
+                verify(exactly = 0) { mockContentResolver.insert(any(), any()) }
+            }
+
+        @Test
+        fun `writeFile accepts audio mime on recordings`() =
+            runTest {
+                stubRecordingsCollections()
+                every {
+                    mockContentResolver.query(any(), any(), any(), any(), any())
+                } answers { createMockCursor(emptyList()) }
+                val insertedUri = mockk<Uri>(relaxed = true)
+                every { mockContentResolver.insert(any(), any()) } returns insertedUri
+                val outputStream = ByteArrayOutputStream()
+                every { mockContentResolver.openOutputStream(eq(insertedUri), eq("wt")) } returns outputStream
+
+                operations.writeFile("builtin:recordings", "memo.mp3", "aud")
+
+                verify { mockContentResolver.insert(eq(fakeCollectionUri), any()) }
             }
 
         @Test

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/StorageLocationProviderTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/StorageLocationProviderTest.kt
@@ -144,8 +144,8 @@ class StorageLocationProviderTest {
                 // Act
                 val result = provider.getAllLocations()
 
-                // Assert — 5 builtins + 1 SAF location
-                assertEquals(6, result.size)
+                // Assert — 6 builtins + 1 SAF location
+                assertEquals(7, result.size)
                 val location = result.last()
                 assertEquals("com.test.provider/primary:Documents", location.id)
                 assertEquals("Documents", location.name)
@@ -169,8 +169,8 @@ class StorageLocationProviderTest {
                 // Act
                 val result = provider.getAllLocations()
 
-                // Assert — only 5 builtins, no SAF locations
-                assertEquals(5, result.size)
+                // Assert — only 6 builtins, no SAF locations
+                assertEquals(6, result.size)
                 assertTrue(result.all { it.isBuiltin })
             }
 
@@ -210,8 +210,8 @@ class StorageLocationProviderTest {
                 // Act
                 val result = provider.getAllLocations()
 
-                // Assert — 5 builtins + 1 SAF location
-                assertEquals(6, result.size)
+                // Assert — 6 builtins + 1 SAF location
+                assertEquals(7, result.size)
                 val location = result.last()
                 assertEquals("com.test.provider/primary:Documents", location.id)
                 assertEquals("Documents", location.name)
@@ -1189,20 +1189,21 @@ class StorageLocationProviderTest {
                 val result = provider.getAllLocations()
 
                 // Assert — builtins come first
-                assertEquals(6, result.size)
+                assertEquals(7, result.size)
                 assertTrue(result[0].isBuiltin)
                 assertTrue(result[1].isBuiltin)
                 assertTrue(result[2].isBuiltin)
                 assertTrue(result[3].isBuiltin)
                 assertTrue(result[4].isBuiltin)
-                assertFalse(result[5].isBuiltin)
-                assertEquals("com.test.provider/primary:Documents", result[5].id)
+                assertTrue(result[5].isBuiltin)
+                assertFalse(result[6].isBuiltin)
+                assertEquals("com.test.provider/primary:Documents", result[6].id)
 
                 unmockkStatic(Uri::class)
             }
 
         @Test
-        fun `getAllLocations returns five builtin locations`() =
+        fun `getAllLocations returns six builtin locations`() =
             runTest {
                 // Arrange
                 coEvery { mockSettingsRepository.getStoredLocations() } returns emptyList()
@@ -1211,13 +1212,14 @@ class StorageLocationProviderTest {
                 val result = provider.getAllLocations()
 
                 // Assert
-                assertEquals(5, result.size)
+                assertEquals(6, result.size)
                 assertTrue(result.all { it.isBuiltin })
                 assertEquals("builtin:downloads", result[0].id)
                 assertEquals("builtin:pictures", result[1].id)
                 assertEquals("builtin:movies", result[2].id)
                 assertEquals("builtin:music", result[3].id)
                 assertEquals("builtin:dcim", result[4].id)
+                assertEquals("builtin:recordings", result[5].id)
             }
 
         @Test
@@ -1397,6 +1399,55 @@ class StorageLocationProviderTest {
                 assertNotNull(dcim)
                 assertTrue(dcim!!.name.startsWith("Camera (DCIM)"))
                 assertEquals("/DCIM", dcim.path)
+            }
+
+        @Test
+        fun `recordings name is Only owned files when audio not granted`() =
+            runTest {
+                // Arrange
+                coEvery { mockSettingsRepository.getStoredLocations() } returns emptyList()
+                every { mockPermissionChecker.hasPermission(any()) } returns false
+
+                // Act
+                val result = provider.getAllLocations()
+
+                // Assert
+                val recordings = result.find { it.id == "builtin:recordings" }
+                assertNotNull(recordings)
+                assertEquals("Recordings - Only owned files", recordings!!.name)
+            }
+
+        @Test
+        fun `recordings name is All files when audio granted`() =
+            runTest {
+                // Arrange
+                coEvery { mockSettingsRepository.getStoredLocations() } returns emptyList()
+                every {
+                    mockPermissionChecker.hasPermission(android.Manifest.permission.READ_MEDIA_AUDIO)
+                } returns true
+
+                // Act
+                val result = provider.getAllLocations()
+
+                // Assert
+                val recordings = result.find { it.id == "builtin:recordings" }
+                assertNotNull(recordings)
+                assertEquals("Recordings - All files", recordings!!.name)
+            }
+
+        @Test
+        fun `recordings location present with Recordings path`() =
+            runTest {
+                // Arrange
+                coEvery { mockSettingsRepository.getStoredLocations() } returns emptyList()
+
+                // Act
+                val result = provider.getAllLocations()
+
+                // Assert
+                val recordings = result.find { it.id == "builtin:recordings" }
+                assertNotNull(recordings)
+                assertEquals("/Recordings", recordings!!.path)
             }
 
         @Test

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -1808,6 +1808,7 @@ Lists all available storage locations: built-in MediaStore locations (always pre
 | `builtin:movies` | `Movies/` | videos | `READ_MEDIA_VIDEO` |
 | `builtin:music` | `Music/` | audio | `READ_MEDIA_AUDIO` |
 | `builtin:dcim` | `DCIM/` | images, videos (camera roll) | `READ_MEDIA_IMAGES`, `READ_MEDIA_VIDEO` |
+| `builtin:recordings` | `Recordings/` | audio | `READ_MEDIA_AUDIO` |
 
 **Input Schema**:
 ```json

--- a/docs/plans/62_builtin_recordings_storage_location_20260814214908.md
+++ b/docs/plans/62_builtin_recordings_storage_location_20260814214908.md
@@ -1,0 +1,150 @@
+<!-- SACRED DOCUMENT — DO NOT MODIFY except for checkmarks ([ ] → [x]) and review findings. -->
+<!-- You MUST NEVER alter, revert, or delete files outside the scope of this plan. -->
+<!-- Plans in docs/plans/ are PERMANENT artifacts. There are ZERO exceptions. -->
+
+# Plan 62 — Add `builtin:recordings` storage location
+
+**Issue**: #156. The Audio collection spans `Music/`, `Podcasts/`, `Ringtones/`, `Alarms/`, `Notifications/`, and `Recordings/` (API 31+), but `builtin:music` is scoped to `Music/` only. Voice recordings land in `Recordings/` and are invisible to the builtin locations.
+
+**Scope decision (user-confirmed)**: `Recordings/` only. The remaining Audio directories (`Podcasts/`, `Ringtones/`, `Alarms/`, `Notifications/`) are NOT added.
+
+**Mechanism**: builds on the multi-collection location mechanism from #155 (PR #157). All consumers (`StorageLocationProviderImpl`, `MediaStoreFileOperationsImpl`, `FileOperationProviderImpl`, `StorageSettingsScreen`, DataStore builtin toggles) are generic over `BuiltinStorageLocation.entries` — the ONLY production-code change is one enum entry. `READ_MEDIA_AUDIO` is already declared in the manifest. `minSdk = 33` satisfies the API 31+ requirement for `Recordings/` as an Audio primary directory; MediaStore itself validates the primary directory on insert, so no extra validation code is needed.
+
+---
+
+## User Story 1: Add `RECORDINGS` builtin location
+
+Why: make `Recordings/` audio visible/writable through the builtin MediaStore locations. Appended after `DCIM` so existing entry ordering (and index-based assertions) stay stable.
+
+**Acceptance criteria**:
+- [x] `BuiltinStorageLocation.fromLocationId("builtin:recordings")` resolves to `RECORDINGS`
+- [x] `getAllLocations()` returns 6 builtin locations, `builtin:recordings` at index 5, before SAF locations
+- [x] Display name follows the existing pattern: "Recordings - Only owned files" without `READ_MEDIA_AUDIO`, "Recordings - All files" with it (single collection — no partial-grant variant possible)
+- [x] Writes through `builtin:recordings` accept only `audio/*` MIME types; other MIME types rejected with `InvalidParams` listing "audio"
+
+### Task 1.1: Add enum entry
+
+**Action 1.1.1** — Modify `app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/data/model/BuiltinStorageLocation.kt`: append `RECORDINGS` entry after `DCIM` (before the `;`):
+
+```kotlin
+    RECORDINGS(
+        locationId = "builtin:recordings",
+        displayBaseName = "Recordings",
+        baseRelativePath = "Recordings/",
+        collections =
+            listOf(
+                MediaCollection(
+                    collectionUriProvider = { MediaStore.Audio.Media.EXTERNAL_CONTENT_URI },
+                    readMediaPermission = android.Manifest.permission.READ_MEDIA_AUDIO,
+                    mimeTypePrefix = "audio/",
+                    typeLabel = "audio",
+                ),
+            ),
+    ),
+```
+
+**Definition of Done**:
+- [x] `RECORDINGS` is the last enum entry, after `DCIM`
+- [x] No other production code modified
+
+### Task 1.2: Model tests
+
+**File**: `app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/data/model/BuiltinStorageLocationTest.kt` (modify)
+
+| Test | Verifies | Nested class |
+|------|----------|--------------|
+| `fromLocationId returns RECORDINGS for recordings builtin id` | `fromLocationId("builtin:recordings")` == `RECORDINGS` | `FromLocationIdTest` |
+| `RECORDINGS entry has Recordings base path and display name` | `baseRelativePath` == `"Recordings/"`, `displayBaseName` == `"Recordings"` | `CollectionsTest` |
+| `RECORDINGS has single audio collection` | `collections.size` == 1; `collections[0]`: `readMediaPermission` == `READ_MEDIA_AUDIO`, `mimeTypePrefix` == `"audio/"`, `typeLabel` == `"audio"` | `CollectionsTest` |
+
+**Definition of Done**:
+- [x] 3 new tests added in the existing nested classes, following existing assertion style
+
+### Task 1.3: Provider tests
+
+**File**: `app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/StorageLocationProviderTest.kt` (modify)
+
+Update existing assertions (builtins count 5 → 6):
+
+| Location | Change |
+|----------|--------|
+| `getAllLocations returns stored locations with enriched metadata` (assert at former line 148) | `assertEquals(6, result.size)` → `assertEquals(7, result.size)`; comment "5 builtins + 1 SAF location" → "6 builtins + 1 SAF location" |
+| `getAllLocations returns empty list when no locations stored` (former line 173) | `assertEquals(5, ...)` → `assertEquals(6, ...)`; comment "only 5 builtins" → "only 6 builtins" |
+| `getAllLocations returns locations with null availableBytes when queryAvailableBytes fails` (former line 214) | `assertEquals(6, result.size)` → `assertEquals(7, result.size)`; comment → "6 builtins + 1 SAF location" |
+| `getAllLocations returns builtins before SAF locations` (former line 1192) | `assertEquals(6, ...)` → `assertEquals(7, ...)`; add `assertTrue(result[5].isBuiltin)`; SAF assertions shift `result[5]` → `result[6]` |
+| `getAllLocations returns five builtin locations` (former line 1205) | Rename to `getAllLocations returns six builtin locations`; `assertEquals(5, ...)` → `assertEquals(6, ...)`; add `assertEquals("builtin:recordings", result[5].id)` |
+
+New tests (same nested class as the existing builtin naming tests; same arrange pattern — `mockSettingsRepository.getStoredLocations()` returns emptyList, `mockPermissionChecker` stubs):
+
+| Test | Verifies | Setup |
+|------|----------|-------|
+| `recordings name is Only owned files when audio not granted` | `result.find { it.id == "builtin:recordings" }!!.name` == `"Recordings - Only owned files"` | `hasPermission(any())` returns false |
+| `recordings name is All files when audio granted` | name == `"Recordings - All files"` | `hasPermission(READ_MEDIA_AUDIO)` returns true |
+| `recordings location present with Recordings path` | location found; `path` == `"/Recordings"` | mirror of `dcim location present with Camera display base` |
+
+**Definition of Done**:
+- [x] All 5 existing assertion groups updated, 3 new tests added
+
+### Task 1.4: File-operations tests
+
+**File**: `app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/MediaStoreFileOperationsTest.kt` (modify)
+
+Setup: stub `RECORDINGS` via the existing pattern — `mockkObject(BuiltinStorageLocation.RECORDINGS)` + `every { ...collections } returns listOf(testCollection(fakeCollectionUri, permission = READ_MEDIA_AUDIO, mimePrefix = "audio/", label = "audio"))`. Add `unmockkObject(BuiltinStorageLocation.RECORDINGS)` to `tearDown()`.
+
+| Test | Verifies | Setup |
+|------|----------|-------|
+| `writeFile rejects non-audio on recordings` | `writeFile("builtin:recordings", "x.txt", "text")` throws `InvalidParams`, message contains "audio", no insert | mirror of `writeFile rejects non-audio on music` |
+| `writeFile accepts audio mime on recordings` | write of an `.mp3` file inserts into the stubbed audio collection URI | mirror of `writeFile routes image mime to images collection`, single collection |
+| `listFiles lists recordings root` | `listFiles("builtin:recordings", "", 0, 200)` queries the stubbed audio collection and returns rows; RELATIVE_PATH filter arg is `"Recordings/%"` | cursor rows with `RELATIVE_PATH = "Recordings/"`; owner filter active (`hasPermission` false by default) |
+| `listFiles returns all recordings in all-files mode` | with `READ_MEDIA_AUDIO` granted, non-owned rows are returned (no owner filter) | `hasPermission(READ_MEDIA_AUDIO)` returns true; mirror of `listFiles returns all files in all-files mode` |
+| `readFile reads owned recording content` | `readFile("builtin:recordings", "memo.txt", 1, 200)` returns the stubbed content | mirror of `readFile reads owned file content` (`stubFindOwnedFile` + `stubFileSizeQuery` are URI-agnostic and work with the `RECORDINGS` stub) |
+
+**Definition of Done**:
+- [x] 5 new tests added, `tearDown()` unmocks `RECORDINGS`
+
+---
+
+## User Story 2: Document `builtin:recordings`
+
+Why: `docs/MCP_TOOLS.md` publishes the builtin locations table used by MCP clients.
+
+**Acceptance criteria**:
+- [x] Built-in locations table lists `builtin:recordings`
+
+### Task 2.1: Update MCP_TOOLS.md
+
+**Action 2.1.1** — Modify `docs/MCP_TOOLS.md`: in the `android_list_storage_locations` "Built-in locations" table, append after the `builtin:dcim` row:
+
+```markdown
+| `builtin:recordings` | `Recordings/` | audio | `READ_MEDIA_AUDIO` |
+```
+
+No other documentation changes — the MIME-rejection error bullets on write/download/camera tools are already generic.
+
+**Definition of Done**:
+- [x] Row added; table renders with consistent columns
+
+---
+
+## User Story 3: Final verification — ground-up double check
+
+Why: mandatory last step; quality gates run only here (never during implementation).
+
+**Acceptance criteria**:
+- [x] Every action of this plan re-verified against the actual code from the ground up
+- [x] All quality gates pass
+
+### Task 3.1: Ground-up double check
+
+- [x] Re-read this plan from disk, action by action, and verify each change exists in the code exactly as specified (enum entry content and position, every test listed in the tables, every count-assertion update, docs table row)
+- [x] Verify NO file outside this plan's scope was modified (`git status` / `git diff --stat`)
+- [x] Verify no TODOs, placeholders, or commented-out code were introduced
+
+### Task 3.2: Quality gates
+
+- [x] `make lint` — zero warnings/errors (pipe through `tee` to `/tmp/p62-lint.log`)
+- [x] `make test-unit` — full suite passes (pipe through `tee` to `/tmp/p62-test-unit.log`)
+- [x] `./gradlew build` — builds without errors or warnings (pipe through `tee` to `/tmp/p62-build.log`)
+
+**Definition of Done**:
+- [x] All checks above pass; any failure fixed at the root cause and gates re-run


### PR DESCRIPTION
## Summary

Adds a `builtin:recordings` MediaStore storage location covering the `Recordings/` audio directory (API 31+), which `builtin:music` does not cover — voice recordings made with recorder apps were invisible to the builtin locations. Closes #156.

## Plan Reference

Implementation of Plan 62: Add `builtin:recordings` storage location from `docs/plans/62_builtin_recordings_storage_location_20260814214908.md`.

## Changes

- Add `RECORDINGS` entry to `BuiltinStorageLocation` (`builtin:recordings`, base path `Recordings/`, Audio collection with `READ_MEDIA_AUDIO`, `audio/*` write routing) — the only production-code change; all location consumers are generic over the enum
- Document `builtin:recordings` in the MCP tools built-in locations table

## Testing

- 3 model tests: location ID resolution, entry properties, audio collection permission/MIME prefix
- 3 provider tests: "Recordings - Only owned files" / "Recordings - All files" display naming, `/Recordings` path; 5 existing builtin-count assertions updated (5→6)
- 5 file-operations tests: audio-only MIME write routing (accept `.mp3`, reject non-audio with `InvalidParams`), root listing with `Recordings/%` path filter, all-files mode without owner filter, owned-file read
- `make lint`, `make test-unit` (full suite, all 11 new tests executed), and `./gradlew build` all pass with zero warnings

## Checklist

- [x] All tests pass (`make test-unit`)
- [x] Lint passes (`make lint`)
- [x] Build succeeds (`./gradlew build`)