### PR TITLE
E2E: upgrade redroid to 14 (API 34) and add partial photo access coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,7 +279,7 @@ jobs:
           curl -s --unix-socket /run/podman/podman.sock http://localhost/_ping
 
       - name: Pre-pull redroid image
-        run: sudo podman pull redroid/redroid:13.0.0-latest
+        run: sudo podman pull redroid/redroid:14.0.0-latest
 
       - name: Run E2E tests
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -527,7 +527,7 @@ fun `tap with valid coordinates calls actionExecutor and returns success`() = ru
 
 ### E2E testing (Redroid + Podman + Testcontainers)
 - Use **Testcontainers Kotlin** for container orchestration via rootful podman.
-- Use **redroid/redroid:13.0.0-latest** container image (native Android in container via kernel modules).
+- Use **redroid/redroid:14.0.0-latest** container image (native Android in container via kernel modules).
 - Use **JUnit 5** for test framework.
 - Use **MCP Kotlin SDK client** with `StreamableHttpClientTransport` for MCP requests.
 - Organize tests in `e2e-tests/src/test/kotlin/` directory (separate Gradle module).

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -554,7 +554,7 @@ HomeScreen contains a TopAppBar, then a scrollable layout with: ServerStatusCard
 
 ### E2E Tests
 
-- **Framework**: Testcontainers Kotlin (`redroid/redroid:13.0.0-latest`), JUnit 5, MCP Kotlin SDK Client
+- **Framework**: Testcontainers Kotlin (`redroid/redroid:14.0.0-latest`), JUnit 5, MCP Kotlin SDK Client
 - **Scope**: Full MCP client → server → Android → action flow, Calculator app test (7 + 3 = 10), screenshot capture validation, error handling (auth, unknown tool, invalid params, node not found)
 - **Infrastructure**: `SharedAndroidContainer` singleton shares one container across all test classes (avoids ~2-4 min boot per class); `McpClient` test utility wraps SDK `Client` + `StreamableHttpClientTransport` with trust-all TLS for self-signed certs; `E2EConfigReceiver` debug-only BroadcastReceiver injects test settings via `adb shell am broadcast`
 - **Run**: `make test-e2e` or `./gradlew :e2e-tests:test`

--- a/e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/AndroidContainerSetup.kt
+++ b/e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/AndroidContainerSetup.kt
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit
  */
 object AndroidContainerSetup {
 
-    private const val DOCKER_IMAGE = "redroid/redroid:13.0.0-latest"
+    private const val DOCKER_IMAGE = "redroid/redroid:14.0.0-latest"
     private const val ADB_PORT = 5555
     private const val MCP_DEFAULT_PORT = 8080
     private const val PROCESS_TIMEOUT_SECONDS = 30L

--- a/e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/E2EStorageEdgeCasesTest.kt
+++ b/e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/E2EStorageEdgeCasesTest.kt
@@ -164,7 +164,7 @@ class E2EStorageEdgeCasesTest {
     fun `ascii case pair listing`() {
         val upper = fileNames(callListFiles(PICTURES, "edge/Case"))
         val lower = fileNames(callListFiles(PICTURES, "edge/case"))
-        // Observed redroid 13 (API 33) behavior — documents the platform, revisit on image upgrade:
+        // Observed redroid 13 (API 33) and 14 (API 34) behavior — documents the platform, revisit on image upgrade:
         // although SQLite LIKE is ASCII case-insensitive, the listing's exact relative-path
         // comparison keeps case-distinct sibling directories separate — no bleed between them.
         assertEquals(listOf("x.jpg"), upper)
@@ -182,7 +182,7 @@ class E2EStorageEdgeCasesTest {
     @Order(6)
     fun `hidden dotfile listing`() {
         val names = fileNames(callListFiles(PICTURES, "edge"))
-        // Observed redroid 13 (API 33) behavior — documents the platform, revisit on image upgrade:
+        // Observed redroid 13 (API 33) and 14 (API 34) behavior — documents the platform, revisit on image upgrade:
         // the media scanner skips dotfiles entirely, so .hidden.jpg is never indexed or listed.
         assertFalse(names.contains(".hidden.jpg"), "names=$names")
     }
@@ -206,7 +206,7 @@ class E2EStorageEdgeCasesTest {
         val entry = listing["files"]!!.jsonArray
             .map { it.jsonObject }
             .find { it["name"]!!.jsonPrimitive.content == "empty.jpg" }
-        // Observed redroid 13 (API 33) behavior — documents the platform, revisit on image upgrade:
+        // Observed redroid 13 (API 33) and 14 (API 34) behavior — documents the platform, revisit on image upgrade:
         // zero-byte files ARE indexed (size=0, mime derived from the extension) and read back empty.
         assertTrue(entry != null, "empty.jpg must be listed")
         assertEquals(0, entry!!["size"]!!.jsonPrimitive.int)
@@ -217,7 +217,7 @@ class E2EStorageEdgeCasesTest {
     @Order(9)
     fun `duplicate display name resolution`() {
         StorageE2E.insertDuplicateRow("f1.jpg", "Pictures/edge/a_b/")
-        // Observed redroid 13 (API 33) behavior — documents the platform, revisit on image upgrade:
+        // Observed redroid 13 (API 33) and 14 (API 34) behavior — documents the platform, revisit on image upgrade:
         // MediaProvider auto-renames the conflicting insert to "f1 (1).jpg" — true duplicate
         // display names are not creatable; the original row still resolves with its content.
         assertEquals("underscore-dir", readFileContent(PICTURES, "edge/a_b/f1.jpg"))
@@ -302,7 +302,7 @@ class E2EStorageEdgeCasesTest {
             "${TOOL_PREFIX}list_files",
             mapOf("location_id" to PICTURES, "path" to "edge", "limit" to 0),
         )
-        // Observed redroid 13 (API 33) behavior — documents the platform, revisit on image upgrade:
+        // Observed redroid 13 (API 33) and 14 (API 34) behavior — documents the platform, revisit on image upgrade:
         // a negative offset fails cleanly ("Requested element count -1 is less than zero");
         // limit=0 succeeds and returns an empty page with has_more=true.
         assertEquals(true, negOffset.isError)
@@ -332,7 +332,7 @@ class E2EStorageEdgeCasesTest {
             }
             val resultA = a.await()
             val resultB = b.await()
-            // Observed redroid 13 (API 33) behavior — documents the platform, revisit on image upgrade:
+            // Observed redroid 13 (API 33) and 14 (API 34) behavior — documents the platform, revisit on image upgrade:
             // both writers succeed without transport errors; depending on interleaving the second
             // writer either overwrites the first's owned row (1 file) or MediaStore auto-renames
             // its insert (2 files) — never a crash or corrupted listing.

--- a/e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/E2EStoragePartialAccessTest.kt
+++ b/e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/E2EStoragePartialAccessTest.kt
@@ -1,0 +1,274 @@
+package com.danielealbano.androidremotecontrolmcp.e2e
+
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assumptions
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestMethodOrder
+
+/**
+ * E2E suite for Android 14+ partial photo access ("Allow limited access").
+ *
+ * Drives the app through the full access-level state machine via `pm grant`/`pm revoke`
+ * of READ_MEDIA_IMAGES / READ_MEDIA_VIDEO / READ_MEDIA_VISUAL_USER_SELECTED and verifies
+ * `list_storage_locations` access_level + display names, MediaProvider row filtering
+ * under partial access (owned + user-selected rows only; no picker selections exist in
+ * this suite, so partial access resolves to owned rows), and that writes/reads of owned
+ * files keep working in every state.
+ *
+ * Requires API 34+ (READ_MEDIA_VISUAL_USER_SELECTED does not exist on API 33); the whole
+ * class is skipped via [Assumptions.assumeTrue] on older container images.
+ *
+ * Tests are ordered: each test transitions the permission state machine and later tests
+ * depend on the state left by earlier ones. Permission revokes KILL the app process, so
+ * transitions use waitForAppProcessDeath + restartServerAndRefreshClient; the baseline
+ * state (all media permissions granted, USER_SELECTED revoked) is restored in [tearDown].
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class E2EStoragePartialAccessTest {
+
+    companion object {
+        private const val TOOL_PREFIX = AndroidContainerSetup.TOOL_NAME_PREFIX
+        private const val PICTURES = "builtin:pictures"
+        private const val MOVIES = "builtin:movies"
+        private const val MUSIC = "builtin:music"
+        private const val DCIM = "builtin:dcim"
+        private const val DOWNLOADS = "builtin:downloads"
+        private const val FIXTURE_DIR = "partial"
+        private const val MIN_PARTIAL_ACCESS_API = 34
+        private const val TEARDOWN_DEATH_POLL_MS = 5_000L
+    }
+
+    private val mcpClient get() = SharedAndroidContainer.mcpClient
+
+    /** True only when the API gate passed and fixtures were set up (guards tearDown). */
+    private var active = false
+
+    @BeforeAll
+    fun setUpPartialAccessFixtures() {
+        // Force shared-container initialization before any adb-based helper below.
+        SharedAndroidContainer.ensureAccessibilityService()
+
+        val sdk = AndroidContainerSetup.execAdb("shell", "getprop", "ro.build.version.sdk").trim().toInt()
+        Assumptions.assumeTrue(
+            sdk >= MIN_PARTIAL_ACCESS_API,
+            "Skipping partial-access tests: READ_MEDIA_VISUAL_USER_SELECTED requires API 34+" +
+                " (container is API $sdk)",
+        )
+        active = true
+
+        StorageE2E.grantAllMediaPermissions()
+        StorageE2E.configureStorageLocation(PICTURES, allowWrite = true, allowDelete = true)
+
+        // Non-owned fixture: seeded via adb shell (no OWNER_PACKAGE_NAME).
+        StorageE2E.seedFile("Pictures/$FIXTURE_DIR/nonowned.jpg", "nonowned-content")
+        StorageE2E.scanPath("Pictures/$FIXTURE_DIR/nonowned.jpg")
+
+        // Owned fixture: written through the app while full access is granted.
+        writeOwnedFile("$FIXTURE_DIR/owned.jpg", "owned-content")
+    }
+
+    @AfterAll
+    fun tearDown() {
+        if (!active) return
+        // Restore the suite baseline: all media permissions granted, USER_SELECTED revoked
+        // (a lingering USER_SELECTED grant changes partial-state display names asserted by
+        // other test classes). The revoke kills the app process when the permission was
+        // granted and is a no-op otherwise, so the death wait below is tolerant.
+        StorageE2E.grantAllMediaPermissions()
+        StorageE2E.revokeMediaPermission(StorageE2E.PERM_VISUAL_USER_SELECTED)
+        waitForPossibleProcessDeath()
+        StorageE2E.restartServerAndRefreshClient()
+        StorageE2E.removeFixtureTree("Pictures/$FIXTURE_DIR")
+        StorageE2E.scanVolume()
+        StorageE2E.configureStorageLocation(PICTURES, allowWrite = false, allowDelete = false)
+    }
+
+    // ─── shared helpers ─────────────────────────────────────────────────────
+
+    private fun toolText(result: CallToolResult): String =
+        (result.content.first() as TextContent).text
+
+    private fun writeOwnedFile(path: String, content: String) = runBlocking {
+        val result = mcpClient.callTool(
+            "${TOOL_PREFIX}write_file",
+            mapOf("location_id" to PICTURES, "path" to path, "content" to content),
+        )
+        check(result.isError != true) { "write_file failed: ${toolText(result)}" }
+    }
+
+    private fun storageLocationsById(): Map<String, JsonObject> = runBlocking {
+        val result = mcpClient.callTool("${TOOL_PREFIX}list_storage_locations", emptyMap())
+        assertNotEquals(true, result.isError, "list_storage_locations failed")
+        Json.parseToJsonElement(stripUntrustedWarning(toolText(result)))
+            .jsonArray.map { it.jsonObject }
+            .associateBy { it["id"]!!.jsonPrimitive.content }
+    }
+
+    private fun assertLocationState(
+        locations: Map<String, JsonObject>,
+        locationId: String,
+        expectedAccessLevel: String,
+        expectedName: String,
+    ) {
+        val location = locations[locationId] ?: error("location $locationId missing from listing")
+        assertEquals(expectedAccessLevel, location["access_level"]!!.jsonPrimitive.content, locationId)
+        assertEquals(expectedName, location["name"]!!.jsonPrimitive.content, locationId)
+    }
+
+    private fun listFixtureDirNames(): List<String> = runBlocking {
+        val result = mcpClient.callTool(
+            "${TOOL_PREFIX}list_files",
+            mapOf("location_id" to PICTURES, "path" to FIXTURE_DIR, "offset" to 0, "limit" to 200),
+        )
+        assertNotEquals(true, result.isError, "list_files failed: ${toolText(result)}")
+        Json.parseToJsonElement(stripUntrustedWarning(toolText(result))).jsonObject["files"]!!
+            .jsonArray.map { it.jsonObject["name"]!!.jsonPrimitive.content }
+    }
+
+    private fun readFileContent(path: String): String = runBlocking {
+        val result = mcpClient.callTool(
+            "${TOOL_PREFIX}read_file",
+            mapOf("location_id" to PICTURES, "path" to path),
+        )
+        assertNotEquals(true, result.isError, "read_file failed: ${toolText(result)}")
+        stripUntrustedWarning(toolText(result))
+            .lines()
+            .filterNot { it.startsWith("--- More lines available") }
+            .joinToString("\n") { it.replace(Regex("^\\d+\\| "), "") }
+    }
+
+    /**
+     * Tolerant variant of [StorageE2E.waitForAppProcessDeath] for teardown: polls until
+     * the app process is gone but does NOT fail if it stays alive (the teardown revoke
+     * is a no-op when USER_SELECTED was already revoked, so no kill happens).
+     */
+    private fun waitForPossibleProcessDeath() {
+        val start = System.currentTimeMillis()
+        while (System.currentTimeMillis() - start < TEARDOWN_DEATH_POLL_MS) {
+            val pid = try {
+                StorageE2E.shell("pidof ${StorageE2E.APP_PACKAGE} || true")
+            } catch (_: Exception) {
+                ""
+            }
+            if (pid.isBlank()) return
+            Thread.sleep(500)
+        }
+    }
+
+    // ─── tests ──────────────────────────────────────────────────────────────
+
+    @Test
+    @Order(1)
+    fun `baseline full access reports full everywhere`() {
+        val locations = storageLocationsById()
+        assertLocationState(locations, PICTURES, "full", "Pictures - All files")
+        assertLocationState(locations, DCIM, "full", "Camera (DCIM) - All files")
+        assertLocationState(locations, DOWNLOADS, "owned_only", "Downloads - Only owned files")
+    }
+
+    @Test
+    @Order(2)
+    fun `lingering user selected grant with full access stays full`() {
+        // After "Allow all" in the system dialog, USER_SELECTED can remain granted
+        // alongside the full permissions; FULL must win (checked before partial).
+        StorageE2E.grantMediaPermission(StorageE2E.PERM_VISUAL_USER_SELECTED)
+        val locations = storageLocationsById()
+        assertLocationState(locations, PICTURES, "full", "Pictures - All files")
+        assertLocationState(locations, DCIM, "full", "Camera (DCIM) - All files")
+    }
+
+    @Test
+    @Order(3)
+    fun `revoking visual permissions with user selected yields partial`() {
+        StorageE2E.revokeMediaPermission(StorageE2E.PERM_IMAGES)
+        StorageE2E.revokeMediaPermission(StorageE2E.PERM_VIDEO)
+        StorageE2E.waitForAppProcessDeath()
+        StorageE2E.restartServerAndRefreshClient()
+
+        val locations = storageLocationsById()
+        assertLocationState(locations, PICTURES, "partial", "Pictures - Selected files only")
+        assertLocationState(locations, DCIM, "partial", "Camera (DCIM) - Selected files only")
+        assertLocationState(locations, MOVIES, "partial", "Movies - Selected files only")
+        // Non-visual location is untouched by the visual selection state.
+        assertLocationState(locations, MUSIC, "full", "Music - All files")
+    }
+
+    @Test
+    @Order(4)
+    fun `partial access lists only owned rows`() {
+        // No picker selections exist in this suite, so MediaProvider limits the
+        // (owner-unfiltered) query to rows owned by the app.
+        val names = listFixtureDirNames()
+        assertTrue(names.contains("owned.jpg"), "names=$names")
+        assertFalse(names.contains("nonowned.jpg"), "names=$names")
+        assertEquals("owned-content", readFileContent("$FIXTURE_DIR/owned.jpg"))
+    }
+
+    @Test
+    @Order(5)
+    fun `partial access read of non owned file fails cleanly`() = runBlocking {
+        val result = mcpClient.callTool(
+            "${TOOL_PREFIX}read_file",
+            mapOf("location_id" to PICTURES, "path" to "$FIXTURE_DIR/nonowned.jpg"),
+        )
+        assertEquals(true, result.isError, "non-owned read must fail under partial access")
+        assertTrue(toolText(result).isNotBlank())
+    }
+
+    @Test
+    @Order(6)
+    fun `write works under partial access`() {
+        writeOwnedFile("$FIXTURE_DIR/owned2.jpg", "owned-2")
+        assertTrue(listFixtureDirNames().contains("owned2.jpg"))
+        assertEquals("owned-2", readFileContent("$FIXTURE_DIR/owned2.jpg"))
+    }
+
+    @Test
+    @Order(7)
+    fun `revoking user selected yields owned only`() {
+        StorageE2E.revokeMediaPermission(StorageE2E.PERM_VISUAL_USER_SELECTED)
+        StorageE2E.waitForAppProcessDeath()
+        StorageE2E.restartServerAndRefreshClient()
+
+        val locations = storageLocationsById()
+        assertLocationState(locations, PICTURES, "owned_only", "Pictures - Only owned files")
+        assertLocationState(locations, MOVIES, "owned_only", "Movies - Only owned files")
+        // Owner-filtered query path (includeNonOwned=false) still shows owned rows only.
+        val names = listFixtureDirNames()
+        assertTrue(names.contains("owned.jpg"), "names=$names")
+        assertFalse(names.contains("nonowned.jpg"), "names=$names")
+    }
+
+    @Test
+    @Order(8)
+    fun `regranting full permissions restores non owned visibility`() {
+        // pm grant does not kill the process and the app checks permissions live,
+        // so no server restart is needed.
+        StorageE2E.grantMediaPermission(StorageE2E.PERM_IMAGES)
+        StorageE2E.grantMediaPermission(StorageE2E.PERM_VIDEO)
+
+        val locations = storageLocationsById()
+        assertLocationState(locations, PICTURES, "full", "Pictures - All files")
+        val names = listFixtureDirNames()
+        assertTrue(names.contains("nonowned.jpg"), "names=$names")
+        assertTrue(names.contains("owned.jpg"), "names=$names")
+        assertEquals("nonowned-content", readFileContent("$FIXTURE_DIR/nonowned.jpg"))
+    }
+}

--- a/e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/E2EStorageToolsTest.kt
+++ b/e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/E2EStorageToolsTest.kt
@@ -378,7 +378,7 @@ class E2EStorageToolsTest {
             "${TOOL_PREFIX}write_file",
             mapOf("location_id" to PICTURES, "path" to "readable.jpg", "content" to "overwrite-attempt"),
         )
-        // Observed redroid 13 (API 33) behavior — documents the platform, revisit on image upgrade:
+        // Observed redroid 13 (API 33) and 14 (API 34) behavior — documents the platform, revisit on image upgrade:
         // the write succeeds and MediaStore auto-renames the new row to "readable (1).jpg";
         // the non-owned original row and its content are untouched.
         assertNotEquals(true, result.isError, toolText(result))
@@ -454,7 +454,7 @@ class E2EStorageToolsTest {
                 "url" to "$fixtureBaseUrl/truncated.txt",
             ),
         )
-        // Observed redroid 13 (API 33) behavior — documents the platform, revisit on image upgrade:
+        // Observed redroid 13 (API 33) and 14 (API 34) behavior — documents the platform, revisit on image upgrade:
         // the mid-stream cut fails cleanly ("unexpected end of stream") and the pending
         // MediaStore row is deleted — no partial file remains in the listing.
         assertEquals(true, result.isError)

--- a/e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/FixtureHttpServer.kt
+++ b/e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/FixtureHttpServer.kt
@@ -52,7 +52,7 @@ class FixtureHttpServer {
     /**
      * Base URL as reachable FROM INSIDE the container.
      *
-     * Verified mechanism on redroid 13 (plan empirical procedure 2): the primary
+     * Verified mechanism on redroid 13 and 14 (plan empirical procedure 2): the primary
      * `host.testcontainers.internal` name is NOT resolvable inside redroid's Android
      * runtime (Android's resolver does not see the Testcontainers hosts entry), so the
      * container's default-gateway IP — the host on podman's bridge — is used instead.

--- a/e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/StorageE2E.kt
+++ b/e2e-tests/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/e2e/StorageE2E.kt
@@ -18,6 +18,9 @@ object StorageE2E {
     const val PERM_IMAGES = "android.permission.READ_MEDIA_IMAGES"
     const val PERM_VIDEO = "android.permission.READ_MEDIA_VIDEO"
     const val PERM_AUDIO = "android.permission.READ_MEDIA_AUDIO"
+
+    /** Platform permission backing Android 14+ partial photo access (API 34+ only). */
+    const val PERM_VISUAL_USER_SELECTED = "android.permission.READ_MEDIA_VISUAL_USER_SELECTED"
     private const val SDCARD = "/storage/emulated/0"
     private const val E2E_ACTION_BASE = "com.danielealbano.androidremotecontrolmcp.debug"
     private const val E2E_CONFIG_RECEIVER =
@@ -83,7 +86,7 @@ object StorageE2E {
     }
 
     /**
-     * Triggers a MediaStore scan. Mechanism verified empirically against redroid 13
+     * Triggers a MediaStore scan. Mechanism verified empirically against redroid 13 and 14
      * per the plan's procedure (scan_volume primary; scan_file per path; legacy
      * broadcast last). The verified mechanism is kept, the others removed.
      */


### PR DESCRIPTION
## Summary

Upgrades the E2E container image from `redroid/redroid:13.0.0-latest` (API 33) to `redroid/redroid:14.0.0-latest` (API 34) and adds end-to-end coverage for Android 14+ partial photo access (`READ_MEDIA_VISUAL_USER_SELECTED`) — the access mode behind the recent camera-roll bug fix, which was previously untestable on the API 33 image.

## Changes

- **redroid 14 adoption**: `AndroidContainerSetup.DOCKER_IMAGE`, CI image pre-pull, and docs references (`CLAUDE.md`, `docs/PROJECT.md`) switched to `14.0.0-latest`. No other CI changes are needed: the kernel prerequisites (binder_linux/binderfs, fuse) are identical for both images.
- **Pinned platform behaviors re-verified**: all eight "Observed redroid 13 (API 33)" pinned behaviors (MediaProvider auto-rename, dotfile skipping, zero-byte indexing, pagination edge semantics, etc.) pass unchanged on API 34; their comments now document both images, as do the fixture-server gateway and media-scan mechanism notes.
- **New `E2EStoragePartialAccessTest`** (8 ordered tests): drives the full permission state machine via `pm grant`/`pm revoke` — baseline full access, lingering `USER_SELECTED` grant with full access (FULL must win), partial access after revoking the visual permissions (Pictures/DCIM/Movies report `partial` / "Selected files only", Music stays `full`), MediaProvider row filtering under partial access (owned rows only, non-owned reads fail cleanly, writes unaffected), owned-only after revoking `USER_SELECTED`, and live restoration of non-owned visibility on re-grant. Revoke-induced process kills recover via the established death-wait + server-restart + client-refresh pattern; teardown restores the baseline permission state so the class is order-independent. The class skips itself on API < 34, keeping the suite valid on older images.

## Testing

- Full E2E suite green on redroid 14: 92 tests, 0 failures, 0 errors, 14 skipped (camera tests, same as on redroid 13).
- New class validated standalone (8/8) and within the full suite alongside the existing storage suites.
- `make lint` green; zero build warnings.