### PR TITLE
fix: fallback to static edge endpoints in cloudflared for physical Android & add ADB config extras

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -351,6 +351,9 @@ compile-cloudflared: ## Cross-compile cloudflared for Android (requires Go + And
 	fi
 	@echo "Compiling cloudflared from submodule ($(CLOUDFLARED_SRC_DIR))..."
 	@echo "Using NDK: $(NDK_ROOT)"
+	@if [ -f "vendor/cloudflared-android-dns.patch" ]; then \
+		cd $(CLOUDFLARED_SRC_DIR) && git apply --check ../cloudflared-android-dns.patch 2>/dev/null && git apply ../cloudflared-android-dns.patch || true; \
+	fi
 	@echo ""
 	@echo "Compiling cloudflared for arm64-v8a..."
 	mkdir -p $(CLOUDFLARED_JNILIBS_DIR)/arm64-v8a

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/mcp/AdbConfigHandler.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/mcp/AdbConfigHandler.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.util.Log
 import com.danielealbano.androidremotecontrolmcp.data.model.BindingAddress
 import com.danielealbano.androidremotecontrolmcp.data.model.CertificateSource
+import com.danielealbano.androidremotecontrolmcp.data.model.CloudflareTunnelMode
 import com.danielealbano.androidremotecontrolmcp.data.model.ServerLogEntry
 import com.danielealbano.androidremotecontrolmcp.data.model.ToolPermissionsConfig
 import com.danielealbano.androidremotecontrolmcp.data.model.TunnelProviderType
@@ -57,6 +58,8 @@ class AdbConfigHandler(
         applyCertificateHostname(intent)
         applyTunnelEnabled(intent)
         applyTunnelProvider(intent)
+        applyCloudflareTunnelMode(intent)
+        applyCloudflareTunnelToken(intent)
         applyNgrokAuthtoken(intent)
         applyNgrokDomain(intent)
         applyFileSizeLimit(intent)
@@ -225,6 +228,33 @@ class AdbConfigHandler(
         Log.i(TAG, "Tunnel provider updated to $provider")
     }
 
+    private suspend fun applyCloudflareTunnelMode(intent: Intent) {
+        val value = intent.getStringExtra(EXTRA_CLOUDFLARE_TUNNEL_MODE) ?: return
+        val mode =
+            try {
+                CloudflareTunnelMode.valueOf(value)
+            } catch (_: IllegalArgumentException) {
+                Log.w(
+                    TAG,
+                    "Ignoring invalid cloudflare_tunnel_mode '$value' " +
+                        "(valid: ${CloudflareTunnelMode.entries.joinToString()})",
+                )
+                return
+            }
+        settingsRepository.updateCloudflareTunnelMode(mode)
+        Log.i(TAG, "Cloudflare tunnel mode updated to $mode")
+    }
+
+    private suspend fun applyCloudflareTunnelToken(intent: Intent) {
+        val value = intent.getStringExtra(EXTRA_CLOUDFLARE_TUNNEL_TOKEN) ?: return
+        if (value.isEmpty()) {
+            Log.w(TAG, "Ignoring empty cloudflare_tunnel_token")
+            return
+        }
+        settingsRepository.updateCloudflareTunnelToken(value)
+        Log.i(TAG, "Cloudflare tunnel token updated (length=${value.length})")
+    }
+
     private suspend fun applyNgrokAuthtoken(intent: Intent) {
         val value = intent.getStringExtra(EXTRA_NGROK_AUTHTOKEN) ?: return
         if (value.isEmpty()) {
@@ -360,6 +390,8 @@ class AdbConfigHandler(
         internal const val EXTRA_CERTIFICATE_HOSTNAME = "certificate_hostname"
         internal const val EXTRA_TUNNEL_ENABLED = "tunnel_enabled"
         internal const val EXTRA_TUNNEL_PROVIDER = "tunnel_provider"
+        internal const val EXTRA_CLOUDFLARE_TUNNEL_MODE = "cloudflare_tunnel_mode"
+        internal const val EXTRA_CLOUDFLARE_TUNNEL_TOKEN = "cloudflare_tunnel_token"
         internal const val EXTRA_NGROK_AUTHTOKEN = "ngrok_authtoken"
         internal const val EXTRA_NGROK_DOMAIN = "ngrok_domain"
         internal const val EXTRA_FILE_SIZE_LIMIT_MB = "file_size_limit_mb"

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/mcp/AdbConfigHandlerTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/mcp/AdbConfigHandlerTest.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.util.Log
 import com.danielealbano.androidremotecontrolmcp.data.model.BindingAddress
 import com.danielealbano.androidremotecontrolmcp.data.model.CertificateSource
+import com.danielealbano.androidremotecontrolmcp.data.model.CloudflareTunnelMode
 import com.danielealbano.androidremotecontrolmcp.data.model.ServerConfig
 import com.danielealbano.androidremotecontrolmcp.data.model.ServerLogEntry
 import com.danielealbano.androidremotecontrolmcp.data.model.ToolPermissionsConfig
@@ -402,6 +403,66 @@ class AdbConfigHandlerTest {
                     }
                 handler.handle(context, intent)
                 coVerify(exactly = 0) { settingsRepository.updateTunnelProvider(any()) }
+            }
+
+        @Test
+        @DisplayName("cloudflare_tunnel_mode FREE is applied")
+        fun cloudflareTunnelModeFree() =
+            runTest {
+                val intent =
+                    createIntent(AdbConfigReceiver.ACTION_CONFIGURE) {
+                        string(AdbConfigHandler.EXTRA_CLOUDFLARE_TUNNEL_MODE, "FREE")
+                    }
+                handler.handle(context, intent)
+                coVerify { settingsRepository.updateCloudflareTunnelMode(CloudflareTunnelMode.FREE) }
+            }
+
+        @Test
+        @DisplayName("cloudflare_tunnel_mode TOKEN is applied")
+        fun cloudflareTunnelModeToken() =
+            runTest {
+                val intent =
+                    createIntent(AdbConfigReceiver.ACTION_CONFIGURE) {
+                        string(AdbConfigHandler.EXTRA_CLOUDFLARE_TUNNEL_MODE, "TOKEN")
+                    }
+                handler.handle(context, intent)
+                coVerify { settingsRepository.updateCloudflareTunnelMode(CloudflareTunnelMode.TOKEN) }
+            }
+
+        @Test
+        @DisplayName("invalid cloudflare_tunnel_mode is rejected")
+        fun invalidCloudflareTunnelMode() =
+            runTest {
+                val intent =
+                    createIntent(AdbConfigReceiver.ACTION_CONFIGURE) {
+                        string(AdbConfigHandler.EXTRA_CLOUDFLARE_TUNNEL_MODE, "INVALID")
+                    }
+                handler.handle(context, intent)
+                coVerify(exactly = 0) { settingsRepository.updateCloudflareTunnelMode(any()) }
+            }
+
+        @Test
+        @DisplayName("cloudflare_tunnel_token is applied")
+        fun cloudflareTunnelToken() =
+            runTest {
+                val intent =
+                    createIntent(AdbConfigReceiver.ACTION_CONFIGURE) {
+                        string(AdbConfigHandler.EXTRA_CLOUDFLARE_TUNNEL_TOKEN, "eyJhIjoidGVzdCJ9")
+                    }
+                handler.handle(context, intent)
+                coVerify { settingsRepository.updateCloudflareTunnelToken("eyJhIjoidGVzdCJ9") }
+            }
+
+        @Test
+        @DisplayName("empty cloudflare_tunnel_token is ignored")
+        fun emptyCloudflareTunnelToken() =
+            runTest {
+                val intent =
+                    createIntent(AdbConfigReceiver.ACTION_CONFIGURE) {
+                        string(AdbConfigHandler.EXTRA_CLOUDFLARE_TUNNEL_TOKEN, "")
+                    }
+                handler.handle(context, intent)
+                coVerify(exactly = 0) { settingsRepository.updateCloudflareTunnelToken(any()) }
             }
 
         @Test

--- a/vendor/cloudflared-android-dns.patch
+++ b/vendor/cloudflared-android-dns.patch
@@ -1,0 +1,63 @@
+diff --git edgediscovery/allregions/discovery.go edgediscovery/allregions/discovery.go
+index cab06611..2d4f03f4 100644
+--- edgediscovery/allregions/discovery.go
++++ edgediscovery/allregions/discovery.go
+@@ -3,11 +3,9 @@ package allregions
+ import (
+ 	"context"
+ 	"crypto/tls"
+-	"fmt"
+ 	"net"
+ 	"time"
+ 
+-	"github.com/pkg/errors"
+ 	"github.com/rs/zerolog"
+ 
+ 	"github.com/cloudflare/cloudflared/management"
+@@ -119,16 +117,15 @@ func edgeDiscovery(log *zerolog.Logger, srvService string) ([][]*EdgeAddr, error
+ 	_, addrs, err := netLookupSRV(srvService, srvProto, srvName)
+ 	if err != nil {
+ 		_, fallbackAddrs, fallbackErr := fallbackLookupSRV(srvService, srvProto, srvName)
+-		if fallbackErr != nil || len(fallbackAddrs) == 0 {
+-			// use the original DNS error `err` in messages, not `fallbackErr`
+-			logger.Err(err).Msg("edge discovery: error looking up Cloudflare edge IPs: the DNS query failed")
+-			for _, s := range friendlyDNSErrorLines {
+-				logger.Error().Msg(s)
++		if fallbackErr == nil && len(fallbackAddrs) > 0 {
++			addrs = fallbackAddrs
++		} else {
++			logger.Warn().Msg("edge discovery: dynamic SRV lookup failed, falling back to static region1/region2 SRV targets")
++			addrs = []*net.SRV{
++				{Target: "region1.v2.argotunnel.com.", Port: 7844, Priority: 1, Weight: 1},
++				{Target: "region2.v2.argotunnel.com.", Port: 7844, Priority: 2, Weight: 1},
+ 			}
+-			return nil, errors.Wrapf(err, "Could not lookup srv records on _%v._%v.%v", srvService, srvProto, srvName)
+ 		}
+-		// Accept the fallback results and keep going
+-		addrs = fallbackAddrs
+ 	}
+ 
+ 	var resolvedAddrPerCNAME [][]*EdgeAddr
+@@ -171,11 +168,17 @@ func lookupSRVWithDOT(srvService string, srvProto string, srvName string) (cname
+ 
+ func resolveSRV(srv *net.SRV) ([]*EdgeAddr, error) {
+ 	ips, err := netLookupIP(srv.Target)
+-	if err != nil {
+-		return nil, errors.Wrapf(err, "Couldn't resolve SRV record %v", srv)
+-	}
+-	if len(ips) == 0 {
+-		return nil, fmt.Errorf("SRV record %v had no IPs", srv)
++	if err != nil || len(ips) == 0 {
++		ips = []net.IP{
++			net.ParseIP("198.41.192.167"),
++			net.ParseIP("198.41.192.67"),
++			net.ParseIP("198.41.192.37"),
++			net.ParseIP("198.41.192.107"),
++			net.ParseIP("198.41.200.13"),
++			net.ParseIP("198.41.200.193"),
++			net.ParseIP("198.41.200.43"),
++			net.ParseIP("198.41.200.73"),
++		}
+ 	}
+ 	addrs := make([]*EdgeAddr, len(ips))
+ 	for i, ip := range ips {


### PR DESCRIPTION
Resolves #164

### Summary
This PR resolves the `cloudflared` crash/exit issue on physical Android devices due to missing `/etc/resolv.conf` and adds missing Cloudflare tunnel extras to `AdbConfigHandler`.

### Details
1. **Cloudflare DNS fallback for Android**:
   - On physical Android devices, `/etc/resolv.conf` does not exist, causing Go's standard DNS resolver to fall back to `[::1]:53` and fail with `connection refused`.
   - Added `vendor/cloudflared-android-dns.patch` to fall back to static Anycast edge targets (`region1.v2.argotunnel.com:7844` / `region2.v2.argotunnel.com:7844`) and Anycast edge IPs when SRV and DoT lookups fail on Android.
   - Updated `Makefile` to apply the patch during `compile-cloudflared`.

2. **ADB Headless Configuration for Cloudflare**:
   - Added `EXTRA_CLOUDFLARE_TUNNEL_MODE` (`cloudflare_tunnel_mode`) and `EXTRA_CLOUDFLARE_TUNNEL_TOKEN` (`cloudflare_tunnel_token`) to `AdbConfigHandler`.
   - Added comprehensive unit tests in `AdbConfigHandlerTest`.

### Verification
- Tested on physical Xiaomi Mi 10 (Android 13 / arm64-v8a).
- Verified full remote MCP protocol initialization and live tool execution over WAN tunnel.
- Unit tests in `AdbConfigHandlerTest` pass.
