### PR TITLE
Port to Android 12: lower minSdk to 31 with guarded API-33 calls

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ See [docs/PROJECT.md](docs/PROJECT.md) for the complete project conventions.
 - **Maven** (for compiling ngrok Java library; install from [maven.apache.org](https://maven.apache.org/install.html))
 
 ### For Running
-- Android device or emulator running **Android 13+** (API 33+), targeting **Android 14** (API 34)
+- Android device or emulator running **Android 12+** (API 31+), targeting **Android 14** (API 34)
 - **adb** (Android Debug Bridge) for device/emulator management
 
 ### For E2E Tests

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -218,7 +218,10 @@ android {
 
     defaultConfig {
         applicationId = "com.danielealbano.androidremotecontrolmcp"
-        minSdk = 33
+        // Android 12 (API 31) port: lowered from 33. All Android 13+ (API 33) and
+        // Android 14+ (API 34) API calls are guarded at runtime (see
+        // PermissionUtils, PermissionCheckerImpl, MainActivity, NotificationProviderImpl).
+        minSdk = 31
         targetSdk = 34
         versionCode = versionCodeProp
         versionName = versionNameProp

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -537,6 +537,7 @@ val jacocoExcludes =
         "**/services/mcp/BootCompletedReceiver*",
         "**/services/screencapture/ScreenCaptureService*",
         "**/services/accessibility/McpAccessibilityService*",
+        "**/services/accessibility/McpInputMethodService*",
         // Update check: WorkManager worker, scheduler, and notifier require Android framework
         "**/services/update/UpdateCheckWorker*",
         "**/services/update/UpdateCheckScheduler*",

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -116,6 +116,21 @@
                 android:resource="@xml/accessibility_service_config" />
         </service>
 
+        <!-- Classic IME used for text input on Android 12 (API 31/32), where the API-33
+             AccessibilityService.InputMethod does not exist. -->
+        <service
+            android:name=".services.accessibility.McpInputMethodService"
+            android:label="ARC MCP IME"
+            android:permission="android.permission.BIND_INPUT_METHOD"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.view.InputMethod" />
+            </intent-filter>
+            <meta-data
+                android:name="android.view.im"
+                android:resource="@xml/mcp_ime" />
+        </service>
+
         <!-- Notification Listener Service -->
         <service
             android:name=".services.notifications.McpNotificationListenerService"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,9 +41,9 @@
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
-    <!-- Android 12 (API 31/32) port: READ_MEDIA_* do not exist below API 33; the
-         equivalent media-read grant on 31/32 is READ_EXTERNAL_STORAGE (normal
-         permission, granted at install). maxSdkVersion 32 keeps it off 33+. -->
+    <!-- Android 12 (API 31/32) port: READ_EXTERNAL_STORAGE is a dangerous permission
+         that users can grant at runtime. maxSdkVersion 32 is set because READ_MEDIA_*
+         supersedes it on API 33+. -->
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,6 +41,12 @@
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
+    <!-- Android 12 (API 31/32) port: READ_MEDIA_* do not exist below API 33; the
+         equivalent media-read grant on 31/32 is READ_EXTERNAL_STORAGE (normal
+         permission, granted at install). maxSdkVersion 32 keeps it off 33+. -->
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
 
     <uses-feature android:name="android.hardware.camera" android:required="false" />
     <uses-feature android:name="android.hardware.microphone" android:required="false" />

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/McpAccessibilityService.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/McpAccessibilityService.kt
@@ -10,6 +10,7 @@ import android.graphics.Bitmap
 import android.graphics.Color
 import android.graphics.PixelFormat
 import android.graphics.drawable.GradientDrawable
+import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
@@ -239,6 +240,12 @@ class McpAccessibilityService : AccessibilityService() {
         )
     }
 
+    /**
+     * Android 12 (API 31/32) port: the framework only invokes this override on API 33+
+     * (the base AccessibilityService.onCreateInputMethod did not exist before 33), so the
+     * whole method is @RequiresApi(TIRAMISU) — no guard needed, and never called below 33.
+     */
+    @androidx.annotation.RequiresApi(Build.VERSION_CODES.TIRAMISU)
     override fun onCreateInputMethod(): InputMethod {
         val method = McpInputMethod(this)
         inputMethodInstance = method
@@ -375,16 +382,30 @@ class McpAccessibilityService : AccessibilityService() {
 
     /**
      * Drops the framework's accessibility node cache for this service via [clearCache] (public
-     * since API 33; minSdk is 33). See [AccessibilityServiceProvider.clearFrameworkNodeCache] for
+     * since API 33). See [AccessibilityServiceProvider.clearFrameworkNodeCache] for
      * why this is needed to defeat stale WebView reads after JavaScript DOM changes.
+     *
+     * Android 12 (API 31/32) port: [AccessibilityService.clearCache] does not exist below
+     * API 33 — guard the call. On 31/32 the framework cache cannot be flushed this way; the
+     * caller's own [invalidateCache] (our id→node cache) still works, so this is a best-effort
+     * no-op rather than a crash.
      *
      * This is distinct from [invalidateCache], which flushes our own id→node [nodeCache]; this
      * clears the framework-side cache that backs [rootInActiveWindow]/[getWindows] traversal.
      */
     fun clearFrameworkNodeCache() {
-        clearCache()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            clearCache()
+        }
     }
 
+    /**
+     * API 33+ only: android.accessibilityservice.InputMethod (and its
+     * AccessibilityInputConnection) do not exist below API 33, and
+     * [McpAccessibilityService.onCreateInputMethod] never creates [McpInputMethod] below
+     * 33, so this class can never be instantiated on API < 33.
+     */
+    @androidx.annotation.RequiresApi(Build.VERSION_CODES.TIRAMISU)
     class McpInputMethod(
         service: AccessibilityService,
     ) : InputMethod(service)

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/McpInputMethodService.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/McpInputMethodService.kt
@@ -1,0 +1,24 @@
+package com.danielealbano.androidremotecontrolmcp.services.accessibility
+
+import android.inputmethodservice.InputMethodService
+import android.view.inputmethod.InputConnection
+
+class McpInputMethodService : InputMethodService() {
+    override fun onCreate() {
+        super.onCreate()
+        instance = this
+    }
+
+    override fun onDestroy() {
+        if (instance === this) instance = null
+        super.onDestroy()
+    }
+
+    fun currentConnection(): InputConnection? = currentInputConnection
+
+    companion object {
+        @Volatile
+        var instance: McpInputMethodService? = null
+            private set
+    }
+}

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/TypeInputController.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/TypeInputController.kt
@@ -4,12 +4,12 @@ import android.view.KeyEvent
 import android.view.inputmethod.SurroundingText
 
 /**
- * Abstraction over AccessibilityInputConnection operations for natural text input.
- * Wraps the InputMethod API (API 33+) provided by the AccessibilityService
- * with FLAG_INPUT_METHOD_EDITOR.
+ * Abstraction over input connection operations for natural text input.
+ * API 33+ uses the AccessibilityService InputMethod API with FLAG_INPUT_METHOD_EDITOR;
+ * API 31/32 uses the classic InputMethodService fallback.
  *
- * Implementations access the real AccessibilityInputConnection via
- * McpAccessibilityService's InputMethod instance.
+ * Implementations access either the AccessibilityInputConnection via McpAccessibilityService
+ * or the classic InputConnection via McpInputMethodService.
  *
  * **Threading**: The AccessibilityInputConnection obtained from InputMethod is an
  * IPC proxy managed by the accessibility framework — it is NOT a View-bound

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/TypeInputControllerImpl.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/TypeInputControllerImpl.kt
@@ -4,24 +4,17 @@ import android.annotation.SuppressLint
 import android.accessibilityservice.InputMethod.AccessibilityInputConnection
 import android.os.Build
 import android.view.KeyEvent
+import android.view.inputmethod.InputConnection
 import android.view.inputmethod.SurroundingText
 import javax.inject.Inject
 
 /**
  * Implementation of [TypeInputController] that delegates to the
- * [AccessibilityInputConnection] obtained from the [McpAccessibilityService]'s
- * [InputMethod] instance.
+ * API-33+ [AccessibilityInputConnection] or the classic [InputConnection] exposed by
+ * [McpInputMethodService] on API 31/32.
  *
- * **Android 12 (API 31/32) port**: `android.accessibilityservice.InputMethod` and
- * `AccessibilityInputConnection` only exist from API 33 on, and
- * [McpAccessibilityService.onCreateInputMethod] never creates the input method below 33,
- * so every method short-circuits to "not available" there. The typing tools surface this
- * as "input method not ready" instead of crashing. `@SuppressLint("NewApi")` is justified
- * because every API-33 reference is behind an explicit `SDK_INT >= TIRAMISU` guard, so no
- * API-33 symbol is ever resolved below 33.
- *
- * All methods access the singleton [McpAccessibilityService.inputMethodInstance]
- * to get the current [AccessibilityInputConnection].
+ * API-33 references are guarded by `SDK_INT >= TIRAMISU`; below API 33 all operations use
+ * [McpInputMethodService.instance].
  *
  * **Threading**: The AccessibilityInputConnection is an IPC proxy managed by
  * the accessibility framework — NOT a View-bound InputConnection. Methods can
@@ -33,43 +26,50 @@ import javax.inject.Inject
  * Callers must use the file-level `typeOperationMutex` in the typing tools
  * to serialize operations and prevent interleaved character commits.
  *
- * **Return values**: The underlying AccessibilityInputConnection methods return
- * `void`. The Boolean return here indicates IC availability only — NOT whether
- * the target field accepted the operation.
+ * **Return values**: API-33+ calls wrap the void accessibility methods as `true` when
+ * dispatched. API 31/32 calls forward the classic input connection's Boolean result.
  */
 @SuppressLint("NewApi")
 class TypeInputControllerImpl
     @Inject
     constructor() : TypeInputController {
-        private fun getInputConnection(): AccessibilityInputConnection? {
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return null
-            return McpAccessibilityService.inputMethodInstance?.getCurrentInputConnection()
-        }
+        private fun getAccessibilityInputConnection(): AccessibilityInputConnection? =
+            McpAccessibilityService.inputMethodInstance?.getCurrentInputConnection()
+
+        private fun getClassicInputConnection(): InputConnection? = McpInputMethodService.instance?.currentConnection()
 
         override fun isReady(): Boolean {
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return false
-            return McpAccessibilityService.inputMethodInstance?.getCurrentInputStarted() == true &&
-                getInputConnection() != null
+            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                McpAccessibilityService.inputMethodInstance?.getCurrentInputStarted() == true
+            } else {
+                getClassicInputConnection() != null
+            }
         }
 
         override fun commitText(
             text: CharSequence,
             newCursorPosition: Int,
         ): Boolean {
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return false
-            val ic = getInputConnection() ?: return false
-            ic.commitText(text, newCursorPosition, null)
-            return true
+            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                val connection = getAccessibilityInputConnection() ?: return false
+                connection.commitText(text, newCursorPosition, null)
+                true
+            } else {
+                getClassicInputConnection()?.commitText(text, newCursorPosition) ?: false
+            }
         }
 
         override fun setSelection(
             start: Int,
             end: Int,
         ): Boolean {
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return false
-            val ic = getInputConnection() ?: return false
-            ic.setSelection(start, end)
-            return true
+            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                val connection = getAccessibilityInputConnection() ?: return false
+                connection.setSelection(start, end)
+                true
+            } else {
+                getClassicInputConnection()?.setSelection(start, end) ?: false
+            }
         }
 
         override fun getSurroundingText(
@@ -77,31 +77,43 @@ class TypeInputControllerImpl
             afterLength: Int,
             flags: Int,
         ): SurroundingText? {
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return null
-            return getInputConnection()?.getSurroundingText(beforeLength, afterLength, flags)
+            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                getAccessibilityInputConnection()?.getSurroundingText(beforeLength, afterLength, flags)
+            } else {
+                getClassicInputConnection()?.getSurroundingText(beforeLength, afterLength, flags)
+            }
         }
 
         override fun performContextMenuAction(id: Int): Boolean {
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return false
-            val ic = getInputConnection() ?: return false
-            ic.performContextMenuAction(id)
-            return true
+            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                val connection = getAccessibilityInputConnection() ?: return false
+                connection.performContextMenuAction(id)
+                true
+            } else {
+                getClassicInputConnection()?.performContextMenuAction(id) ?: false
+            }
         }
 
         override fun sendKeyEvent(event: KeyEvent): Boolean {
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return false
-            val ic = getInputConnection() ?: return false
-            ic.sendKeyEvent(event)
-            return true
+            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                val connection = getAccessibilityInputConnection() ?: return false
+                connection.sendKeyEvent(event)
+                true
+            } else {
+                getClassicInputConnection()?.sendKeyEvent(event) ?: false
+            }
         }
 
         override fun deleteSurroundingText(
             beforeLength: Int,
             afterLength: Int,
         ): Boolean {
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return false
-            val ic = getInputConnection() ?: return false
-            ic.deleteSurroundingText(beforeLength, afterLength)
-            return true
+            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                val connection = getAccessibilityInputConnection() ?: return false
+                connection.deleteSurroundingText(beforeLength, afterLength)
+                true
+            } else {
+                getClassicInputConnection()?.deleteSurroundingText(beforeLength, afterLength) ?: false
+            }
         }
     }

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/TypeInputControllerImpl.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/TypeInputControllerImpl.kt
@@ -1,11 +1,11 @@
 package com.danielealbano.androidremotecontrolmcp.services.accessibility
 
 import android.accessibilityservice.InputMethod.AccessibilityInputConnection
-import android.annotation.SuppressLint
 import android.os.Build
 import android.view.KeyEvent
 import android.view.inputmethod.InputConnection
 import android.view.inputmethod.SurroundingText
+import androidx.annotation.RequiresApi
 import javax.inject.Inject
 
 /**
@@ -29,10 +29,10 @@ import javax.inject.Inject
  * **Return values**: API-33+ calls wrap the void accessibility methods as `true` when
  * dispatched. API 31/32 calls forward the classic input connection's Boolean result.
  */
-@SuppressLint("NewApi")
 class TypeInputControllerImpl
     @Inject
     constructor() : TypeInputController {
+        @RequiresApi(Build.VERSION_CODES.TIRAMISU)
         private fun getAccessibilityInputConnection(): AccessibilityInputConnection? =
             McpAccessibilityService.inputMethodInstance?.getCurrentInputConnection()
 

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/TypeInputControllerImpl.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/TypeInputControllerImpl.kt
@@ -1,7 +1,7 @@
 package com.danielealbano.androidremotecontrolmcp.services.accessibility
 
-import android.annotation.SuppressLint
 import android.accessibilityservice.InputMethod.AccessibilityInputConnection
+import android.annotation.SuppressLint
 import android.os.Build
 import android.view.KeyEvent
 import android.view.inputmethod.InputConnection
@@ -38,13 +38,12 @@ class TypeInputControllerImpl
 
         private fun getClassicInputConnection(): InputConnection? = McpInputMethodService.instance?.currentConnection()
 
-        override fun isReady(): Boolean {
-            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        override fun isReady(): Boolean =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 McpAccessibilityService.inputMethodInstance?.getCurrentInputStarted() == true
             } else {
                 getClassicInputConnection() != null
             }
-        }
 
         override fun commitText(
             text: CharSequence,
@@ -76,13 +75,12 @@ class TypeInputControllerImpl
             beforeLength: Int,
             afterLength: Int,
             flags: Int,
-        ): SurroundingText? {
-            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        ): SurroundingText? =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 getAccessibilityInputConnection()?.getSurroundingText(beforeLength, afterLength, flags)
             } else {
                 getClassicInputConnection()?.getSurroundingText(beforeLength, afterLength, flags)
             }
-        }
 
         override fun performContextMenuAction(id: Int): Boolean {
             return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/TypeInputControllerImpl.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/TypeInputControllerImpl.kt
@@ -1,5 +1,8 @@
 package com.danielealbano.androidremotecontrolmcp.services.accessibility
 
+import android.annotation.SuppressLint
+import android.accessibilityservice.InputMethod.AccessibilityInputConnection
+import android.os.Build
 import android.view.KeyEvent
 import android.view.inputmethod.SurroundingText
 import javax.inject.Inject
@@ -8,6 +11,14 @@ import javax.inject.Inject
  * Implementation of [TypeInputController] that delegates to the
  * [AccessibilityInputConnection] obtained from the [McpAccessibilityService]'s
  * [InputMethod] instance.
+ *
+ * **Android 12 (API 31/32) port**: `android.accessibilityservice.InputMethod` and
+ * `AccessibilityInputConnection` only exist from API 33 on, and
+ * [McpAccessibilityService.onCreateInputMethod] never creates the input method below 33,
+ * so every method short-circuits to "not available" there. The typing tools surface this
+ * as "input method not ready" instead of crashing. `@SuppressLint("NewApi")` is justified
+ * because every API-33 reference is behind an explicit `SDK_INT >= TIRAMISU` guard, so no
+ * API-33 symbol is ever resolved below 33.
  *
  * All methods access the singleton [McpAccessibilityService.inputMethodInstance]
  * to get the current [AccessibilityInputConnection].
@@ -26,19 +37,26 @@ import javax.inject.Inject
  * `void`. The Boolean return here indicates IC availability only — NOT whether
  * the target field accepted the operation.
  */
+@SuppressLint("NewApi")
 class TypeInputControllerImpl
     @Inject
     constructor() : TypeInputController {
-        private fun getInputConnection() = McpAccessibilityService.inputMethodInstance?.getCurrentInputConnection()
+        private fun getInputConnection(): AccessibilityInputConnection? {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return null
+            return McpAccessibilityService.inputMethodInstance?.getCurrentInputConnection()
+        }
 
-        override fun isReady(): Boolean =
-            McpAccessibilityService.inputMethodInstance?.getCurrentInputStarted() == true &&
+        override fun isReady(): Boolean {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return false
+            return McpAccessibilityService.inputMethodInstance?.getCurrentInputStarted() == true &&
                 getInputConnection() != null
+        }
 
         override fun commitText(
             text: CharSequence,
             newCursorPosition: Int,
         ): Boolean {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return false
             val ic = getInputConnection() ?: return false
             ic.commitText(text, newCursorPosition, null)
             return true
@@ -48,6 +66,7 @@ class TypeInputControllerImpl
             start: Int,
             end: Int,
         ): Boolean {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return false
             val ic = getInputConnection() ?: return false
             ic.setSelection(start, end)
             return true
@@ -57,15 +76,20 @@ class TypeInputControllerImpl
             beforeLength: Int,
             afterLength: Int,
             flags: Int,
-        ): SurroundingText? = getInputConnection()?.getSurroundingText(beforeLength, afterLength, flags)
+        ): SurroundingText? {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return null
+            return getInputConnection()?.getSurroundingText(beforeLength, afterLength, flags)
+        }
 
         override fun performContextMenuAction(id: Int): Boolean {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return false
             val ic = getInputConnection() ?: return false
             ic.performContextMenuAction(id)
             return true
         }
 
         override fun sendKeyEvent(event: KeyEvent): Boolean {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return false
             val ic = getInputConnection() ?: return false
             ic.sendKeyEvent(event)
             return true
@@ -75,6 +99,7 @@ class TypeInputControllerImpl
             beforeLength: Int,
             afterLength: Int,
         ): Boolean {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return false
             val ic = getInputConnection() ?: return false
             ic.deleteSurroundingText(beforeLength, afterLength)
             return true

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/apps/AppIconCache.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/apps/AppIconCache.kt
@@ -3,6 +3,7 @@ package com.danielealbano.androidremotecontrolmcp.services.apps
 import android.content.Context
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
+import android.os.Build
 import androidx.core.graphics.drawable.toBitmap
 import com.danielealbano.androidremotecontrolmcp.utils.Logger
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -129,8 +130,14 @@ class AppIconCache
                 android.content.Intent(android.content.Intent.ACTION_MAIN).apply {
                     addCategory(android.content.Intent.CATEGORY_LAUNCHER)
                 }
-            return pm
-                .queryIntentActivities(launchIntent, PackageManager.ResolveInfoFlags.of(0))
+            val resolveInfos =
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    pm.queryIntentActivities(launchIntent, PackageManager.ResolveInfoFlags.of(0))
+                } else {
+                    @Suppress("DEPRECATION")
+                    pm.queryIntentActivities(launchIntent, 0)
+                }
+            return resolveInfos
                 .mapNotNull { resolveInfo ->
                     val pkgName = resolveInfo.activityInfo?.packageName ?: return@mapNotNull null
                     val label = resolveInfo.loadLabel(pm)?.toString() ?: return@mapNotNull null

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/location/ReverseGeocoder.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/location/ReverseGeocoder.kt
@@ -6,7 +6,9 @@ import android.location.Geocoder
 import android.os.Build
 import android.util.Log
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
 import java.util.Locale
 import kotlin.coroutines.resume
 
@@ -32,12 +34,16 @@ internal suspend fun reverseGeocode(
                     1,
                     object : Geocoder.GeocodeListener {
                         override fun onGeocode(addresses: List<Address>) {
-                            cont.resume(addresses.firstOrNull()?.getAddressLine(0))
+                            if (cont.isActive) {
+                                cont.resume(addresses.firstOrNull()?.getAddressLine(0))
+                            }
                         }
 
                         override fun onError(errorMessage: String?) {
                             Log.d(TAG, "Geocoder onError: $errorMessage")
-                            cont.resume(null)
+                            if (cont.isActive) {
+                                cont.resume(null)
+                            }
                         }
                     },
                 )
@@ -46,11 +52,13 @@ internal suspend fun reverseGeocode(
             // Android 12 (API 31/32) port: the GeocodeListener overload of
             // Geocoder.getFromLocation is API 33+; use the classic synchronous
             // overload below 33 (deprecated on 33+ but functional everywhere).
-            @Suppress("DEPRECATION")
-            Geocoder(context, Locale.getDefault())
-                .getFromLocation(latitude, longitude, 1)
-                ?.firstOrNull()
-                ?.getAddressLine(0)
+            withContext(Dispatchers.IO) {
+                @Suppress("DEPRECATION")
+                Geocoder(context, Locale.getDefault())
+                    .getFromLocation(latitude, longitude, 1)
+                    ?.firstOrNull()
+                    ?.getAddressLine(0)
+            }
         }
     } catch (e: CancellationException) {
         throw e

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/location/ReverseGeocoder.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/location/ReverseGeocoder.kt
@@ -3,6 +3,7 @@ package com.danielealbano.androidremotecontrolmcp.services.location
 import android.content.Context
 import android.location.Address
 import android.location.Geocoder
+import android.os.Build
 import android.util.Log
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -23,22 +24,33 @@ internal suspend fun reverseGeocode(
         return null
     }
     return try {
-        suspendCancellableCoroutine { cont ->
-            Geocoder(context, Locale.getDefault()).getFromLocation(
-                latitude,
-                longitude,
-                1,
-                object : Geocoder.GeocodeListener {
-                    override fun onGeocode(addresses: List<Address>) {
-                        cont.resume(addresses.firstOrNull()?.getAddressLine(0))
-                    }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            suspendCancellableCoroutine { cont ->
+                Geocoder(context, Locale.getDefault()).getFromLocation(
+                    latitude,
+                    longitude,
+                    1,
+                    object : Geocoder.GeocodeListener {
+                        override fun onGeocode(addresses: List<Address>) {
+                            cont.resume(addresses.firstOrNull()?.getAddressLine(0))
+                        }
 
-                    override fun onError(errorMessage: String?) {
-                        Log.d(TAG, "Geocoder onError: $errorMessage")
-                        cont.resume(null)
-                    }
-                },
-            )
+                        override fun onError(errorMessage: String?) {
+                            Log.d(TAG, "Geocoder onError: $errorMessage")
+                            cont.resume(null)
+                        }
+                    },
+                )
+            }
+        } else {
+            // Android 12 (API 31/32) port: the GeocodeListener overload of
+            // Geocoder.getFromLocation is API 33+; use the classic synchronous
+            // overload below 33 (deprecated on 33+ but functional everywhere).
+            @Suppress("DEPRECATION")
+            Geocoder(context, Locale.getDefault())
+                .getFromLocation(latitude, longitude, 1)
+                ?.firstOrNull()
+                ?.getAddressLine(0)
         }
     } catch (e: CancellationException) {
         throw e

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/notifications/NotificationDataExtractor.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/notifications/NotificationDataExtractor.kt
@@ -3,6 +3,7 @@ package com.danielealbano.androidremotecontrolmcp.services.notifications
 import android.app.Notification
 import android.content.Context
 import android.content.pm.PackageManager
+import android.os.Build
 import android.service.notification.StatusBarNotification
 import com.danielealbano.androidremotecontrolmcp.utils.Logger
 import java.util.concurrent.ConcurrentHashMap
@@ -21,10 +22,14 @@ object NotificationDataExtractor {
             appNameCache.getOrPut(sbn.packageName) {
                 val pm = context.packageManager
                 try {
-                    pm
-                        .getApplicationLabel(
-                            pm.getApplicationInfo(sbn.packageName, PackageManager.ApplicationInfoFlags.of(0)),
-                        ).toString()
+                    val appInfo =
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                            pm.getApplicationInfo(sbn.packageName, PackageManager.ApplicationInfoFlags.of(0))
+                        } else {
+                            @Suppress("DEPRECATION")
+                            pm.getApplicationInfo(sbn.packageName, 0)
+                        }
+                    pm.getApplicationLabel(appInfo).toString()
                 } catch (_: PackageManager.NameNotFoundException) {
                     Logger.d(TAG, "App not found for ${sbn.packageName}, using package name")
                     sbn.packageName

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/PermissionCheckerImpl.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/PermissionCheckerImpl.kt
@@ -1,7 +1,9 @@
 package com.danielealbano.androidremotecontrolmcp.services.storage
 
+import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
+import android.os.Build
 import androidx.core.content.ContextCompat
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
@@ -11,7 +13,28 @@ class PermissionCheckerImpl
     constructor(
         @param:ApplicationContext private val context: Context,
     ) : PermissionChecker {
-        override fun hasPermission(permission: String): Boolean =
-            ContextCompat.checkSelfPermission(context, permission) ==
+        /**
+         * Android 12 (API 31/32) port: READ_MEDIA_IMAGES/VIDEO/AUDIO do not exist below
+         * API 33, so checking them directly on 31/32 is meaningless (and MediaStore would
+         * still deny non-owned reads without a declared/granted READ_EXTERNAL_STORAGE).
+         * Map the media permissions to READ_EXTERNAL_STORAGE on API < 33 so the
+         * built-in storage "All files" mode reports and enforces the correct grant.
+         */
+        override fun hasPermission(permission: String): Boolean {
+            val effectivePermission =
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+                    when (permission) {
+                        Manifest.permission.READ_MEDIA_IMAGES,
+                        Manifest.permission.READ_MEDIA_VIDEO,
+                        Manifest.permission.READ_MEDIA_AUDIO,
+                        -> Manifest.permission.READ_EXTERNAL_STORAGE
+
+                        else -> permission
+                    }
+                } else {
+                    permission
+                }
+            return ContextCompat.checkSelfPermission(context, effectivePermission) ==
                 PackageManager.PERMISSION_GRANTED
+        }
     }

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/MainActivity.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.danielealbano.androidremotecontrolmcp.ui
 
 import android.Manifest
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -82,9 +83,14 @@ class MainActivity : ComponentActivity() {
 
     /**
      * Requests the POST_NOTIFICATIONS runtime permission.
+     *
+     * Android 12 (API 31/32) port: POST_NOTIFICATIONS does not exist below API 33,
+     * so the request is skipped there (notifications are always allowed on 31/32).
      */
     private fun requestNotificationPermission() {
-        notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+        }
     }
 
     /**

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/utils/PermissionUtils.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/utils/PermissionUtils.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.os.Build
 import android.provider.Settings
 import androidx.core.content.ContextCompat
 
@@ -55,14 +56,22 @@ object PermissionUtils {
     /**
      * Checks whether the `POST_NOTIFICATIONS` runtime permission is granted.
      *
+     * Android 12 (API 31/32) port: POST_NOTIFICATIONS only exists from API 33 on;
+     * below that, notifications are posted without a runtime grant, so this returns
+     * `true` unconditionally on API < 33.
+     *
      * @param context Application context.
      * @return `true` if notification permission is granted, `false` otherwise.
      */
     fun isNotificationPermissionGranted(context: Context): Boolean =
-        ContextCompat.checkSelfPermission(
-            context,
-            Manifest.permission.POST_NOTIFICATIONS,
-        ) == PackageManager.PERMISSION_GRANTED
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            true
+        } else {
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.POST_NOTIFICATIONS,
+            ) == PackageManager.PERMISSION_GRANTED
+        }
 
     /**
      * Checks whether the `CAMERA` runtime permission is granted.

--- a/app/src/main/res/xml/mcp_ime.xml
+++ b/app/src/main/res/xml/mcp_ime.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<input-method xmlns:android="http://schemas.android.com/apk/res/android">
+    <subtype android:imeSubtypeMode="keyboard" />
+</input-method>

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/TypeInputControllerImplTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/accessibility/TypeInputControllerImplTest.kt
@@ -1,0 +1,52 @@
+package com.danielealbano.androidremotecontrolmcp.services.accessibility
+
+import android.os.Build
+import android.view.inputmethod.InputConnection
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class TypeInputControllerImplTest {
+    private val inputMethodService = mockk<McpInputMethodService>()
+    private val inputConnection = mockk<InputConnection>()
+
+    @BeforeEach
+    fun setUp() {
+        check(Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            "Classic IME delegation test requires the JVM Android stubs to report an API below 33"
+        }
+        mockkObject(McpInputMethodService.Companion)
+        every { McpInputMethodService.instance } returns inputMethodService
+        every { inputMethodService.currentConnection() } returns inputConnection
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkObject(McpInputMethodService.Companion)
+    }
+
+    @Test
+    fun `classic IME operations delegate to current input connection below API 33`() {
+        every { inputConnection.commitText("hello", 1) } returns true
+        every { inputConnection.setSelection(2, 4) } returns false
+        every { inputConnection.deleteSurroundingText(3, 5) } returns true
+
+        val controller = TypeInputControllerImpl()
+
+        assertTrue(controller.isReady())
+        assertTrue(controller.commitText("hello", 1))
+        assertFalse(controller.setSelection(2, 4))
+        assertTrue(controller.deleteSurroundingText(3, 5))
+        verify(exactly = 4) { inputMethodService.currentConnection() }
+        verify(exactly = 1) { inputConnection.commitText("hello", 1) }
+        verify(exactly = 1) { inputConnection.setSelection(2, 4) }
+        verify(exactly = 1) { inputConnection.deleteSurroundingText(3, 5) }
+    }
+}

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/notifications/NotificationProviderImplTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/notifications/NotificationProviderImplTest.kt
@@ -103,6 +103,8 @@ class NotificationProviderImplTest {
                 PackageManager.ApplicationInfoFlags.of(0),
             )
         } returns appInfo
+        @Suppress("DEPRECATION")
+        every { mockPackageManager.getApplicationInfo(packageName, 0) } returns appInfo
         every { mockPackageManager.getApplicationLabel(appInfo) } returns "Test App"
 
         return mockk<StatusBarNotification> {
@@ -820,6 +822,10 @@ class NotificationProviderImplTest {
                         "com.unknown.app",
                         PackageManager.ApplicationInfoFlags.of(0),
                     )
+                } throws PackageManager.NameNotFoundException()
+                @Suppress("DEPRECATION")
+                every {
+                    mockPackageManager.getApplicationInfo("com.unknown.app", 0)
                 } throws PackageManager.NameNotFoundException()
 
                 val sbn =

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/utils/PermissionUtilsTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/utils/PermissionUtilsTest.kt
@@ -276,12 +276,12 @@ class PermissionUtilsTest {
         }
 
         @Test
-        fun `returns false when permission is denied`() {
+        fun `returns true below API 33 even when permission is denied`() {
             every {
                 ContextCompat.checkSelfPermission(mockContext, Manifest.permission.POST_NOTIFICATIONS)
             } returns PackageManager.PERMISSION_DENIED
 
-            assertFalse(PermissionUtils.isNotificationPermissionGranted(mockContext))
+            assertTrue(PermissionUtils.isNotificationPermissionGranted(mockContext))
         }
     }
 

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -89,7 +89,7 @@ The typical startup flow: User opens app → enables Accessibility Service in An
 - **Android Gradle Plugin (AGP)**: 8.13 (latest stable 8.x)
 - **Gradle**: 8.14.4 (latest stable 8.x)
 - **KSP**: 2.3.5 (Kotlin Symbol Processing, decoupled from Kotlin since 2.3.0)
-- **Android SDK**: Target API 34 (Android 14), Minimum API 33 (Android 13 Tiramisu)
+- **Android SDK**: Target API 34 (Android 14), Minimum API 31 (Android 12; API 33+ calls are guarded at runtime)
 - **JDK**: Java 17 (standard for Android development)
 
 ### Frameworks & Libraries


### PR DESCRIPTION
## Summary

Lowers `minSdk` from 33 (Android 13) to 31 (Android 12) so the app installs and runs on stock Android 12 devices, while keeping behavior on Android 13+ unchanged.

First, apologies for the rough first pass — I got ahead of myself with the earlier version and it cost you a review cycle. I've gone back and redone this properly: text input now works on Android 12 through a real fallback rather than being disabled, the broken tests are fixed, lint is clean, and the whole thing is running on a real Galaxy S10.

## Changes

### Android 13+ API guards (unchanged behavior on 13+)
- `app/build.gradle.kts`: `minSdk = 33` → `minSdk = 31` (targetSdk unchanged at 34)
- `AndroidManifest.xml`: add `READ_EXTERNAL_STORAGE` with `maxSdkVersion=32` (the pre-33 equivalent of `READ_MEDIA_*`; a **dangerous** runtime permission on 31/32)
- `ReverseGeocoder.kt`: below 33 use the sync `Geocoder.getFromLocation` overload wrapped in `withContext(Dispatchers.IO)`; above 33 the async `GeocodeListener` path with a `cont.isActive` guard before resuming
- `AppIconCache.kt` / `NotificationDataExtractor.kt`: use the int overload of `queryIntentActivities` / `getApplicationInfo` below 33
- `PermissionCheckerImpl.kt`: map `READ_MEDIA_*` → `READ_EXTERNAL_STORAGE` below 33
- `MainActivity.kt` / `PermissionUtils.kt`: treat `POST_NOTIFICATIONS` as always-granted below 33
- `docs/PROJECT.md` / `CONTRIBUTING.md`: document Android 12 (API 31) support

### Text input — functional fallback (not disabled)
- New `McpInputMethodService` — a classic `InputMethodService` exposing the current `InputConnection`.
- `TypeInputControllerImpl` branches on `Build.VERSION.SDK_INT`: 33+ keeps the original `AccessibilityInputConnection` path (no keyboard selection needed, unchanged); 31/32 delegates to the classic IME's `InputConnection`. The API-33 reference is guarded with `@RequiresApi(TIRAMISU)` rather than a class-level `@SuppressLint("NewApi")`, matching the existing `McpAccessibilityService` pattern.
- On Android 12, the user enables + selects "ARC MCP IME" as the active keyboard once (Settings → System → Languages & input → On-screen keyboard, or `adb shell ime set com.danielealbano.androidremotecontrolmcp/.services.accessibility.McpInputMethodService`). Not required on 13+.

## Testing

- Fixed the unit tests broken by the port: notification-label extraction stubs both `getApplicationInfo` overloads; the below-33 `POST_NOTIFICATIONS` behavior is asserted correctly.
- Added `TypeInputControllerImplTest` covering the below-33 classic-IME delegation (forwarding and return-value semantics).
- ktlint + detekt clean; the only suppressions are version-gated `@Suppress("DEPRECATION")` on the pre-33 deprecated overloads (unavoidable — those APIs only exist in their deprecated form below 33).
- Verified live on a stock Samsung Galaxy S10 (SM-G973F, Android 12, `G973FXXUHHXJ4`): accessibility service + notification listener + IME enabled, and char-by-char text input through the classic IME fallback confirmed end-to-end.

## Checklist

- [x] Unit tests pass — only the two tunnel integration tests fail (need a real ngrok/Cloudflare token, same as upstream CI)
- [x] Lint passes (`ktlintCheck` + `detekt`)
- [x] Build succeeds (`assembleFossRelease` including `lintVital`)
