### PR TITLE
feat: add Cloudflare tunnel mode and token extras to AdbConfigHandler

### DIFF
--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/mcp/AdbConfigHandler.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/mcp/AdbConfigHandler.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.util.Log
 import com.danielealbano.androidremotecontrolmcp.data.model.BindingAddress
 import com.danielealbano.androidremotecontrolmcp.data.model.CertificateSource
+import com.danielealbano.androidremotecontrolmcp.data.model.CloudflareTunnelMode
 import com.danielealbano.androidremotecontrolmcp.data.model.ServerLogEntry
 import com.danielealbano.androidremotecontrolmcp.data.model.ToolPermissionsConfig
 import com.danielealbano.androidremotecontrolmcp.data.model.TunnelProviderType
@@ -57,6 +58,8 @@ class AdbConfigHandler(
         applyCertificateHostname(intent)
         applyTunnelEnabled(intent)
         applyTunnelProvider(intent)
+        applyCloudflareTunnelMode(intent)
+        applyCloudflareTunnelToken(intent)
         applyNgrokAuthtoken(intent)
         applyNgrokDomain(intent)
         applyFileSizeLimit(intent)
@@ -225,6 +228,33 @@ class AdbConfigHandler(
         Log.i(TAG, "Tunnel provider updated to $provider")
     }
 
+    private suspend fun applyCloudflareTunnelMode(intent: Intent) {
+        val value = intent.getStringExtra(EXTRA_CLOUDFLARE_TUNNEL_MODE) ?: return
+        val mode =
+            try {
+                CloudflareTunnelMode.valueOf(value)
+            } catch (_: IllegalArgumentException) {
+                Log.w(
+                    TAG,
+                    "Ignoring invalid cloudflare_tunnel_mode '$value' " +
+                        "(valid: ${CloudflareTunnelMode.entries.joinToString()})",
+                )
+                return
+            }
+        settingsRepository.updateCloudflareTunnelMode(mode)
+        Log.i(TAG, "Cloudflare tunnel mode updated to $mode")
+    }
+
+    private suspend fun applyCloudflareTunnelToken(intent: Intent) {
+        val value = intent.getStringExtra(EXTRA_CLOUDFLARE_TUNNEL_TOKEN) ?: return
+        if (value.isEmpty()) {
+            Log.w(TAG, "Ignoring empty cloudflare_tunnel_token")
+            return
+        }
+        settingsRepository.updateCloudflareTunnelToken(value)
+        Log.i(TAG, "Cloudflare tunnel token updated (length=${value.length})")
+    }
+
     private suspend fun applyNgrokAuthtoken(intent: Intent) {
         val value = intent.getStringExtra(EXTRA_NGROK_AUTHTOKEN) ?: return
         if (value.isEmpty()) {
@@ -360,6 +390,8 @@ class AdbConfigHandler(
         internal const val EXTRA_CERTIFICATE_HOSTNAME = "certificate_hostname"
         internal const val EXTRA_TUNNEL_ENABLED = "tunnel_enabled"
         internal const val EXTRA_TUNNEL_PROVIDER = "tunnel_provider"
+        internal const val EXTRA_CLOUDFLARE_TUNNEL_MODE = "cloudflare_tunnel_mode"
+        internal const val EXTRA_CLOUDFLARE_TUNNEL_TOKEN = "cloudflare_tunnel_token"
         internal const val EXTRA_NGROK_AUTHTOKEN = "ngrok_authtoken"
         internal const val EXTRA_NGROK_DOMAIN = "ngrok_domain"
         internal const val EXTRA_FILE_SIZE_LIMIT_MB = "file_size_limit_mb"

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/mcp/AdbConfigHandlerTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/mcp/AdbConfigHandlerTest.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.util.Log
 import com.danielealbano.androidremotecontrolmcp.data.model.BindingAddress
 import com.danielealbano.androidremotecontrolmcp.data.model.CertificateSource
+import com.danielealbano.androidremotecontrolmcp.data.model.CloudflareTunnelMode
 import com.danielealbano.androidremotecontrolmcp.data.model.ServerConfig
 import com.danielealbano.androidremotecontrolmcp.data.model.ServerLogEntry
 import com.danielealbano.androidremotecontrolmcp.data.model.ToolPermissionsConfig
@@ -402,6 +403,66 @@ class AdbConfigHandlerTest {
                     }
                 handler.handle(context, intent)
                 coVerify(exactly = 0) { settingsRepository.updateTunnelProvider(any()) }
+            }
+
+        @Test
+        @DisplayName("cloudflare_tunnel_mode FREE is applied")
+        fun cloudflareTunnelModeFree() =
+            runTest {
+                val intent =
+                    createIntent(AdbConfigReceiver.ACTION_CONFIGURE) {
+                        string(AdbConfigHandler.EXTRA_CLOUDFLARE_TUNNEL_MODE, "FREE")
+                    }
+                handler.handle(context, intent)
+                coVerify { settingsRepository.updateCloudflareTunnelMode(CloudflareTunnelMode.FREE) }
+            }
+
+        @Test
+        @DisplayName("cloudflare_tunnel_mode TOKEN is applied")
+        fun cloudflareTunnelModeToken() =
+            runTest {
+                val intent =
+                    createIntent(AdbConfigReceiver.ACTION_CONFIGURE) {
+                        string(AdbConfigHandler.EXTRA_CLOUDFLARE_TUNNEL_MODE, "TOKEN")
+                    }
+                handler.handle(context, intent)
+                coVerify { settingsRepository.updateCloudflareTunnelMode(CloudflareTunnelMode.TOKEN) }
+            }
+
+        @Test
+        @DisplayName("invalid cloudflare_tunnel_mode is rejected")
+        fun invalidCloudflareTunnelMode() =
+            runTest {
+                val intent =
+                    createIntent(AdbConfigReceiver.ACTION_CONFIGURE) {
+                        string(AdbConfigHandler.EXTRA_CLOUDFLARE_TUNNEL_MODE, "INVALID")
+                    }
+                handler.handle(context, intent)
+                coVerify(exactly = 0) { settingsRepository.updateCloudflareTunnelMode(any()) }
+            }
+
+        @Test
+        @DisplayName("cloudflare_tunnel_token is applied")
+        fun cloudflareTunnelToken() =
+            runTest {
+                val intent =
+                    createIntent(AdbConfigReceiver.ACTION_CONFIGURE) {
+                        string(AdbConfigHandler.EXTRA_CLOUDFLARE_TUNNEL_TOKEN, "eyJhIjoidGVzdCJ9")
+                    }
+                handler.handle(context, intent)
+                coVerify { settingsRepository.updateCloudflareTunnelToken("eyJhIjoidGVzdCJ9") }
+            }
+
+        @Test
+        @DisplayName("empty cloudflare_tunnel_token is ignored")
+        fun emptyCloudflareTunnelToken() =
+            runTest {
+                val intent =
+                    createIntent(AdbConfigReceiver.ACTION_CONFIGURE) {
+                        string(AdbConfigHandler.EXTRA_CLOUDFLARE_TUNNEL_TOKEN, "")
+                    }
+                handler.handle(context, intent)
+                coVerify(exactly = 0) { settingsRepository.updateCloudflareTunnelToken(any()) }
             }
 
         @Test


### PR DESCRIPTION
## Summary

Add cloudflare_tunnel_mode and cloudflare_tunnel_token broadcast intent extras to AdbConfigHandler, allowing headless configuration of Cloudflare tunnels via ADB commands (matching existing ngrok extras).

(Split from #165 per maintainer request in #164)

## Changes

- AdbConfigHandler.kt:
  - Handle EXTRA_CLOUDFLARE_TUNNEL_MODE (cloudflare_tunnel_mode) with validation for FREE and TOKEN modes.
  - Handle EXTRA_CLOUDFLARE_TUNNEL_TOKEN (cloudflare_tunnel_token) for named tunnel token configuration.
- AdbConfigHandlerTest.kt:
  - Added unit test coverage for FREE mode, TOKEN mode, invalid mode rejection, valid token update, and empty token rejection.

## Testing

- Unit tests in AdbConfigHandlerTest pass.
- Verified headless configuration via m broadcast on a physical device.

## Checklist

- [x] All unit tests pass
- [x] Follows project commit and code style guidelines