### PR TITLE
Plan 64: E2E storage-tool tests on redroid 13 (core + edge-case suites)

### DIFF
--- a/app/src/debug/kotlin/com/danielealbano/androidremotecontrolmcp/debug/E2EConfigReceiver.kt
+++ b/app/src/debug/kotlin/com/danielealbano/androidremotecontrolmcp/debug/E2EConfigReceiver.kt
@@ -114,6 +114,7 @@ class E2EConfigReceiver : BroadcastReceiver() {
                 Log.i(TAG, "Auto-start on boot updated to $autoStart")
             }
             applyAuthFlags(intent)
+            applyDownloadSettings(intent)
             val storageLocationId = intent.getStringExtra(EXTRA_STORAGE_LOCATION_ID)
             if (!storageLocationId.isNullOrEmpty()) {
                 if (storageLocationProvider.isLocationAuthorized(storageLocationId)) {
@@ -148,6 +149,21 @@ class E2EConfigReceiver : BroadcastReceiver() {
         }
     }
 
+    private suspend fun applyDownloadSettings(intent: Intent) {
+        val downloadTimeout = intent.getIntExtra(EXTRA_DOWNLOAD_TIMEOUT_SECONDS, -1)
+        if (downloadTimeout in
+            ServerConfig.MIN_DOWNLOAD_TIMEOUT_SECONDS..ServerConfig.MAX_DOWNLOAD_TIMEOUT_SECONDS
+        ) {
+            settingsRepository.updateDownloadTimeout(downloadTimeout)
+            Log.i(TAG, "Download timeout updated to $downloadTimeout s")
+        }
+        if (intent.hasExtra(EXTRA_ALLOW_HTTP_DOWNLOADS)) {
+            val allowHttp = intent.getBooleanExtra(EXTRA_ALLOW_HTTP_DOWNLOADS, false)
+            settingsRepository.updateAllowHttpDownloads(allowHttp)
+            Log.i(TAG, "Allow HTTP downloads updated to $allowHttp")
+        }
+    }
+
     private fun handleStartServer(context: Context) {
         Log.i(TAG, "Received E2E start server broadcast")
         val intent =
@@ -171,5 +187,7 @@ class E2EConfigReceiver : BroadcastReceiver() {
         private const val EXTRA_STORAGE_LOCATION_ID = "storage_location_id"
         private const val EXTRA_STORAGE_ALLOW_WRITE = "storage_allow_write"
         private const val EXTRA_STORAGE_ALLOW_DELETE = "storage_allow_delete"
+        private const val EXTRA_DOWNLOAD_TIMEOUT_SECONDS = "download_timeout_seconds"
+        private const val EXTRA_ALLOW_HTTP_DOWNLOADS = "allow_http_downloads"
     }
 }

--- a/docs/plans/64_e2e_storage_tests_redroid13_20260815113951.md
+++ b/docs/plans/64_e2e_storage_tests_redroid13_20260815113951.md
@@ -1,0 +1,517 @@
+<!-- SACRED DOCUMENT — DO NOT MODIFY except for checkmarks ([ ] → [x]) and review findings. -->
+<!-- You MUST NEVER alter, revert, or delete files outside the scope of this plan. -->
+<!-- Plans in docs/plans/ are PERMANENT artifacts. There are ZERO exceptions. -->
+
+# Plan 64 — E2E storage-tool tests on redroid 13 (core suite + edge-case suite)
+
+**Motivation**: all three storage bugs of 2026-08-14/15 (#154 path filtering, #155 DCIM coverage, partial photo access) were invisible to CI because unit/integration tests mock MediaStore and `PermissionChecker`. The redroid E2E suite has zero storage coverage. This plan adds it against the real MediaProvider.
+
+**User decisions (confirmed)**:
+- Image stays `redroid/redroid:13.0.0-latest` (API 33). Partial-access (`READ_MEDIA_VISUAL_USER_SELECTED`) selection tests are OUT of scope (permission does not exist on API 33); the API 33 graceful-degradation behavior IS in scope.
+- Both tiers in one plan: Tier 1 core suite (tool coverage × permission states) + Tier 2 edge-case suite (adversarial fixtures, provider states, protocol boundaries, concurrency).
+- The mid-session permission-revoke lifecycle test IS included.
+
+**Key infrastructure facts (verified)**:
+- `E2EConfigReceiver` already supports `storage_location_id` + `storage_allow_write`/`storage_allow_delete` broadcast extras. This plan touches the `e2e-tests` module plus ONE debug-source-set addition (new `download_timeout_seconds` and `allow_http_downloads` extras in `E2EConfigReceiver` — required because `ServerConfig.allowHttpDownloads` defaults to `false` and `DownloadUrlValidator` rejects `http://` URLs before connecting, and because the default 60s download timeout would make the slow-endpoint test take >60s). The receiver lives in `app/src/debug` and is absent from the release APK. Main-source-set production code is untouched.
+- `AndroidContainerSetup.execAdb` is `private`; it becomes `internal` so the new storage helper can use it. App package in E2E is `com.danielealbano.androidremotecontrolmcp.gms.debug`; tool prefix `android_`; bearer token `AndroidContainerSetup.E2E_BEARER_TOKEN`; `McpClient(baseUrl, bearerToken)`; `stripUntrustedWarning()` exists for device-content responses.
+- Files seeded via adb shell are NON-OWNED (owner = media provider); files written through the app's MCP tools are OWNED. Seeded files are indexed only after an explicit media scan, and land in the MediaStore collection implied by their file extension.
+- **`builtin:downloads` is permanently owned-only** (its collection has `readMediaPermission = null`, so the owner filter always applies): seeded non-owned files under `Download/` are INVISIBLE to the app by design. Therefore ALL seeded-fixture listing/read tests use permissioned locations (`Pictures/`, `DCIM/`, `Music/`, `Recordings/`) with media extensions (`.jpg`/`.mp4`/`.mp3`/`.m4a` — content bytes are irrelevant to indexing), and `Download/` is exercised via app-OWNED write flows plus one dedicated test asserting the seeded-file invisibility itself.
+- `pm revoke` of a granted runtime permission KILLS the app process — any test revoking must restart the server and refresh the SHARED client (`SharedAndroidContainer.mcpClient` is cached; its session dies with the process, and later test classes use the cached instance).
+- `Testcontainers.exposeHostPorts` must be called BEFORE container start; `SharedAndroidContainer` gains that call so the fixture HTTP server is reachable at `http://host.testcontainers.internal:<port>`; documented fallback: the container's default-gateway IP (from `ip route` inside the container).
+- `settingsRepository.updateDownloadTimeout(seconds)` and `updateAllowHttpDownloads(enabled)` exist. Permission checks, display names, access levels, allow-toggles, and `ServerConfig` are all evaluated live per request — no server restart is needed after `pm grant` or config broadcasts (only after `pm revoke`, which kills the process).
+
+**Empirical-verification procedure — authorized deviations from "no tests during implementation"**: some mechanics can only be determined against a live redroid 13 container, and a subset of tests deliberately PIN observed platform behavior. For these, targeted single-test e2e runs DURING implementation are explicitly part of this plan's procedure (CLAUDE.md: use the sandbox to gain clarity instead of assuming). The full quality gates still run only in the final user story.
+1. Media scan: primary `content call --uri content://media/none --method scan_volume --arg external_primary`; if unavailable on redroid 13, fallback to per-file `--method scan_file --arg <abs path>`; if both fail, legacy `am broadcast -a android.intent.action.MEDIA_SCANNER_SCAN_FILE`. Whichever works first is kept in the helper with a comment naming the verified mechanism.
+2. Fixture-server reachability: primary `host.testcontainers.internal`; fallback gateway IP. Same keep-and-comment rule.
+3. Observed-behavior pinning (marked "PINNED" in the tables): implement the test with the assertion left failing-by-construction, run it once, pin the assertion to the actual redroid 13 behavior, and add a comment `// Observed redroid 13 (API 33) behavior — documents the platform, revisit on image upgrade`.
+4. MediaStore row injection (`insertPendingRow`/`insertDuplicateRow`): verify shell `content insert` against `content://media/external_primary/file` on redroid 13; if the files-table URI rejects shell inserts, use `content://media/external_primary/images/media` with an image display name instead. Whichever works is kept, the other removed.
+
+**Fixture naming constraint**: seeded names MUST NOT contain `"` or `` ` `` or `$` (the seeding helper quotes with double quotes).
+
+---
+
+## User Story 1: Storage E2E infrastructure
+
+Why: shared fixtures/permissions/scan/toggle/restart/HTTP-server plumbing used by both test classes; `execAdb` must become module-visible; the revoke flow must refresh the cached shared client so later classes stay healthy. Tasks are ordered so every cross-file CODE reference points to an EARLIER task: `FixtureHttpServer` (self-contained, owns the port constant) → `SharedAndroidContainer` (uses `FixtureHttpServer.FIXTURE_HTTP_PORT`) → `StorageE2E` (uses `SharedAndroidContainer.refreshMcpClient`).
+
+**Acceptance criteria**:
+- [x] `StorageE2E` helper object provides seeding, scanning, permission control, toggle + download-settings configuration, process-death wait, server restart with shared-client refresh, and pending/duplicate row insertion
+- [x] `FixtureHttpServer` serves 200/404/slow/truncated endpoints on the fixed exposed port
+- [x] `SharedAndroidContainer` exposes the fixture port before container start and can refresh its cached client
+- [x] `E2EConfigReceiver` gains `download_timeout_seconds` and `allow_http_downloads` extras (debug source set only)
+- [x] No main-source-set production code modified
+
+### Task 1.1: execAdb visibility
+
+**Action 1.1.1** — Modify `e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/AndroidContainerSetup.kt`: change `private fun execAdb(vararg args: String): String` to `internal fun execAdb(vararg args: String): String`. No other change.
+
+**Definition of Done**:
+- [x] Visibility changed; no callers broken
+
+### Task 1.2: Fixture HTTP server
+
+**Action 1.2.1** — Create `e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/FixtureHttpServer.kt`:
+
+```kotlin
+package com.danielealbano.androidremotecontrolmcp.e2e
+
+import com.sun.net.httpserver.HttpServer
+import java.net.InetSocketAddress
+
+/**
+ * Minimal host-side HTTP server for download_from_url E2E tests.
+ * Bound on 0.0.0.0:[FIXTURE_HTTP_PORT] (the port is exposed to the container
+ * before it starts).
+ *
+ * Endpoints:
+ * - GET /fixture.txt   -> 200, body [FIXTURE_CONTENT], Content-Type text/plain
+ * - GET /missing.txt   -> 404
+ * - GET /slow.txt      -> sleeps [SLOW_DELAY_MS], then 200 (exceeds the 10s test download timeout)
+ * - GET /truncated.txt -> declares Content-Length 1000, writes 10 bytes, closes (mid-stream cut)
+ */
+class FixtureHttpServer {
+    private var server: HttpServer? = null
+
+    fun start() {
+        val s = HttpServer.create(InetSocketAddress("0.0.0.0", FIXTURE_HTTP_PORT), 0)
+        s.createContext("/fixture.txt") { exchange ->
+            val body = FIXTURE_CONTENT.toByteArray()
+            exchange.responseHeaders.add("Content-Type", "text/plain")
+            exchange.sendResponseHeaders(200, body.size.toLong())
+            exchange.responseBody.use { it.write(body) }
+        }
+        s.createContext("/missing.txt") { exchange ->
+            exchange.sendResponseHeaders(404, -1)
+            exchange.close()
+        }
+        s.createContext("/slow.txt") { exchange ->
+            Thread.sleep(SLOW_DELAY_MS)
+            val body = "late".toByteArray()
+            exchange.sendResponseHeaders(200, body.size.toLong())
+            exchange.responseBody.use { it.write(body) }
+        }
+        s.createContext("/truncated.txt") { exchange ->
+            exchange.sendResponseHeaders(200, 1000L)
+            exchange.responseBody.write(ByteArray(10))
+            exchange.close()
+        }
+        s.start()
+        server = s
+    }
+
+    fun stop() {
+        server?.stop(0)
+        server = null
+    }
+
+    /**
+     * Base URL as reachable FROM INSIDE the container. Primary: host.testcontainers.internal.
+     * Fallback (verified empirically per the plan's procedure): the container's default
+     * gateway IP (from `ip route` run inside the container).
+     */
+    fun containerReachableBaseUrl(): String = "http://host.testcontainers.internal:$FIXTURE_HTTP_PORT"
+
+    companion object {
+        /** Fixed host port, exposed to the container by SharedAndroidContainer before start. */
+        const val FIXTURE_HTTP_PORT = 18923
+        const val FIXTURE_CONTENT = "e2e-download-fixture-content"
+        const val SLOW_DELAY_MS = 15_000L
+    }
+}
+```
+
+### Task 1.3: SharedAndroidContainer — port exposure + client refresh
+
+**Action 1.3.1** — Modify `e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/SharedAndroidContainer.kt`:
+
+1. In `ensureInitialized()`, BEFORE the container is created/started, add:
+
+```kotlin
+                org.testcontainers.Testcontainers.exposeHostPorts(FixtureHttpServer.FIXTURE_HTTP_PORT)
+```
+
+2. Add a shared-client refresh function (closes the cached client best-effort, builds and connects a fresh one, replaces the cache):
+
+```kotlin
+    /**
+     * Replaces the cached MCP client with a freshly connected one. Required after the
+     * app process is killed (e.g. by a runtime-permission revoke): the cached client's
+     * MCP session dies with the process, and later test classes read [mcpClient].
+     */
+    fun refreshMcpClient(): McpClient {
+        ensureInitialized()
+        synchronized(lock) {
+            try {
+                runBlocking { _mcpClient?.close() }
+            } catch (_: Exception) {
+                // Best-effort close of a dead session
+            }
+            val client = McpClient(mcpServerUrl, AndroidContainerSetup.E2E_BEARER_TOKEN)
+            runBlocking { client.connect() }
+            _mcpClient = client
+            return client
+        }
+    }
+```
+
+Constraint: the construction/connect call MUST mirror how `ensureInitialized()` builds the original client (adapt to the actual code; intent: identical client, fresh session).
+
+### Task 1.4: StorageE2E helper
+
+**Action 1.4.1** — Create `e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/StorageE2E.kt`:
+
+```kotlin
+package com.danielealbano.androidremotecontrolmcp.e2e
+
+import java.util.Base64
+
+/**
+ * Shared storage-E2E infrastructure: MediaStore fixture seeding, media scanning,
+ * READ_MEDIA_* permission control, builtin allow-write/allow-delete toggles,
+ * download settings, app-process lifecycle helpers, and MediaStore row injection.
+ *
+ * Files seeded via adb shell are NON-OWNED from the app's perspective; files created
+ * through the app's MCP tools are OWNED. Seeded files become visible to MediaStore
+ * only after [scanVolume]/[scanPath], in the collection implied by their extension.
+ *
+ * Fixture names MUST NOT contain double quotes, backticks, or '$' (double-quote shell quoting).
+ */
+object StorageE2E {
+    const val APP_PACKAGE = "com.danielealbano.androidremotecontrolmcp.gms.debug"
+    const val PERM_IMAGES = "android.permission.READ_MEDIA_IMAGES"
+    const val PERM_VIDEO = "android.permission.READ_MEDIA_VIDEO"
+    const val PERM_AUDIO = "android.permission.READ_MEDIA_AUDIO"
+    private const val SDCARD = "/storage/emulated/0"
+    private const val E2E_ACTION_BASE = "com.danielealbano.androidremotecontrolmcp.debug"
+    private const val E2E_CONFIG_RECEIVER =
+        "$APP_PACKAGE/com.danielealbano.androidremotecontrolmcp.debug.E2EConfigReceiver"
+
+    fun shell(cmd: String): String = AndroidContainerSetup.execAdb("shell", "sh", "-c", cmd)
+
+    fun grantMediaPermission(permission: String) {
+        AndroidContainerSetup.execAdb("shell", "pm", "grant", APP_PACKAGE, permission)
+    }
+
+    fun grantAllMediaPermissions() {
+        grantMediaPermission(PERM_IMAGES)
+        grantMediaPermission(PERM_VIDEO)
+        grantMediaPermission(PERM_AUDIO)
+    }
+
+    /**
+     * Revokes a granted runtime permission. WARNING: this KILLS the app process.
+     * Callers MUST afterwards call [waitForAppProcessDeath], then
+     * [restartServerAndRefreshClient].
+     */
+    fun revokeMediaPermission(permission: String) {
+        AndroidContainerSetup.execAdb("shell", "pm", "revoke", APP_PACKAGE, permission)
+    }
+
+    /** Seeds a file with the given text content at an /sdcard-relative path (parents created). */
+    fun seedFile(relativePath: String, content: String) {
+        val path = "$SDCARD/$relativePath"
+        val dir = path.substringBeforeLast('/')
+        val b64 = Base64.getEncoder().encodeToString(content.toByteArray())
+        shell("mkdir -p \"$dir\" && echo $b64 | base64 -d > \"$path\"")
+    }
+
+    /** Seeds [count] one-byte files named <prefix>NNN.jpg under an /sdcard-relative directory. */
+    fun seedBulk(dirRelativePath: String, count: Int, prefix: String = "bulk") {
+        val dir = "$SDCARD/$dirRelativePath"
+        val d = "\$"
+        shell(
+            "mkdir -p \"$dir\" && i=0; while [ ${d}i -lt $count ]; do " +
+                "printf x > \"$dir/$prefix${d}(printf %03d ${d}i).jpg\"; i=${d}((i+1)); done",
+        )
+    }
+
+    /** Removes a single seeded file from disk (plain rm, no recursion). */
+    fun removeFromDisk(relativePath: String) {
+        shell("rm \"$SDCARD/$relativePath\"")
+    }
+
+    /** Removes a seeded fixture directory tree. ONLY for paths created by this suite. */
+    fun removeFixtureTree(relativePath: String) {
+        require(relativePath.isNotBlank() && !relativePath.contains("..")) { "unsafe path" }
+        shell("rm -rf \"$SDCARD/$relativePath\"")
+    }
+
+    /**
+     * Triggers a MediaStore scan. Mechanism verified empirically against redroid 13
+     * per the plan's procedure (scan_volume primary; scan_file per path; legacy
+     * broadcast last). The verified mechanism is kept, the others removed.
+     */
+    fun scanVolume() {
+        AndroidContainerSetup.execAdb(
+            "shell", "content", "call", "--uri", "content://media/none",
+            "--method", "scan_volume", "--arg", "external_primary",
+        )
+    }
+
+    fun scanPath(relativePath: String) {
+        AndroidContainerSetup.execAdb(
+            "shell", "content", "call", "--uri", "content://media/none",
+            "--method", "scan_file", "--arg", "$SDCARD/$relativePath",
+        )
+    }
+
+    /** Sets builtin location allow-write/allow-delete via the E2E config broadcast. */
+    fun configureStorageLocation(locationId: String, allowWrite: Boolean, allowDelete: Boolean) {
+        AndroidContainerSetup.execAdb(
+            "shell", "am", "broadcast", "--include-stopped-packages",
+            "-a", "$E2E_ACTION_BASE.E2E_CONFIGURE",
+            "-n", E2E_CONFIG_RECEIVER,
+            "--es", "storage_location_id", locationId,
+            "--ez", "storage_allow_write", allowWrite.toString(),
+            "--ez", "storage_allow_delete", allowDelete.toString(),
+        )
+        Thread.sleep(1_000)
+    }
+
+    /** Sets download timeout + HTTP-download allowance via the E2E config broadcast. */
+    fun configureDownloadSettings(timeoutSeconds: Int, allowHttp: Boolean) {
+        AndroidContainerSetup.execAdb(
+            "shell", "am", "broadcast", "--include-stopped-packages",
+            "-a", "$E2E_ACTION_BASE.E2E_CONFIGURE",
+            "-n", E2E_CONFIG_RECEIVER,
+            "--ei", "download_timeout_seconds", timeoutSeconds.toString(),
+            "--ez", "allow_http_downloads", allowHttp.toString(),
+        )
+        Thread.sleep(1_000)
+    }
+
+    /** Inserts a MediaStore row with IS_PENDING=1 (no backing content written). */
+    fun insertPendingRow(displayName: String, relativePathWithSlash: String) {
+        AndroidContainerSetup.execAdb(
+            "shell", "content", "insert", "--uri", "content://media/external_primary/file",
+            "--bind", "_display_name:s:$displayName",
+            "--bind", "relative_path:s:$relativePathWithSlash",
+            "--bind", "is_pending:i:1",
+        )
+    }
+
+    /** Inserts a second MediaStore row with the same display name + relative path. */
+    fun insertDuplicateRow(displayName: String, relativePathWithSlash: String) {
+        AndroidContainerSetup.execAdb(
+            "shell", "content", "insert", "--uri", "content://media/external_primary/file",
+            "--bind", "_display_name:s:$displayName",
+            "--bind", "relative_path:s:$relativePathWithSlash",
+        )
+    }
+
+    /** Polls until the app process is gone (used after [revokeMediaPermission]). */
+    fun waitForAppProcessDeath(timeoutMs: Long = 15_000L) {
+        val start = System.currentTimeMillis()
+        while (System.currentTimeMillis() - start < timeoutMs) {
+            val pid = try {
+                shell("pidof $APP_PACKAGE || true")
+            } catch (_: Exception) {
+                ""
+            }
+            if (pid.isBlank()) return
+            Thread.sleep(500)
+        }
+        error("App process still alive ${timeoutMs}ms after permission revoke")
+    }
+
+    /**
+     * Restarts the MCP server and REFRESHES the shared cached client
+     * (SharedAndroidContainer.mcpClient), so both this suite and any test class
+     * running afterwards see a live session. Returns the refreshed client.
+     */
+    fun restartServerAndRefreshClient(): McpClient {
+        AndroidContainerSetup.startMcpServer()
+        AndroidContainerSetup.waitForServerReady(SharedAndroidContainer.mcpServerUrl)
+        return SharedAndroidContainer.refreshMcpClient()
+    }
+}
+```
+
+### Task 1.5: E2EConfigReceiver download-settings extras
+
+**Action 1.5.1** — Modify `app/src/debug/kotlin/com/danielealbano/androidremotecontrolmcp/debug/E2EConfigReceiver.kt` (debug source set — absent from release APK): add a private helper and call it from `handleConfigure`'s coroutine next to `applyAuthFlags(intent)` (extracted as a helper so the already-long `handleConfigure` does not grow — no lint suppression permitted):
+
+```kotlin
+    private suspend fun applyDownloadSettings(intent: Intent) {
+        val downloadTimeout = intent.getIntExtra(EXTRA_DOWNLOAD_TIMEOUT_SECONDS, -1)
+        if (downloadTimeout in
+            ServerConfig.MIN_DOWNLOAD_TIMEOUT_SECONDS..ServerConfig.MAX_DOWNLOAD_TIMEOUT_SECONDS
+        ) {
+            settingsRepository.updateDownloadTimeout(downloadTimeout)
+            Log.i(TAG, "Download timeout updated to $downloadTimeout s")
+        }
+        if (intent.hasExtra(EXTRA_ALLOW_HTTP_DOWNLOADS)) {
+            val allowHttp = intent.getBooleanExtra(EXTRA_ALLOW_HTTP_DOWNLOADS, false)
+            settingsRepository.updateAllowHttpDownloads(allowHttp)
+            Log.i(TAG, "Allow HTTP downloads updated to $allowHttp")
+        }
+    }
+```
+
+and in the companion object:
+
+```kotlin
+        private const val EXTRA_DOWNLOAD_TIMEOUT_SECONDS = "download_timeout_seconds"
+        private const val EXTRA_ALLOW_HTTP_DOWNLOADS = "allow_http_downloads"
+```
+
+**Definition of Done** (Tasks 1.2–1.5):
+- [x] All files in place; helper compiles against actual `McpClient`/`AndroidContainerSetup`/`SharedAndroidContainer` internals; port exposed before container start; receiver extras validated and applied via the extracted helper
+
+---
+
+## User Story 2: Tier 1 — core storage suite
+
+Why: end-to-end coverage of all 8 file tools against real MediaStore, in the regression classes of #154/#155/#156 and the permission/toggle matrix.
+
+**Acceptance criteria**:
+- [x] All 8 file tools exercised end-to-end at least once
+- [x] The #154 (path filter), #155 (multi-collection), #156 (recordings) regression classes each have a live-MediaStore test
+- [x] Owned-vs-non-owned filtering verified against real `OWNER_PACKAGE_NAME` values in both directions, including the `builtin:downloads` seeded-file invisibility
+- [x] Toggle gating (allow-write/allow-delete off → denied) verified
+- [x] All download edge scenarios (success, 404, refused, timeout, truncated) exercised through the fixture server
+
+### Task 2.1: E2EStorageToolsTest
+
+**File**: `e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/E2EStorageToolsTest.kt` (create; `@TestInstance(PER_CLASS)` + `@TestMethodOrder(MethodOrderer.OrderAnnotation::class)` with `@Order(n)` equal to the table row number — required because rows 12/13/16/17/18 form a mutable-file chain on `e2e-rt.txt`; uses `SharedAndroidContainer.mcpClient`; tool names prefixed `android_`; device-content responses unwrapped with `stripUntrustedWarning`)
+
+**Class setup (`@BeforeAll`)**: `grantAllMediaPermissions()`; `configureStorageLocation` allowWrite+allowDelete=true for `builtin:downloads`, `builtin:pictures`, `builtin:dcim`, `builtin:recordings`, `builtin:music` (`builtin:movies` deliberately left false for denial tests); `configureDownloadSettings(10, allowHttp = true)`; start a class-held `FixtureHttpServer` and resolve `<base>` via `containerReachableBaseUrl()` (fallback per header procedure 2); seed the core fixture tree; scan. NO server restart: granting does not kill the process, and all settings/permissions are evaluated live per request.
+
+**Core fixture tree** (all seeded = non-owned; media extensions so files land in permissioned collections — see the `builtin:downloads` fact in the header):
+
+| Path | Content |
+|------|---------|
+| `DCIM/Camera/photo1.jpg` | `"jpeg-fixture-1"` |
+| `DCIM/Camera/video1.mp4` | `"mp4-fixture-1"` |
+| `DCIM/Screenshots/shot1.png` | `"png-fixture-1"` |
+| `Pictures/Vacation/pic1.jpg` | `"jpeg-fixture-2"` |
+| `Pictures/clip.mp4` | `"mp4-fixture-2"` |
+| `Pictures/readable.jpg` | `"line one\nline two"` |
+| `Pictures/depth/notes.jpg` | `"notes"` |
+| `Pictures/bulk/bulk000..209.jpg` | 210 one-byte files via `seedBulk` |
+| `Music/Album/song.mp3` | `"mp3-fixture"` |
+| `Recordings/memo.m4a` | `"m4a-fixture"` |
+| `Download/seeded.txt` | `"invisible"` (for the owned-only invisibility test) |
+
+**Class teardown (`@AfterAll`)**: stop the `FixtureHttpServer`; `removeFixtureTree`/`removeFromDisk` for every path seeded above plus files created by write/download tests; scan; reset the five locations' toggles to false via `configureStorageLocation`; `configureDownloadSettings(60, allowHttp = false)` (restore defaults).
+
+| # | Test | Verifies |
+|---|------|----------|
+| 1 | `list_storage_locations returns six builtins with access levels` | ids in order downloads/pictures/movies/music/dcim/recordings; pictures/movies/dcim/music/recordings `access_level=="full"` + name "- All files"; downloads `owned_only` + "- Only owned files"; response text begins with the untrusted warning |
+| 2 | `dcim root synthesizes camera and screenshots directories` | dirs `Camera`, `Screenshots` present, `is_directory` true |
+| 3 | `dcim camera merges images and videos` | `photo1.jpg` AND `video1.mp4` in one listing (#155) |
+| 4 | `pictures root includes video stored under pictures` | `clip.mp4` listed (#155) |
+| 5 | `single segment path constrains listing` | `pictures` path=`Vacation` → exactly `pic1.jpg` (#154) |
+| 6 | `nested path constrains listing` | `pictures` path=`depth` → `notes.jpg` only; `pictures` root listing shows `depth` as a directory, not `notes.jpg` as a file |
+| 7 | `unknown path returns empty listing` | `dcim` path=`DoesNotExist` → `total_count==0` |
+| 8 | `recordings lists seeded audio` | `memo.m4a` listed (#156) |
+| 9 | `music lists seeded audio` | `song.mp3` under path=`Album` |
+| 10 | `read_file reads non-owned file in all-files mode` | `pictures` `readable.jpg` → content `"line one\nline two"`, 2 lines |
+| 11 | `downloads hides non-owned seeded files` | `Download/seeded.txt` (seeded + scanned) absent from `downloads` listing — live proof of the permanent owner filter |
+| 12 | `write_file then read_file round trip` | `downloads` write `e2e-rt.txt` → read back identical content (owned path) |
+| 13 | `written file appears in listing without manual scan` | `e2e-rt.txt` visible in `downloads` root listing |
+| 14 | `write_file routes image to dcim and lists it` | write `e2e-shot.jpg` to `dcim` succeeds; appears in `dcim` root listing |
+| 15 | `write_file rejects wrong mime with accepted types` | `x.txt` to `pictures` → `isError`, message lists `images, videos` |
+| 16 | `append_file appends to owned file` | append to `e2e-rt.txt` → read shows appended line |
+| 17 | `file_replace replaces text in owned file` | replace in `e2e-rt.txt` → read shows replacement |
+| 18 | `delete_file removes owned file and repeat errors not found` | delete `e2e-rt.txt` → gone from listing; second delete → `isError` "not found" (idempotent retry) |
+| 19 | `write denied when allow write disabled` | write to `builtin:movies` → `isError` permission denied |
+| 20 | `delete denied when allow delete disabled` | delete on `builtin:movies` → `isError` permission denied |
+| 21 | `delete of non-owned file reports not found` | delete seeded `Pictures/clip.mp4` → `isError` "not found" — deletes resolve OWNED files only (`findOwnedFileOrThrow`), a security property: the tool can never touch non-owned files |
+| 22 | `write_file to existing non-owned name` | write `readable.jpg` to `pictures` → PINNED (clean error, or new/auto-renamed row; no crash) |
+| 23 | `download_from_url downloads fixture file` | download `<base>/fixture.txt` to `downloads` → read back `FIXTURE_CONTENT` |
+| 24 | `download_from_url 404 returns error and leaves no file` | `<base>/missing.txt` → `isError` mentioning the HTTP failure (NOT the http-disabled gate); target name absent from listing |
+| 25 | `download_from_url connection refused returns error` | URL on an unused port of the same host → `isError`, no file |
+| 26 | `download_from_url times out on slow server` | `<base>/slow.txt` with the configured 10s timeout → `isError` within < `SLOW_DELAY_MS` + margin; no file left |
+| 27 | `download_from_url handles truncated response` | `<base>/truncated.txt` (content-length lie, mid-stream close) → PINNED (clean error, or file with observed size — no crash); server healthy afterwards |
+| 28 | `pagination returns stable non-overlapping pages` | `pictures` path=`bulk`, limit=100: pages 100/100/10; union of names == 210 seeded, no duplicates; `total_count==210` on each page; `has_more` true/true/false |
+| 29 | `pagination offset beyond end returns empty page` | offset=1000 → 0 files, `has_more==false`, `total_count==210` |
+| 30 | `limit above cap is coerced to 200` | limit=500 → exactly 200 entries, `has_more==true` |
+| 31 | `newly seeded file appears after scan` | seed `Pictures/late.jpg` + `scanPath` → visible in `pictures` root listing |
+
+**Definition of Done**:
+- [x] 31 tests implemented with `@Order` = row number; fixture-server lifecycle owned by the class; every assertion on device-content responses unwraps the untrusted warning
+
+---
+
+## User Story 3: Tier 2 — edge-case suite
+
+Why: adversarial inputs and provider states that mocks cannot reproduce; a fixture matrix auditable row by row.
+
+**Acceptance criteria**:
+- [x] Every fixture-matrix row is exercised by at least one test
+- [x] All PINNED tests carry the observed-behavior comment
+- [x] Concurrency tests use a second `McpClient` session
+- [x] The revoke lifecycle test runs LAST and leaves full grants, a healthy server, and a refreshed shared client
+
+### Task 3.1: E2EStorageEdgeCasesTest
+
+**File**: `e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/E2EStorageEdgeCasesTest.kt` (create; same conventions as Task 2.1 including `@TestMethodOrder` + `@Order` = row number — the revoke test MUST be last)
+
+**Class setup (`@BeforeAll`)**: `grantAllMediaPermissions()`; toggles allowWrite+allowDelete=true for `builtin:downloads` and `builtin:pictures`; seed the adversarial matrix; scan. NO restart needed (see header facts); uses `SharedAndroidContainer.mcpClient` (the revoke test refreshes it via `restartServerAndRefreshClient()`).
+**Class teardown (`@AfterAll`)**: re-grant all media permissions (the revoke test may leave IMAGES revoked on failure); `StorageE2E.restartServerAndRefreshClient()` — the revoke test kills the process even on success, and the SHARED cached client must be live for any later class; `removeFixtureTree("Pictures/edge")` plus owned leftovers; scan; reset toggles to false.
+
+**Adversarial fixture matrix** (all under `Pictures/edge/` — a permissioned location; `.jpg` names so rows land in the Images collection):
+
+| Row | Fixture | Purpose |
+|-----|---------|---------|
+| F1 | `a_b/f1.jpg`, `a%b/f2.jpg`, `axb/f3.jpg` | LIKE `_`/`%` escaping — positive proof |
+| F2 | `sp ace/s.jpg` | space in directory name |
+| F3 | `ünïcødé/u1.jpg`, `照片/c1.jpg` | unicode dir names |
+| F4 | `Case/x.jpg`, `case/y.jpg` | ASCII case pair (SQLite LIKE case-insensitivity) |
+| F5 | `a/b/c/d/e/deep.jpg` | deep nesting + dir synthesis per level |
+| F6 | `.hidden.jpg` | dotfile (media scanner hidden-file convention) |
+| F7 | `report.v2.final.jpg` | multi-dot name |
+| F8 | `empty.jpg` (0 bytes, via `seedFile(..., "")`) | zero-byte file |
+
+| # | Test | Verifies |
+|---|------|----------|
+| 1 | `underscore dir does not match percent dir` | path=`edge/a_b` → exactly `f1.jpg`; path=`edge/a%b` → exactly `f2.jpg`; path=`edge/axb` → exactly `f3.jpg` (F1 — the escaping proof impossible on real phones) |
+| 2 | `directory with space lists and reads` | path=`edge/sp ace` → `s.jpg`; `read_file` succeeds (F2) |
+| 3 | `unicode directories list and read` | both F3 dirs list their file; read one content back |
+| 4 | `ascii case pair listing` | path=`edge/Case` vs `edge/case` → PINNED (does LIKE case-insensitivity bleed the listings together?) (F4) |
+| 5 | `deep nested path resolves` | path=`edge/a/b/c/d/e` → `deep.jpg`; path=`edge/a` synthesizes dir `b` (F5) |
+| 6 | `hidden dotfile listing` | `.hidden.jpg` in path=`edge` listing → PINNED (scanner likely skips dotfiles entirely) (F6) |
+| 7 | `multi dot name round trips` | read F7; `write_file` `out.v1.draft.txt` to `downloads` then read back (owned) |
+| 8 | `zero byte file lists and reads empty` | `empty.jpg` → PINNED (scanner may skip 0-byte files; if listed: size==0 and read returns empty content) (F8) |
+| 9 | `duplicate display name resolution` | `insertDuplicateRow("f1.jpg", "Pictures/edge/a_b/")` → `read_file` of `edge/a_b/f1.jpg` → PINNED (which row resolves; no crash) |
+| 10 | `pending row invisible to listing` | `insertPendingRow("pending.jpg", "Pictures/edge/")` → absent from path=`edge` listing |
+| 11 | `stale row read fails cleanly` | `removeFromDisk("Pictures/edge/report.v2.final.jpg")` (row still present) → `read_file` → `isError`, clean message; after `scanPath` the row disappears from listing |
+| 12 | `unscanned file invisible until scan` | seed `Pictures/edge/unscanned.jpg` WITHOUT scan → absent; after `scanPath` → present |
+| 13 | `path traversal rejected end to end` | path=`../Music`, path=`/etc`, path with `\n` → each `isError` invalid params over real JSON-RPC |
+| 14 | `missing or wrongly typed params rejected` | `list_files` without `location_id` → `isError` invalid params; `list_files` with `path` passed as an integer → `isError` invalid params |
+| 15 | `unknown location id rejected` | `location_id="builtin:nope"` → `isError` "not found" |
+| 16 | `negative offset and zero limit` | offset=-1, then limit=0 → PINNED (clean error or clamped result; no crash, no 500) |
+| 17 | `parallel writes to same filename` | second `McpClient`; two concurrent `write_file` of `race.txt` to `downloads` → both calls complete without transport error; subsequent listing PINNED (row count for `race.txt`); server healthy |
+| 18 | `delete during read does not break server` | concurrent `read_file` loop + `delete_file` on the same owned file via second client → no transport errors; each call returns success or clean not-found; server healthy afterwards |
+| 19 | `list during writes stays consistent` | second client writes 10 files sequentially to `downloads` while the first client polls `list_files` — every listing call succeeds (no transport error, no `isError`), `total_count` is monotonically non-decreasing across polls |
+| 20 | `revoke mid session kills process and server recovers` | `revokeMediaPermission(PERM_IMAGES)` → `waitForAppProcessDeath()` → `restartServerAndRefreshClient()` → `list_storage_locations` shows pictures name `"Pictures - All videos, owned images"` and `access_level=="partial"` (per-type mixed grant, live) → re-grant IMAGES → `restartServerAndRefreshClient()` → pictures back to `"Pictures - All files"`/`"full"` |
+
+**Definition of Done**:
+- [x] 20 tests implemented with `@Order` = row number (revoke last); every PINNED assertion carries the observed-behavior comment; teardown restores grants, toggles, server, shared client, and disk state
+
+---
+
+## User Story 4: Final verification — ground-up double check
+
+Why: mandatory last step; quality gates run only here (except the authorized targeted runs defined in the header procedure).
+
+**Acceptance criteria**:
+- [x] Every action of this plan re-verified against the actual code from the ground up
+- [x] All quality gates pass, including the full E2E suite
+
+### Task 4.1: Ground-up double check
+
+- [x] Re-read this plan from disk, action by action, and verify each change exists as specified (visibility change, all new/modified infra files, the receiver extras, both test classes with `@Order` numbering, every test in the tables, every fixture row seeded, every PINNED test carrying its comment, teardown restoration steps)
+- [x] Verify NO file outside this plan's scope was modified (`git status` / `git diff --stat`) — the only app-module change is the debug-source-set `E2EConfigReceiver` addition; main source set untouched
+- [x] Verify no TODOs, placeholders, or commented-out code were introduced
+
+### Task 4.2: Quality gates
+
+- [x] `make lint` — zero warnings/errors (pipe through `tee` to `/tmp/p64-lint.log`)
+- [x] `make test-unit` — full suite passes (pipe through `tee` to `/tmp/p64-test-unit.log`)
+- [x] `make test-e2e` — full E2E suite passes including both new classes AND all pre-existing E2E classes (pipe through `tee` to `/tmp/p64-test-e2e.log`)
+- [x] `./gradlew build` — builds without errors or warnings (pipe through `tee` to `/tmp/p64-build.log`)
+
+**Definition of Done**:
+- [x] All checks above pass; any failure fixed at the root cause and gates re-run

--- a/e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/AndroidContainerSetup.kt
+++ b/e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/AndroidContainerSetup.kt
@@ -737,7 +737,7 @@ object AndroidContainerSetup {
      * Execute an adb command on the host targeting the redroid container.
      * Returns stdout on success. Uses [PROCESS_TIMEOUT_SECONDS] timeout.
      */
-    private fun execAdb(vararg args: String): String {
+    internal fun execAdb(vararg args: String): String {
         val command = arrayOf("adb", "-s", adbSerial) + args
         return runProcess(*command)
     }

--- a/e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/E2EStorageEdgeCasesTest.kt
+++ b/e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/E2EStorageEdgeCasesTest.kt
@@ -90,7 +90,7 @@ class E2EStorageEdgeCasesTest {
     // ─── shared helpers ─────────────────────────────────────────────────────
 
     private fun toolText(result: CallToolResult): String =
-        (result.content.first() as TextContent).text ?: ""
+        (result.content.first() as TextContent).text
 
     private fun callListFiles(
         locationId: String,
@@ -425,7 +425,7 @@ class E2EStorageEdgeCasesTest {
         val partial = refreshed.callTool("${TOOL_PREFIX}list_storage_locations", emptyMap())
         assertNotEquals(true, partial.isError)
         val partialPictures = Json
-            .parseToJsonElement(stripUntrustedWarning((partial.content.first() as TextContent).text ?: ""))
+            .parseToJsonElement(stripUntrustedWarning((partial.content.first() as TextContent).text))
             .jsonArray.map { it.jsonObject }
             .first { it["id"]!!.jsonPrimitive.content == PICTURES }
         assertEquals("Pictures - All videos, owned images", partialPictures["name"]!!.jsonPrimitive.content)
@@ -436,7 +436,7 @@ class E2EStorageEdgeCasesTest {
         val full = restored.callTool("${TOOL_PREFIX}list_storage_locations", emptyMap())
         assertNotEquals(true, full.isError)
         val fullPictures = Json
-            .parseToJsonElement(stripUntrustedWarning((full.content.first() as TextContent).text ?: ""))
+            .parseToJsonElement(stripUntrustedWarning((full.content.first() as TextContent).text))
             .jsonArray.map { it.jsonObject }
             .first { it["id"]!!.jsonPrimitive.content == PICTURES }
         assertEquals("Pictures - All files", fullPictures["name"]!!.jsonPrimitive.content)

--- a/e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/E2EStorageEdgeCasesTest.kt
+++ b/e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/E2EStorageEdgeCasesTest.kt
@@ -1,0 +1,445 @@
+package com.danielealbano.androidremotecontrolmcp.e2e
+
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestMethodOrder
+
+/**
+ * E2E Tier 2 edge-case suite: adversarial file/directory-name fixtures, MediaStore
+ * provider states (pending/stale/unscanned/duplicate rows), protocol-boundary
+ * rejections over real JSON-RPC, concurrency via a second MCP session, and the
+ * mid-session permission-revoke lifecycle.
+ *
+ * Tests are ordered (@Order = plan table row); the revoke test MUST run last
+ * because it kills the app process.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class E2EStorageEdgeCasesTest {
+
+    companion object {
+        private const val TOOL_PREFIX = AndroidContainerSetup.TOOL_NAME_PREFIX
+        private const val DOWNLOADS = "builtin:downloads"
+        private const val PICTURES = "builtin:pictures"
+    }
+
+    private val mcpClient get() = SharedAndroidContainer.mcpClient
+
+    @BeforeAll
+    fun setUpEdgeFixtures() {
+        // Force shared-container initialization: the container boots lazily on first
+        // access, and every StorageE2E call below requires a booted container (adb).
+        SharedAndroidContainer.ensureAccessibilityService()
+
+        StorageE2E.grantAllMediaPermissions()
+        StorageE2E.configureStorageLocation(DOWNLOADS, allowWrite = true, allowDelete = true)
+        StorageE2E.configureStorageLocation(PICTURES, allowWrite = true, allowDelete = true)
+
+        StorageE2E.seedFile("Pictures/edge/a_b/f1.jpg", "underscore-dir")
+        StorageE2E.seedFile("Pictures/edge/a%b/f2.jpg", "percent-dir")
+        StorageE2E.seedFile("Pictures/edge/axb/f3.jpg", "x-dir")
+        StorageE2E.seedFile("Pictures/edge/sp ace/s.jpg", "space-dir")
+        StorageE2E.seedFile("Pictures/edge/ünïcødé/u1.jpg", "unicode-latin")
+        StorageE2E.seedFile("Pictures/edge/照片/c1.jpg", "unicode-cjk")
+        StorageE2E.seedFile("Pictures/edge/Case/x.jpg", "upper-case-dir")
+        StorageE2E.seedFile("Pictures/edge/case/y.jpg", "lower-case-dir")
+        StorageE2E.seedFile("Pictures/edge/a/b/c/d/e/deep.jpg", "deep")
+        StorageE2E.seedFile("Pictures/edge/.hidden.jpg", "hidden")
+        StorageE2E.seedFile("Pictures/edge/report.v2.final.jpg", "multi-dot")
+        StorageE2E.seedFile("Pictures/edge/empty.jpg", "")
+        StorageE2E.scanVolume()
+    }
+
+    @AfterAll
+    fun tearDownEdgeFixtures() {
+        StorageE2E.grantAllMediaPermissions()
+        StorageE2E.restartServerAndRefreshClient()
+        StorageE2E.removeFixtureTree("Pictures/edge")
+        // Owned leftovers from write/concurrency tests (best-effort)
+        StorageE2E.removeFromDisk("Download/out.v1.draft.txt")
+        StorageE2E.removeFromDisk("Download/race.txt")
+        StorageE2E.removeFromDisk("Download/race (1).txt")
+        for (i in 0 until 10) {
+            StorageE2E.removeFromDisk("Download/consist$i.txt")
+        }
+        StorageE2E.scanVolume()
+        StorageE2E.configureStorageLocation(DOWNLOADS, allowWrite = false, allowDelete = false)
+        StorageE2E.configureStorageLocation(PICTURES, allowWrite = false, allowDelete = false)
+    }
+
+    // ─── shared helpers ─────────────────────────────────────────────────────
+
+    private fun toolText(result: CallToolResult): String =
+        (result.content.first() as TextContent).text ?: ""
+
+    private fun callListFiles(
+        locationId: String,
+        path: String = "",
+        offset: Int = 0,
+        limit: Int = 200,
+    ): JsonObject = runBlocking {
+        val result = mcpClient.callTool(
+            "${TOOL_PREFIX}list_files",
+            mapOf("location_id" to locationId, "path" to path, "offset" to offset, "limit" to limit),
+        )
+        assertNotEquals(true, result.isError, "list_files failed: ${toolText(result)}")
+        Json.parseToJsonElement(stripUntrustedWarning(toolText(result))).jsonObject
+    }
+
+    private fun fileNames(listing: JsonObject): List<String> =
+        listing["files"]!!.jsonArray.map { it.jsonObject["name"]!!.jsonPrimitive.content }
+
+    private fun dirNames(listing: JsonObject): List<String> =
+        listing["files"]!!.jsonArray
+            .filter { it.jsonObject["is_directory"]!!.jsonPrimitive.boolean }
+            .map { it.jsonObject["name"]!!.jsonPrimitive.content }
+
+    private fun totalCount(listing: JsonObject): Int = listing["total_count"]!!.jsonPrimitive.int
+
+    private fun readFileContent(locationId: String, path: String): String = runBlocking {
+        val result = mcpClient.callTool(
+            "${TOOL_PREFIX}read_file",
+            mapOf("location_id" to locationId, "path" to path),
+        )
+        assertNotEquals(true, result.isError, "read_file failed: ${toolText(result)}")
+        stripUntrustedWarning(toolText(result))
+            .lines()
+            .filterNot { it.startsWith("--- More lines available") }
+            .joinToString("\n") { it.replace(Regex("^\\d+\\| "), "") }
+    }
+
+    private fun newSecondClient(): McpClient {
+        val client = McpClient(SharedAndroidContainer.mcpServerUrl, AndroidContainerSetup.E2E_BEARER_TOKEN)
+        runBlocking { client.connect() }
+        return client
+    }
+
+    // ─── tests ──────────────────────────────────────────────────────────────
+
+    @Test
+    @Order(1)
+    fun `underscore dir does not match percent dir`() {
+        assertEquals(listOf("f1.jpg"), fileNames(callListFiles(PICTURES, "edge/a_b")))
+        assertEquals(listOf("f2.jpg"), fileNames(callListFiles(PICTURES, "edge/a%b")))
+        assertEquals(listOf("f3.jpg"), fileNames(callListFiles(PICTURES, "edge/axb")))
+    }
+
+    @Test
+    @Order(2)
+    fun `directory with space lists and reads`() {
+        assertEquals(listOf("s.jpg"), fileNames(callListFiles(PICTURES, "edge/sp ace")))
+        assertEquals("space-dir", readFileContent(PICTURES, "edge/sp ace/s.jpg"))
+    }
+
+    @Test
+    @Order(3)
+    fun `unicode directories list and read`() {
+        assertEquals(listOf("u1.jpg"), fileNames(callListFiles(PICTURES, "edge/ünïcødé")))
+        assertEquals(listOf("c1.jpg"), fileNames(callListFiles(PICTURES, "edge/照片")))
+        assertEquals("unicode-cjk", readFileContent(PICTURES, "edge/照片/c1.jpg"))
+    }
+
+    @Test
+    @Order(4)
+    fun `ascii case pair listing`() {
+        val upper = fileNames(callListFiles(PICTURES, "edge/Case"))
+        val lower = fileNames(callListFiles(PICTURES, "edge/case"))
+        // Observed redroid 13 (API 33) behavior — documents the platform, revisit on image upgrade:
+        // although SQLite LIKE is ASCII case-insensitive, the listing's exact relative-path
+        // comparison keeps case-distinct sibling directories separate — no bleed between them.
+        assertEquals(listOf("x.jpg"), upper)
+        assertEquals(listOf("y.jpg"), lower)
+    }
+
+    @Test
+    @Order(5)
+    fun `deep nested path resolves`() {
+        assertEquals(listOf("deep.jpg"), fileNames(callListFiles(PICTURES, "edge/a/b/c/d/e")))
+        assertTrue(dirNames(callListFiles(PICTURES, "edge/a")).contains("b"))
+    }
+
+    @Test
+    @Order(6)
+    fun `hidden dotfile listing`() {
+        val names = fileNames(callListFiles(PICTURES, "edge"))
+        // Observed redroid 13 (API 33) behavior — documents the platform, revisit on image upgrade:
+        // the media scanner skips dotfiles entirely, so .hidden.jpg is never indexed or listed.
+        assertFalse(names.contains(".hidden.jpg"), "names=$names")
+    }
+
+    @Test
+    @Order(7)
+    fun `multi dot name round trips`() = runBlocking {
+        assertEquals("multi-dot", readFileContent(PICTURES, "edge/report.v2.final.jpg"))
+        val write = mcpClient.callTool(
+            "${TOOL_PREFIX}write_file",
+            mapOf("location_id" to DOWNLOADS, "path" to "out.v1.draft.txt", "content" to "draft-1"),
+        )
+        assertNotEquals(true, write.isError, toolText(write))
+        assertEquals("draft-1", readFileContent(DOWNLOADS, "out.v1.draft.txt"))
+    }
+
+    @Test
+    @Order(8)
+    fun `zero byte file lists and reads empty`() {
+        val listing = callListFiles(PICTURES, "edge")
+        val entry = listing["files"]!!.jsonArray
+            .map { it.jsonObject }
+            .find { it["name"]!!.jsonPrimitive.content == "empty.jpg" }
+        // Observed redroid 13 (API 33) behavior — documents the platform, revisit on image upgrade:
+        // zero-byte files ARE indexed (size=0, mime derived from the extension) and read back empty.
+        assertTrue(entry != null, "empty.jpg must be listed")
+        assertEquals(0, entry!!["size"]!!.jsonPrimitive.int)
+        assertEquals("", readFileContent(PICTURES, "edge/empty.jpg"))
+    }
+
+    @Test
+    @Order(9)
+    fun `duplicate display name resolution`() {
+        StorageE2E.insertDuplicateRow("f1.jpg", "Pictures/edge/a_b/")
+        // Observed redroid 13 (API 33) behavior — documents the platform, revisit on image upgrade:
+        // MediaProvider auto-renames the conflicting insert to "f1 (1).jpg" — true duplicate
+        // display names are not creatable; the original row still resolves with its content.
+        assertEquals("underscore-dir", readFileContent(PICTURES, "edge/a_b/f1.jpg"))
+        val names = fileNames(callListFiles(PICTURES, "edge/a_b"))
+        assertTrue(names.contains("f1.jpg"), "names=$names")
+        assertTrue(names.contains("f1 (1).jpg"), "names=$names")
+    }
+
+    @Test
+    @Order(10)
+    fun `pending row invisible to listing`() {
+        StorageE2E.insertPendingRow("pending.jpg", "Pictures/edge/")
+        assertFalse(fileNames(callListFiles(PICTURES, "edge")).contains("pending.jpg"))
+    }
+
+    @Test
+    @Order(11)
+    fun `stale row read fails cleanly`() = runBlocking {
+        StorageE2E.removeFromDisk("Pictures/edge/report.v2.final.jpg")
+        val result = mcpClient.callTool(
+            "${TOOL_PREFIX}read_file",
+            mapOf("location_id" to PICTURES, "path" to "edge/report.v2.final.jpg"),
+        )
+        assertEquals(true, result.isError, "reading a stale row must fail cleanly")
+        assertTrue(toolText(result).isNotBlank())
+        StorageE2E.scanPath("Pictures/edge/report.v2.final.jpg")
+        assertFalse(fileNames(callListFiles(PICTURES, "edge")).contains("report.v2.final.jpg"))
+    }
+
+    @Test
+    @Order(12)
+    fun `unscanned file invisible until scan`() {
+        StorageE2E.seedFile("Pictures/edge/unscanned.jpg", "unscanned")
+        assertFalse(fileNames(callListFiles(PICTURES, "edge")).contains("unscanned.jpg"))
+        StorageE2E.scanPath("Pictures/edge/unscanned.jpg")
+        assertTrue(fileNames(callListFiles(PICTURES, "edge")).contains("unscanned.jpg"))
+    }
+
+    @Test
+    @Order(13)
+    fun `path traversal rejected end to end`() = runBlocking {
+        for (badPath in listOf("../Music", "/etc", "bad\npath")) {
+            val result = mcpClient.callTool(
+                "${TOOL_PREFIX}list_files",
+                mapOf("location_id" to PICTURES, "path" to badPath),
+            )
+            assertEquals(true, result.isError, "path '$badPath' must be rejected")
+        }
+    }
+
+    @Test
+    @Order(14)
+    fun `missing or wrongly typed params rejected`() = runBlocking {
+        val missing = mcpClient.callTool("${TOOL_PREFIX}list_files", mapOf("path" to ""))
+        assertEquals(true, missing.isError)
+        val wrongType = mcpClient.callTool(
+            "${TOOL_PREFIX}list_files",
+            mapOf("location_id" to PICTURES, "path" to 42),
+        )
+        assertEquals(true, wrongType.isError)
+    }
+
+    @Test
+    @Order(15)
+    fun `unknown location id rejected`() = runBlocking {
+        val result = mcpClient.callTool(
+            "${TOOL_PREFIX}list_files",
+            mapOf("location_id" to "builtin:nope", "path" to ""),
+        )
+        assertEquals(true, result.isError)
+        assertTrue(toolText(result).contains("not found", ignoreCase = true), toolText(result))
+    }
+
+    @Test
+    @Order(16)
+    fun `negative offset and zero limit`() = runBlocking<Unit> {
+        val negOffset = mcpClient.callTool(
+            "${TOOL_PREFIX}list_files",
+            mapOf("location_id" to PICTURES, "path" to "edge", "offset" to -1),
+        )
+        val zeroLimit = mcpClient.callTool(
+            "${TOOL_PREFIX}list_files",
+            mapOf("location_id" to PICTURES, "path" to "edge", "limit" to 0),
+        )
+        // Observed redroid 13 (API 33) behavior — documents the platform, revisit on image upgrade:
+        // a negative offset fails cleanly ("Requested element count -1 is less than zero");
+        // limit=0 succeeds and returns an empty page with has_more=true.
+        assertEquals(true, negOffset.isError)
+        assertTrue(toolText(negOffset).contains("less than zero"), toolText(negOffset))
+        assertNotEquals(true, zeroLimit.isError)
+        val listing = Json.parseToJsonElement(stripUntrustedWarning(toolText(zeroLimit))).jsonObject
+        assertEquals(0, fileNames(listing).size)
+        assertTrue(listing["has_more"]!!.jsonPrimitive.boolean)
+    }
+
+    @Test
+    @Order(17)
+    fun `parallel writes to same filename`() = runBlocking<Unit> {
+        val second = newSecondClient()
+        try {
+            val a = async(Dispatchers.IO) {
+                mcpClient.callTool(
+                    "${TOOL_PREFIX}write_file",
+                    mapOf("location_id" to DOWNLOADS, "path" to "race.txt", "content" to "writer-a"),
+                )
+            }
+            val b = async(Dispatchers.IO) {
+                second.callTool(
+                    "${TOOL_PREFIX}write_file",
+                    mapOf("location_id" to DOWNLOADS, "path" to "race.txt", "content" to "writer-b"),
+                )
+            }
+            val resultA = a.await()
+            val resultB = b.await()
+            // Observed redroid 13 (API 33) behavior — documents the platform, revisit on image upgrade:
+            // both writers succeed without transport errors; depending on interleaving the second
+            // writer either overwrites the first's owned row (1 file) or MediaStore auto-renames
+            // its insert (2 files) — never a crash or corrupted listing.
+            assertNotEquals(true, resultA.isError, toolText(resultA))
+            assertNotEquals(true, resultB.isError, toolText(resultB))
+            val raceCount = fileNames(callListFiles(DOWNLOADS)).count { it.startsWith("race") }
+            assertTrue(raceCount in 1..2, "raceCount=$raceCount")
+        } finally {
+            second.close()
+        }
+    }
+
+    @Test
+    @Order(18)
+    fun `delete during read does not break server`() = runBlocking {
+        val write = mcpClient.callTool(
+            "${TOOL_PREFIX}write_file",
+            mapOf("location_id" to DOWNLOADS, "path" to "victim.txt", "content" to "short-lived"),
+        )
+        assertNotEquals(true, write.isError, toolText(write))
+        val second = newSecondClient()
+        try {
+            val reads = async(Dispatchers.IO) {
+                (1..5).map {
+                    mcpClient.callTool(
+                        "${TOOL_PREFIX}read_file",
+                        mapOf("location_id" to DOWNLOADS, "path" to "victim.txt"),
+                    )
+                }
+            }
+            val delete = async(Dispatchers.IO) {
+                second.callTool(
+                    "${TOOL_PREFIX}delete_file",
+                    mapOf("location_id" to DOWNLOADS, "path" to "victim.txt"),
+                )
+            }
+            val readResults = reads.await()
+            val deleteResult = delete.await()
+            // Every call must complete with success or a clean tool error (never a transport failure).
+            for (read in readResults) {
+                if (read.isError == true) {
+                    assertTrue(toolText(read).isNotBlank())
+                }
+            }
+            assertNotEquals(true, deleteResult.isError, toolText(deleteResult))
+            // Server healthy afterwards
+            assertTrue(totalCount(callListFiles(DOWNLOADS)) >= 0)
+        } finally {
+            second.close()
+        }
+    }
+
+    @Test
+    @Order(19)
+    fun `list during writes stays consistent`() = runBlocking {
+        val second = newSecondClient()
+        try {
+            val writer = async(Dispatchers.IO) {
+                for (i in 0 until 10) {
+                    val result = second.callTool(
+                        "${TOOL_PREFIX}write_file",
+                        mapOf("location_id" to DOWNLOADS, "path" to "consist$i.txt", "content" to "c$i"),
+                    )
+                    assertNotEquals(true, result.isError, toolText(result))
+                }
+            }
+            var previousCount = -1
+            while (writer.isActive) {
+                val listing = callListFiles(DOWNLOADS)
+                val count = totalCount(listing)
+                assertTrue(
+                    count >= previousCount,
+                    "total_count must be monotonically non-decreasing ($previousCount -> $count)",
+                )
+                previousCount = count
+            }
+            writer.await()
+        } finally {
+            second.close()
+        }
+    }
+
+    @Test
+    @Order(20)
+    fun `revoke mid session kills process and server recovers`() = runBlocking {
+        StorageE2E.revokeMediaPermission(StorageE2E.PERM_IMAGES)
+        StorageE2E.waitForAppProcessDeath()
+        val refreshed = StorageE2E.restartServerAndRefreshClient()
+
+        val partial = refreshed.callTool("${TOOL_PREFIX}list_storage_locations", emptyMap())
+        assertNotEquals(true, partial.isError)
+        val partialPictures = Json
+            .parseToJsonElement(stripUntrustedWarning((partial.content.first() as TextContent).text ?: ""))
+            .jsonArray.map { it.jsonObject }
+            .first { it["id"]!!.jsonPrimitive.content == PICTURES }
+        assertEquals("Pictures - All videos, owned images", partialPictures["name"]!!.jsonPrimitive.content)
+        assertEquals("partial", partialPictures["access_level"]!!.jsonPrimitive.content)
+
+        StorageE2E.grantMediaPermission(StorageE2E.PERM_IMAGES)
+        val restored = StorageE2E.restartServerAndRefreshClient()
+        val full = restored.callTool("${TOOL_PREFIX}list_storage_locations", emptyMap())
+        assertNotEquals(true, full.isError)
+        val fullPictures = Json
+            .parseToJsonElement(stripUntrustedWarning((full.content.first() as TextContent).text ?: ""))
+            .jsonArray.map { it.jsonObject }
+            .first { it["id"]!!.jsonPrimitive.content == PICTURES }
+        assertEquals("Pictures - All files", fullPictures["name"]!!.jsonPrimitive.content)
+        assertEquals("full", fullPictures["access_level"]!!.jsonPrimitive.content)
+    }
+}

--- a/e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/E2EStorageToolsTest.kt
+++ b/e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/E2EStorageToolsTest.kt
@@ -1,0 +1,511 @@
+package com.danielealbano.androidremotecontrolmcp.e2e
+
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestMethodOrder
+
+/**
+ * E2E Tier 1 core storage suite: all 8 file tools against the real MediaProvider,
+ * covering the regression classes of #154 (path filtering), #155 (multi-collection
+ * DCIM/Pictures), #156 (recordings), permission/toggle states, downloads via the
+ * host-side fixture server, and pagination.
+ *
+ * Tests are ordered (@Order = plan table row) because rows 12/13/16/17/18 form a
+ * mutable-file chain on e2e-rt.txt.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class E2EStorageToolsTest {
+
+    companion object {
+        private const val TOOL_PREFIX = AndroidContainerSetup.TOOL_NAME_PREFIX
+        private const val DOWNLOADS = "builtin:downloads"
+        private const val PICTURES = "builtin:pictures"
+        private const val MOVIES = "builtin:movies"
+        private const val MUSIC = "builtin:music"
+        private const val DCIM = "builtin:dcim"
+        private const val RECORDINGS = "builtin:recordings"
+        private const val BULK_COUNT = 210
+    }
+
+    private val mcpClient get() = SharedAndroidContainer.mcpClient
+    private val fixtureServer = FixtureHttpServer()
+    private lateinit var fixtureBaseUrl: String
+
+    @BeforeAll
+    fun setUpStorage() {
+        // Force shared-container initialization: the container boots lazily on first
+        // access, and every StorageE2E call below requires a booted container (adb).
+        SharedAndroidContainer.ensureAccessibilityService()
+
+        StorageE2E.grantAllMediaPermissions()
+        for (location in listOf(DOWNLOADS, PICTURES, DCIM, RECORDINGS, MUSIC)) {
+            StorageE2E.configureStorageLocation(location, allowWrite = true, allowDelete = true)
+        }
+        StorageE2E.configureDownloadSettings(10, allowHttp = true)
+
+        fixtureServer.start()
+        fixtureBaseUrl = fixtureServer.containerReachableBaseUrl()
+
+        StorageE2E.seedFile("DCIM/Camera/photo1.jpg", "jpeg-fixture-1")
+        StorageE2E.seedFile("DCIM/Camera/video1.mp4", "mp4-fixture-1")
+        StorageE2E.seedFile("DCIM/Screenshots/shot1.png", "png-fixture-1")
+        StorageE2E.seedFile("Pictures/Vacation/pic1.jpg", "jpeg-fixture-2")
+        StorageE2E.seedFile("Pictures/clip.mp4", "mp4-fixture-2")
+        StorageE2E.seedFile("Pictures/readable.jpg", "line one\nline two")
+        StorageE2E.seedFile("Pictures/depth/notes.jpg", "notes")
+        StorageE2E.seedBulk("Pictures/bulk", BULK_COUNT)
+        StorageE2E.seedFile("Music/Album/song.mp3", "mp3-fixture")
+        StorageE2E.seedFile("Recordings/memo.m4a", "m4a-fixture")
+        StorageE2E.seedFile("Download/seeded.txt", "invisible")
+        StorageE2E.scanVolume()
+    }
+
+    @AfterAll
+    fun tearDownStorage() {
+        fixtureServer.stop()
+        StorageE2E.removeFixtureTree("DCIM/Camera")
+        StorageE2E.removeFixtureTree("DCIM/Screenshots")
+        StorageE2E.removeFixtureTree("Pictures/Vacation")
+        StorageE2E.removeFixtureTree("Pictures/depth")
+        StorageE2E.removeFixtureTree("Pictures/bulk")
+        StorageE2E.removeFromDisk("Pictures/clip.mp4")
+        StorageE2E.removeFromDisk("Pictures/readable.jpg")
+        StorageE2E.removeFromDisk("Pictures/readable (1).jpg")
+        StorageE2E.removeFromDisk("Pictures/late.jpg")
+        StorageE2E.removeFixtureTree("Music/Album")
+        StorageE2E.removeFromDisk("Recordings/memo.m4a")
+        StorageE2E.removeFromDisk("Download/seeded.txt")
+        // Owned leftovers from write/download tests (best-effort; some are deleted by tests)
+        StorageE2E.removeFromDisk("Download/e2e-dl.txt")
+        StorageE2E.removeFromDisk("Download/e2e-truncated.txt")
+        StorageE2E.removeFromDisk("DCIM/e2e-shot.jpg")
+        StorageE2E.scanVolume()
+        for (location in listOf(DOWNLOADS, PICTURES, DCIM, RECORDINGS, MUSIC)) {
+            StorageE2E.configureStorageLocation(location, allowWrite = false, allowDelete = false)
+        }
+        StorageE2E.configureDownloadSettings(60, allowHttp = false)
+    }
+
+    // ─── shared helpers ─────────────────────────────────────────────────────
+
+    private fun toolText(result: io.modelcontextprotocol.kotlin.sdk.types.CallToolResult): String =
+        (result.content.first() as TextContent).text ?: ""
+
+    private fun callListFiles(
+        locationId: String,
+        path: String = "",
+        offset: Int = 0,
+        limit: Int = 200,
+    ): JsonObject = runBlocking {
+        val result = mcpClient.callTool(
+            "${TOOL_PREFIX}list_files",
+            mapOf("location_id" to locationId, "path" to path, "offset" to offset, "limit" to limit),
+        )
+        assertNotEquals(true, result.isError, "list_files failed: ${toolText(result)}")
+        Json.parseToJsonElement(stripUntrustedWarning(toolText(result))).jsonObject
+    }
+
+    private fun fileNames(listing: JsonObject): List<String> =
+        listing["files"]!!.jsonArray.map { it.jsonObject["name"]!!.jsonPrimitive.content }
+
+    private fun dirNames(listing: JsonObject): List<String> =
+        listing["files"]!!.jsonArray
+            .filter { it.jsonObject["is_directory"]!!.jsonPrimitive.boolean }
+            .map { it.jsonObject["name"]!!.jsonPrimitive.content }
+
+    private fun plainFileNames(listing: JsonObject): List<String> =
+        listing["files"]!!.jsonArray
+            .filter { !it.jsonObject["is_directory"]!!.jsonPrimitive.boolean }
+            .map { it.jsonObject["name"]!!.jsonPrimitive.content }
+
+    private fun totalCount(listing: JsonObject): Int = listing["total_count"]!!.jsonPrimitive.int
+
+    private fun hasMore(listing: JsonObject): Boolean = listing["has_more"]!!.jsonPrimitive.boolean
+
+    /**
+     * Reads a file via read_file and strips the "N| " line-number prefixes the tool
+     * adds (output format: "1| line content\n2| ..." + optional "--- More lines ---" trailer).
+     */
+    private fun readFileContent(locationId: String, path: String): String = runBlocking {
+        val result = mcpClient.callTool(
+            "${TOOL_PREFIX}read_file",
+            mapOf("location_id" to locationId, "path" to path),
+        )
+        assertNotEquals(true, result.isError, "read_file failed: ${toolText(result)}")
+        stripUntrustedWarning(toolText(result))
+            .lines()
+            .filterNot { it.startsWith("--- More lines available") }
+            .joinToString("\n") { it.replace(Regex("^\\d+\\| "), "") }
+    }
+
+    private fun writeFile(locationId: String, path: String, content: String) = runBlocking {
+        val result = mcpClient.callTool(
+            "${TOOL_PREFIX}write_file",
+            mapOf("location_id" to locationId, "path" to path, "content" to content),
+        )
+        assertNotEquals(true, result.isError, "write_file failed: ${toolText(result)}")
+    }
+
+    // ─── tests ──────────────────────────────────────────────────────────────
+
+    @Test
+    @Order(1)
+    fun `list_storage_locations returns six builtins with access levels`() = runBlocking {
+        val result = mcpClient.callTool("${TOOL_PREFIX}list_storage_locations", emptyMap())
+        assertNotEquals(true, result.isError)
+        val raw = toolText(result)
+        assertNotEquals(raw, stripUntrustedWarning(raw), "response must begin with the untrusted warning")
+        val locations = Json.parseToJsonElement(stripUntrustedWarning(raw)).jsonArray.map { it.jsonObject }
+        val ids = locations.map { it["id"]!!.jsonPrimitive.content }
+        assertEquals(
+            listOf(DOWNLOADS, PICTURES, MOVIES, MUSIC, DCIM, RECORDINGS),
+            ids.filter { it.startsWith("builtin:") },
+        )
+        val byId = locations.associateBy { it["id"]!!.jsonPrimitive.content }
+        for (id in listOf(PICTURES, MOVIES, MUSIC, DCIM, RECORDINGS)) {
+            assertEquals("full", byId[id]!!["access_level"]!!.jsonPrimitive.content, id)
+            assertTrue(byId[id]!!["name"]!!.jsonPrimitive.content.endsWith("- All files"), id)
+        }
+        assertEquals("owned_only", byId[DOWNLOADS]!!["access_level"]!!.jsonPrimitive.content)
+        assertTrue(byId[DOWNLOADS]!!["name"]!!.jsonPrimitive.content.endsWith("- Only owned files"))
+    }
+
+    @Test
+    @Order(2)
+    fun `dcim root synthesizes camera and screenshots directories`() {
+        val dirs = dirNames(callListFiles(DCIM))
+        assertTrue(dirs.contains("Camera"), "dirs=$dirs")
+        assertTrue(dirs.contains("Screenshots"), "dirs=$dirs")
+    }
+
+    @Test
+    @Order(3)
+    fun `dcim camera merges images and videos`() {
+        val names = fileNames(callListFiles(DCIM, "Camera"))
+        assertTrue(names.contains("photo1.jpg"), "names=$names")
+        assertTrue(names.contains("video1.mp4"), "names=$names")
+    }
+
+    @Test
+    @Order(4)
+    fun `pictures root includes video stored under pictures`() {
+        val names = plainFileNames(callListFiles(PICTURES))
+        assertTrue(names.contains("clip.mp4"), "names=$names")
+    }
+
+    @Test
+    @Order(5)
+    fun `single segment path constrains listing`() {
+        val names = fileNames(callListFiles(PICTURES, "Vacation"))
+        assertEquals(listOf("pic1.jpg"), names)
+    }
+
+    @Test
+    @Order(6)
+    fun `nested path constrains listing`() {
+        val depthNames = fileNames(callListFiles(PICTURES, "depth"))
+        assertEquals(listOf("notes.jpg"), depthNames)
+        val root = callListFiles(PICTURES)
+        assertTrue(dirNames(root).contains("depth"))
+        assertFalse(plainFileNames(root).contains("notes.jpg"))
+    }
+
+    @Test
+    @Order(7)
+    fun `unknown path returns empty listing`() {
+        assertEquals(0, totalCount(callListFiles(DCIM, "DoesNotExist")))
+    }
+
+    @Test
+    @Order(8)
+    fun `recordings lists seeded audio`() {
+        assertTrue(fileNames(callListFiles(RECORDINGS)).contains("memo.m4a"))
+    }
+
+    @Test
+    @Order(9)
+    fun `music lists seeded audio`() {
+        assertEquals(listOf("song.mp3"), fileNames(callListFiles(MUSIC, "Album")))
+    }
+
+    @Test
+    @Order(10)
+    fun `read_file reads non-owned file in all-files mode`() {
+        assertEquals("line one\nline two", readFileContent(PICTURES, "readable.jpg"))
+    }
+
+    @Test
+    @Order(11)
+    fun `downloads hides non-owned seeded files`() {
+        assertFalse(
+            fileNames(callListFiles(DOWNLOADS)).contains("seeded.txt"),
+            "non-owned seeded file must be invisible in the owned-only downloads location",
+        )
+    }
+
+    @Test
+    @Order(12)
+    fun `write_file then read_file round trip`() {
+        writeFile(DOWNLOADS, "e2e-rt.txt", "round-trip-content")
+        assertEquals("round-trip-content", readFileContent(DOWNLOADS, "e2e-rt.txt"))
+    }
+
+    @Test
+    @Order(13)
+    fun `written file appears in listing without manual scan`() {
+        assertTrue(fileNames(callListFiles(DOWNLOADS)).contains("e2e-rt.txt"))
+    }
+
+    @Test
+    @Order(14)
+    fun `write_file routes image to dcim and lists it`() {
+        writeFile(DCIM, "e2e-shot.jpg", "shot")
+        assertTrue(plainFileNames(callListFiles(DCIM)).contains("e2e-shot.jpg"))
+    }
+
+    @Test
+    @Order(15)
+    fun `write_file rejects wrong mime with accepted types`() = runBlocking {
+        val result = mcpClient.callTool(
+            "${TOOL_PREFIX}write_file",
+            mapOf("location_id" to PICTURES, "path" to "x.txt", "content" to "text"),
+        )
+        assertEquals(true, result.isError)
+        assertTrue(toolText(result).contains("images, videos"), toolText(result))
+    }
+
+    @Test
+    @Order(16)
+    fun `append_file appends to owned file`() = runBlocking {
+        val result = mcpClient.callTool(
+            "${TOOL_PREFIX}append_file",
+            mapOf("location_id" to DOWNLOADS, "path" to "e2e-rt.txt", "content" to "\nappended-line"),
+        )
+        assertNotEquals(true, result.isError, toolText(result))
+        assertTrue(readFileContent(DOWNLOADS, "e2e-rt.txt").contains("appended-line"))
+    }
+
+    @Test
+    @Order(17)
+    fun `file_replace replaces text in owned file`() = runBlocking {
+        val result = mcpClient.callTool(
+            "${TOOL_PREFIX}file_replace",
+            mapOf(
+                "location_id" to DOWNLOADS,
+                "path" to "e2e-rt.txt",
+                "old_string" to "round-trip-content",
+                "new_string" to "replaced-content",
+            ),
+        )
+        assertNotEquals(true, result.isError, toolText(result))
+        assertTrue(readFileContent(DOWNLOADS, "e2e-rt.txt").contains("replaced-content"))
+    }
+
+    @Test
+    @Order(18)
+    fun `delete_file removes owned file and repeat errors not found`() = runBlocking {
+        val first = mcpClient.callTool(
+            "${TOOL_PREFIX}delete_file",
+            mapOf("location_id" to DOWNLOADS, "path" to "e2e-rt.txt"),
+        )
+        assertNotEquals(true, first.isError, toolText(first))
+        assertFalse(fileNames(callListFiles(DOWNLOADS)).contains("e2e-rt.txt"))
+        val second = mcpClient.callTool(
+            "${TOOL_PREFIX}delete_file",
+            mapOf("location_id" to DOWNLOADS, "path" to "e2e-rt.txt"),
+        )
+        assertEquals(true, second.isError)
+        assertTrue(toolText(second).contains("not found", ignoreCase = true), toolText(second))
+    }
+
+    @Test
+    @Order(19)
+    fun `write denied when allow write disabled`() = runBlocking {
+        val result = mcpClient.callTool(
+            "${TOOL_PREFIX}write_file",
+            mapOf("location_id" to MOVIES, "path" to "denied.mp4", "content" to "x"),
+        )
+        assertEquals(true, result.isError)
+        assertTrue(toolText(result).contains("not allowed", ignoreCase = true), toolText(result))
+    }
+
+    @Test
+    @Order(20)
+    fun `delete denied when allow delete disabled`() = runBlocking {
+        val result = mcpClient.callTool(
+            "${TOOL_PREFIX}delete_file",
+            mapOf("location_id" to MOVIES, "path" to "whatever.mp4"),
+        )
+        assertEquals(true, result.isError)
+        assertTrue(toolText(result).contains("not allowed", ignoreCase = true), toolText(result))
+    }
+
+    @Test
+    @Order(21)
+    fun `delete of non-owned file reports not found`() = runBlocking {
+        val result = mcpClient.callTool(
+            "${TOOL_PREFIX}delete_file",
+            mapOf("location_id" to PICTURES, "path" to "clip.mp4"),
+        )
+        assertEquals(true, result.isError)
+        assertTrue(toolText(result).contains("not found", ignoreCase = true), toolText(result))
+        // Deletes resolve OWNED files only: the tool can never touch non-owned files.
+        assertTrue(plainFileNames(callListFiles(PICTURES)).contains("clip.mp4"))
+    }
+
+    @Test
+    @Order(22)
+    fun `write_file to existing non-owned name`() = runBlocking<Unit> {
+        val result = mcpClient.callTool(
+            "${TOOL_PREFIX}write_file",
+            mapOf("location_id" to PICTURES, "path" to "readable.jpg", "content" to "overwrite-attempt"),
+        )
+        // Observed redroid 13 (API 33) behavior — documents the platform, revisit on image upgrade:
+        // the write succeeds and MediaStore auto-renames the new row to "readable (1).jpg";
+        // the non-owned original row and its content are untouched.
+        assertNotEquals(true, result.isError, toolText(result))
+        val names = plainFileNames(callListFiles(PICTURES))
+        assertTrue(names.contains("readable.jpg"), "names=$names")
+        assertTrue(names.contains("readable (1).jpg"), "names=$names")
+        assertEquals("line one\nline two", readFileContent(PICTURES, "readable.jpg"))
+    }
+
+    @Test
+    @Order(23)
+    fun `download_from_url downloads fixture file`() = runBlocking {
+        val result = mcpClient.callTool(
+            "${TOOL_PREFIX}download_from_url",
+            mapOf("location_id" to DOWNLOADS, "path" to "e2e-dl.txt", "url" to "$fixtureBaseUrl/fixture.txt"),
+        )
+        assertNotEquals(true, result.isError, toolText(result))
+        assertEquals(FixtureHttpServer.FIXTURE_CONTENT, readFileContent(DOWNLOADS, "e2e-dl.txt"))
+    }
+
+    @Test
+    @Order(24)
+    fun `download_from_url 404 returns error and leaves no file`() = runBlocking {
+        val result = mcpClient.callTool(
+            "${TOOL_PREFIX}download_from_url",
+            mapOf("location_id" to DOWNLOADS, "path" to "e2e-404.txt", "url" to "$fixtureBaseUrl/missing.txt"),
+        )
+        assertEquals(true, result.isError)
+        assertFalse(
+            toolText(result).contains("not allowed", ignoreCase = true),
+            "must fail on the HTTP error, not the http-disabled gate: ${toolText(result)}",
+        )
+        assertFalse(fileNames(callListFiles(DOWNLOADS)).contains("e2e-404.txt"))
+    }
+
+    @Test
+    @Order(25)
+    fun `download_from_url connection refused returns error`() = runBlocking {
+        val refusedUrl = fixtureBaseUrl.replace(":${FixtureHttpServer.FIXTURE_HTTP_PORT}", ":18999")
+        val result = mcpClient.callTool(
+            "${TOOL_PREFIX}download_from_url",
+            mapOf("location_id" to DOWNLOADS, "path" to "e2e-refused.txt", "url" to "$refusedUrl/x.txt"),
+        )
+        assertEquals(true, result.isError)
+        assertFalse(fileNames(callListFiles(DOWNLOADS)).contains("e2e-refused.txt"))
+    }
+
+    @Test
+    @Order(26)
+    fun `download_from_url times out on slow server`() = runBlocking {
+        val start = System.currentTimeMillis()
+        val result = mcpClient.callTool(
+            "${TOOL_PREFIX}download_from_url",
+            mapOf("location_id" to DOWNLOADS, "path" to "e2e-slow.txt", "url" to "$fixtureBaseUrl/slow.txt"),
+        )
+        val elapsed = System.currentTimeMillis() - start
+        assertEquals(true, result.isError, toolText(result))
+        assertTrue(
+            elapsed < FixtureHttpServer.SLOW_DELAY_MS + 5_000,
+            "timeout must trigger before the slow endpoint responds (elapsed=${elapsed}ms)",
+        )
+        assertFalse(fileNames(callListFiles(DOWNLOADS)).contains("e2e-slow.txt"))
+    }
+
+    @Test
+    @Order(27)
+    fun `download_from_url handles truncated response`() = runBlocking<Unit> {
+        val result = mcpClient.callTool(
+            "${TOOL_PREFIX}download_from_url",
+            mapOf(
+                "location_id" to DOWNLOADS,
+                "path" to "e2e-truncated.txt",
+                "url" to "$fixtureBaseUrl/truncated.txt",
+            ),
+        )
+        // Observed redroid 13 (API 33) behavior — documents the platform, revisit on image upgrade:
+        // the mid-stream cut fails cleanly ("unexpected end of stream") and the pending
+        // MediaStore row is deleted — no partial file remains in the listing.
+        assertEquals(true, result.isError)
+        assertTrue(toolText(result).contains("unexpected end of stream"), toolText(result))
+        assertFalse(fileNames(callListFiles(DOWNLOADS)).contains("e2e-truncated.txt"))
+        // Server healthy afterwards
+        assertTrue(totalCount(callListFiles(DOWNLOADS)) >= 0)
+    }
+
+    @Test
+    @Order(28)
+    fun `pagination returns stable non-overlapping pages`() {
+        val page1 = callListFiles(PICTURES, "bulk", offset = 0, limit = 100)
+        val page2 = callListFiles(PICTURES, "bulk", offset = 100, limit = 100)
+        val page3 = callListFiles(PICTURES, "bulk", offset = 200, limit = 100)
+        for (page in listOf(page1, page2, page3)) {
+            assertEquals(BULK_COUNT, totalCount(page))
+        }
+        assertEquals(100, fileNames(page1).size)
+        assertEquals(100, fileNames(page2).size)
+        assertEquals(10, fileNames(page3).size)
+        assertTrue(hasMore(page1))
+        assertTrue(hasMore(page2))
+        assertFalse(hasMore(page3))
+        val union = fileNames(page1) + fileNames(page2) + fileNames(page3)
+        assertEquals(BULK_COUNT, union.size)
+        assertEquals(BULK_COUNT, union.toSet().size, "pages must not overlap")
+    }
+
+    @Test
+    @Order(29)
+    fun `pagination offset beyond end returns empty page`() {
+        val page = callListFiles(PICTURES, "bulk", offset = 1000, limit = 100)
+        assertEquals(0, fileNames(page).size)
+        assertFalse(hasMore(page))
+        assertEquals(BULK_COUNT, totalCount(page))
+    }
+
+    @Test
+    @Order(30)
+    fun `limit above cap is coerced to 200`() {
+        val page = callListFiles(PICTURES, "bulk", offset = 0, limit = 500)
+        assertEquals(200, fileNames(page).size)
+        assertTrue(hasMore(page))
+    }
+
+    @Test
+    @Order(31)
+    fun `newly seeded file appears after scan`() {
+        StorageE2E.seedFile("Pictures/late.jpg", "late")
+        StorageE2E.scanPath("Pictures/late.jpg")
+        assertTrue(plainFileNames(callListFiles(PICTURES)).contains("late.jpg"))
+    }
+}

--- a/e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/E2EStorageToolsTest.kt
+++ b/e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/E2EStorageToolsTest.kt
@@ -107,7 +107,7 @@ class E2EStorageToolsTest {
     // ─── shared helpers ─────────────────────────────────────────────────────
 
     private fun toolText(result: io.modelcontextprotocol.kotlin.sdk.types.CallToolResult): String =
-        (result.content.first() as TextContent).text ?: ""
+        (result.content.first() as TextContent).text
 
     private fun callListFiles(
         locationId: String,

--- a/e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/FixtureHttpServer.kt
+++ b/e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/FixtureHttpServer.kt
@@ -1,0 +1,76 @@
+package com.danielealbano.androidremotecontrolmcp.e2e
+
+import com.sun.net.httpserver.HttpServer
+import java.net.InetSocketAddress
+
+/**
+ * Minimal host-side HTTP server for download_from_url E2E tests.
+ * Bound on 0.0.0.0:[FIXTURE_HTTP_PORT] (the port is exposed to the container
+ * before it starts).
+ *
+ * Endpoints:
+ * - GET /fixture.txt   -> 200, body [FIXTURE_CONTENT], Content-Type text/plain
+ * - GET /missing.txt   -> 404
+ * - GET /slow.txt      -> sleeps [SLOW_DELAY_MS], then 200 (exceeds the 10s test download timeout)
+ * - GET /truncated.txt -> declares Content-Length 1000, writes 10 bytes, closes (mid-stream cut)
+ */
+class FixtureHttpServer {
+    private var server: HttpServer? = null
+
+    fun start() {
+        val s = HttpServer.create(InetSocketAddress("0.0.0.0", FIXTURE_HTTP_PORT), 0)
+        s.createContext("/fixture.txt") { exchange ->
+            val body = FIXTURE_CONTENT.toByteArray()
+            exchange.responseHeaders.add("Content-Type", "text/plain")
+            exchange.sendResponseHeaders(200, body.size.toLong())
+            exchange.responseBody.use { it.write(body) }
+        }
+        s.createContext("/missing.txt") { exchange ->
+            exchange.sendResponseHeaders(404, -1)
+            exchange.close()
+        }
+        s.createContext("/slow.txt") { exchange ->
+            Thread.sleep(SLOW_DELAY_MS)
+            val body = "late".toByteArray()
+            exchange.sendResponseHeaders(200, body.size.toLong())
+            exchange.responseBody.use { it.write(body) }
+        }
+        s.createContext("/truncated.txt") { exchange ->
+            exchange.sendResponseHeaders(200, 1000L)
+            exchange.responseBody.write(ByteArray(10))
+            exchange.close()
+        }
+        s.start()
+        server = s
+    }
+
+    fun stop() {
+        server?.stop(0)
+        server = null
+    }
+
+    /**
+     * Base URL as reachable FROM INSIDE the container.
+     *
+     * Verified mechanism on redroid 13 (plan empirical procedure 2): the primary
+     * `host.testcontainers.internal` name is NOT resolvable inside redroid's Android
+     * runtime (Android's resolver does not see the Testcontainers hosts entry), so the
+     * container's default-gateway IP — the host on podman's bridge — is used instead.
+     */
+    fun containerReachableBaseUrl(): String {
+        // Android uses policy routing, so the main `ip route` table has no `default` line;
+        // `ip route get <external ip>` resolves through the policy tables and prints
+        // "<ip> via <gateway> dev ...".
+        val out = AndroidContainerSetup.execAdb("shell", "ip", "route", "get", "1.1.1.1")
+        val tokens = out.split(Regex("\\s+"))
+        val gateway = tokens[tokens.indexOf("via") + 1]
+        return "http://$gateway:$FIXTURE_HTTP_PORT"
+    }
+
+    companion object {
+        /** Fixed host port, exposed to the container by SharedAndroidContainer before start. */
+        const val FIXTURE_HTTP_PORT = 18923
+        const val FIXTURE_CONTENT = "e2e-download-fixture-content"
+        const val SLOW_DELAY_MS = 15_000L
+    }
+}

--- a/e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/SharedAndroidContainer.kt
+++ b/e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/SharedAndroidContainer.kt
@@ -79,6 +79,10 @@ object SharedAndroidContainer {
             try {
                 println("[SharedAndroidContainer] Initializing shared container...")
 
+                // Expose the fixture HTTP server port to the container BEFORE it starts
+                // (Testcontainers requires exposeHostPorts before container start).
+                org.testcontainers.Testcontainers.exposeHostPorts(FixtureHttpServer.FIXTURE_HTTP_PORT)
+
                 val c = AndroidContainerSetup.createContainer()
                 c.start() // ADB-based boot wait strategy runs inside start()
 
@@ -157,6 +161,26 @@ object SharedAndroidContainer {
     fun ensureAccessibilityService() {
         ensureInitialized()
         AndroidContainerSetup.ensureAccessibilityService()
+    }
+
+    /**
+     * Replaces the cached MCP client with a freshly connected one. Required after the
+     * app process is killed (e.g. by a runtime-permission revoke): the cached client's
+     * MCP session dies with the process, and later test classes read [mcpClient].
+     */
+    fun refreshMcpClient(): McpClient {
+        ensureInitialized()
+        synchronized(lock) {
+            try {
+                runBlocking { _mcpClient?.close() }
+            } catch (_: Exception) {
+                // Best-effort close of a dead session
+            }
+            val client = McpClient(mcpServerUrl, AndroidContainerSetup.E2E_BEARER_TOKEN)
+            runBlocking { client.connect() }
+            _mcpClient = client
+            return client
+        }
     }
 
     init {

--- a/e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/StorageE2E.kt
+++ b/e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/StorageE2E.kt
@@ -1,0 +1,173 @@
+package com.danielealbano.androidremotecontrolmcp.e2e
+
+import java.util.Base64
+
+/**
+ * Shared storage-E2E infrastructure: MediaStore fixture seeding, media scanning,
+ * READ_MEDIA_* permission control, builtin allow-write/allow-delete toggles,
+ * download settings, app-process lifecycle helpers, and MediaStore row injection.
+ *
+ * Files seeded via adb shell are NON-OWNED from the app's perspective; files created
+ * through the app's MCP tools are OWNED. Seeded files become visible to MediaStore
+ * only after [scanVolume]/[scanPath], in the collection implied by their extension.
+ *
+ * Fixture names MUST NOT contain double quotes, backticks, or '$' (double-quote shell quoting).
+ */
+object StorageE2E {
+    const val APP_PACKAGE = "com.danielealbano.androidremotecontrolmcp.gms.debug"
+    const val PERM_IMAGES = "android.permission.READ_MEDIA_IMAGES"
+    const val PERM_VIDEO = "android.permission.READ_MEDIA_VIDEO"
+    const val PERM_AUDIO = "android.permission.READ_MEDIA_AUDIO"
+    private const val SDCARD = "/storage/emulated/0"
+    private const val E2E_ACTION_BASE = "com.danielealbano.androidremotecontrolmcp.debug"
+    private const val E2E_CONFIG_RECEIVER =
+        "$APP_PACKAGE/com.danielealbano.androidremotecontrolmcp.debug.E2EConfigReceiver"
+
+    /**
+     * Runs a shell command on the device. `adb shell` re-joins its arguments with
+     * spaces before the device shell parses them, so the whole command is wrapped
+     * in single quotes (with embedded single quotes escaped) to reach the device's
+     * `sh -c` as ONE argument.
+     */
+    fun shell(cmd: String): String {
+        val quoted = "'" + cmd.replace("'", "'\\''") + "'"
+        return AndroidContainerSetup.execAdb("shell", "sh", "-c", quoted)
+    }
+
+    fun grantMediaPermission(permission: String) {
+        AndroidContainerSetup.execAdb("shell", "pm", "grant", APP_PACKAGE, permission)
+    }
+
+    fun grantAllMediaPermissions() {
+        grantMediaPermission(PERM_IMAGES)
+        grantMediaPermission(PERM_VIDEO)
+        grantMediaPermission(PERM_AUDIO)
+    }
+
+    /**
+     * Revokes a granted runtime permission. WARNING: this KILLS the app process.
+     * Callers MUST afterwards call [waitForAppProcessDeath], then
+     * [restartServerAndRefreshClient].
+     */
+    fun revokeMediaPermission(permission: String) {
+        AndroidContainerSetup.execAdb("shell", "pm", "revoke", APP_PACKAGE, permission)
+    }
+
+    /** Seeds a file with the given text content at an /sdcard-relative path (parents created). */
+    fun seedFile(relativePath: String, content: String) {
+        val path = "$SDCARD/$relativePath"
+        val dir = path.substringBeforeLast('/')
+        val b64 = Base64.getEncoder().encodeToString(content.toByteArray())
+        shell("mkdir -p \"$dir\" && echo $b64 | base64 -d > \"$path\"")
+    }
+
+    /** Seeds [count] one-byte files named <prefix>NNN.jpg under an /sdcard-relative directory. */
+    fun seedBulk(dirRelativePath: String, count: Int, prefix: String = "bulk") {
+        val dir = "$SDCARD/$dirRelativePath"
+        val d = "\$"
+        shell(
+            "mkdir -p \"$dir\" && i=0; while [ ${d}i -lt $count ]; do " +
+                "printf x > \"$dir/$prefix${d}(printf %03d ${d}i).jpg\"; i=${d}((i+1)); done",
+        )
+    }
+
+    /** Removes a single seeded file from disk (rm -f: best-effort, no recursion). */
+    fun removeFromDisk(relativePath: String) {
+        shell("rm -f \"$SDCARD/$relativePath\"")
+    }
+
+    /** Removes a seeded fixture directory tree. ONLY for paths created by this suite. */
+    fun removeFixtureTree(relativePath: String) {
+        require(relativePath.isNotBlank() && !relativePath.contains("..")) { "unsafe path" }
+        shell("rm -rf \"$SDCARD/$relativePath\"")
+    }
+
+    /**
+     * Triggers a MediaStore scan. Mechanism verified empirically against redroid 13
+     * per the plan's procedure (scan_volume primary; scan_file per path; legacy
+     * broadcast last). The verified mechanism is kept, the others removed.
+     */
+    fun scanVolume() {
+        AndroidContainerSetup.execAdb(
+            "shell", "content", "call", "--uri", "content://media/none",
+            "--method", "scan_volume", "--arg", "external_primary",
+        )
+    }
+
+    fun scanPath(relativePath: String) {
+        AndroidContainerSetup.execAdb(
+            "shell", "content", "call", "--uri", "content://media/none",
+            "--method", "scan_file", "--arg", "$SDCARD/$relativePath",
+        )
+    }
+
+    /** Sets builtin location allow-write/allow-delete via the E2E config broadcast. */
+    fun configureStorageLocation(locationId: String, allowWrite: Boolean, allowDelete: Boolean) {
+        AndroidContainerSetup.execAdb(
+            "shell", "am", "broadcast", "--include-stopped-packages",
+            "-a", "$E2E_ACTION_BASE.E2E_CONFIGURE",
+            "-n", E2E_CONFIG_RECEIVER,
+            "--es", "storage_location_id", locationId,
+            "--ez", "storage_allow_write", allowWrite.toString(),
+            "--ez", "storage_allow_delete", allowDelete.toString(),
+        )
+        Thread.sleep(1_000)
+    }
+
+    /** Sets download timeout + HTTP-download allowance via the E2E config broadcast. */
+    fun configureDownloadSettings(timeoutSeconds: Int, allowHttp: Boolean) {
+        AndroidContainerSetup.execAdb(
+            "shell", "am", "broadcast", "--include-stopped-packages",
+            "-a", "$E2E_ACTION_BASE.E2E_CONFIGURE",
+            "-n", E2E_CONFIG_RECEIVER,
+            "--ei", "download_timeout_seconds", timeoutSeconds.toString(),
+            "--ez", "allow_http_downloads", allowHttp.toString(),
+        )
+        Thread.sleep(1_000)
+    }
+
+    /** Inserts a MediaStore row with IS_PENDING=1 (no backing content written). */
+    fun insertPendingRow(displayName: String, relativePathWithSlash: String) {
+        AndroidContainerSetup.execAdb(
+            "shell", "content", "insert", "--uri", "content://media/external_primary/file",
+            "--bind", "_display_name:s:$displayName",
+            "--bind", "relative_path:s:$relativePathWithSlash",
+            "--bind", "is_pending:i:1",
+        )
+    }
+
+    /** Inserts a second MediaStore row with the same display name + relative path. */
+    fun insertDuplicateRow(displayName: String, relativePathWithSlash: String) {
+        AndroidContainerSetup.execAdb(
+            "shell", "content", "insert", "--uri", "content://media/external_primary/file",
+            "--bind", "_display_name:s:$displayName",
+            "--bind", "relative_path:s:$relativePathWithSlash",
+        )
+    }
+
+    /** Polls until the app process is gone (used after [revokeMediaPermission]). */
+    fun waitForAppProcessDeath(timeoutMs: Long = 15_000L) {
+        val start = System.currentTimeMillis()
+        while (System.currentTimeMillis() - start < timeoutMs) {
+            val pid = try {
+                shell("pidof $APP_PACKAGE || true")
+            } catch (_: Exception) {
+                ""
+            }
+            if (pid.isBlank()) return
+            Thread.sleep(500)
+        }
+        error("App process still alive ${timeoutMs}ms after permission revoke")
+    }
+
+    /**
+     * Restarts the MCP server and REFRESHES the shared cached client
+     * (SharedAndroidContainer.mcpClient), so both this suite and any test class
+     * running afterwards see a live session. Returns the refreshed client.
+     */
+    fun restartServerAndRefreshClient(): McpClient {
+        AndroidContainerSetup.startMcpServer()
+        AndroidContainerSetup.waitForServerReady(SharedAndroidContainer.mcpServerUrl)
+        return SharedAndroidContainer.refreshMcpClient()
+    }
+}


### PR DESCRIPTION
## Summary

Adds the missing E2E coverage for the MCP storage/file tools against the real MediaProvider in the redroid 13 container. The three storage bugs of the last days (#154 path filtering, #155 DCIM coverage, partial photo access) were invisible to CI because unit/integration tests mock MediaStore — this suite closes that gap with 51 new tests across two tiers, all verified green together with the entire pre-existing E2E suite (84 tests, 0 failures).

## Plan Reference

Implementation of Plan 64: E2E storage-tool tests on redroid 13 from `docs/plans/64_e2e_storage_tests_redroid13_20260815113951.md`.

## Changes

- **Infrastructure**: `StorageE2E` helper (MediaStore fixture seeding via adb with device-shell quoting, media scanning, `READ_MEDIA_*` grant/revoke, toggle + download-settings broadcasts, process-death wait, server restart with shared-client refresh, pending/duplicate row injection); host-side `FixtureHttpServer` (200/404/slow/truncated endpoints) reached via the container gateway IP (`host.testcontainers.internal` is not resolvable inside redroid's Android runtime); `SharedAndroidContainer.refreshMcpClient()` for revoke-kill recovery; debug-only `E2EConfigReceiver` extras (`download_timeout_seconds`, `allow_http_downloads`) — main source set untouched
- **Tier 1 (`E2EStorageToolsTest`, 31 tests)**: all 8 file tools end-to-end; #154/#155/#156 regression classes; owned-vs-non-owned filtering both ways incl. the permanent owner filter on `builtin:downloads`; toggle gating; download success/404/refused/timeout/truncated; pagination over a 210-file tree
- **Tier 2 (`E2EStorageEdgeCasesTest`, 20 tests)**: adversarial fixtures (SQL-LIKE `_`/`%` escaping proof, unicode, ASCII case pairs, deep nesting, dotfiles, zero-byte), provider states (pending/stale/unscanned/duplicate rows), protocol-boundary rejections over real JSON-RPC, concurrency via a second MCP session, and the mid-session permission-revoke lifecycle with server recovery
- 8 tests PIN observed redroid 13 platform behavior (auto-rename on name collisions, dotfile skipping, zero-byte indexing, clean truncated-stream failure, …) with explicit revisit-on-upgrade comments

## Testing

- `make lint`, `make test-unit`, `make test-e2e` (full suite: 84 tests, 0 failures — 51 new + all pre-existing classes), and `./gradlew build` all pass with zero warnings

## Checklist

- [x] All tests pass (`make test-unit`, `make test-e2e`)
- [x] Lint passes (`make lint`)
- [x] Build succeeds (`./gradlew build`)