### PR TITLE
feat: add Cloudflare tunnel extra arguments support and ADB config

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,7 @@ adb shell am broadcast \
   --es tunnel_provider "CLOUDFLARE" \
   --es cloudflare_tunnel_mode "TOKEN" \
   --es cloudflare_tunnel_token "your-cloudflare-tunnel-token" \
+  --es cloudflare_tunnel_extra_args "--edge region1.v2.argotunnel.com:7844" \
   --es ngrok_authtoken "your-ngrok-token" \
   --es ngrok_domain "your-domain.ngrok-free.app" \
   --ei file_size_limit_mb 50 \
@@ -481,6 +482,7 @@ Bearer enforcement is controlled by `--ez bearer_token_enabled <bool>`, NOT by c
 | `tunnel_provider` | string | `CLOUDFLARE` or `NGROK` |
 | `cloudflare_tunnel_mode` | string | `FREE` (Quick Tunnel, random `*.trycloudflare.com` URL) or `TOKEN` (named tunnel with static hostname) |
 | `cloudflare_tunnel_token` | string | Cloudflare named-tunnel token (used when `cloudflare_tunnel_mode` is `TOKEN`) |
+| `cloudflare_tunnel_extra_args` | string | Optional extra arguments passed to cloudflared (e.g. `--edge region1.v2.argotunnel.com:7844`) |
 | `ngrok_authtoken` | string | ngrok authentication token |
 | `ngrok_domain` | string | ngrok custom domain (optional) |
 | `file_size_limit_mb` | int | Max file size for file operations (1-500) |

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/data/model/ServerConfig.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/data/model/ServerConfig.kt
@@ -50,6 +50,7 @@ data class ServerConfig(
     val ngrokDomain: String = "",
     val cloudflareTunnelMode: CloudflareTunnelMode = CloudflareTunnelMode.FREE,
     val cloudflareTunnelToken: String = "",
+    val cloudflareTunnelExtraArgs: String = "",
     val fileSizeLimitMb: Int = DEFAULT_FILE_SIZE_LIMIT_MB,
     val allowHttpDownloads: Boolean = false,
     val allowUnverifiedHttpsCerts: Boolean = false,

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/data/repository/SettingsRepository.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/data/repository/SettingsRepository.kt
@@ -168,6 +168,9 @@ interface SettingsRepository : EventChannelSettings {
     /** Updates the Cloudflare tunnel token (required when using token mode). */
     suspend fun updateCloudflareTunnelToken(token: String)
 
+    /** Updates the optional extra command-line arguments for Cloudflare tunnel. */
+    suspend fun updateCloudflareTunnelExtraArgs(extraArgs: String)
+
     /** Updates the file size limit for file operations (in MB). */
     suspend fun updateFileSizeLimit(limitMb: Int)
 

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/data/repository/SettingsRepositoryImpl.kt
@@ -57,6 +57,7 @@ private val NGROK_AUTHTOKEN_KEY = stringPreferencesKey("ngrok_authtoken")
 private val NGROK_DOMAIN_KEY = stringPreferencesKey("ngrok_domain")
 private val CLOUDFLARE_TUNNEL_MODE_KEY = stringPreferencesKey("cloudflare_tunnel_mode")
 private val CLOUDFLARE_TUNNEL_TOKEN_KEY = stringPreferencesKey("cloudflare_tunnel_token")
+private val CLOUDFLARE_TUNNEL_EXTRA_ARGS_KEY = stringPreferencesKey("cloudflare_tunnel_extra_args")
 private val FILE_SIZE_LIMIT_KEY = intPreferencesKey("file_size_limit_mb")
 private val ALLOW_HTTP_DOWNLOADS_KEY = booleanPreferencesKey("allow_http_downloads")
 private val ALLOW_UNVERIFIED_HTTPS_KEY = booleanPreferencesKey("allow_unverified_https_certs")
@@ -128,6 +129,7 @@ private fun mapPreferencesToServerConfig(prefs: Preferences): ServerConfig {
             CloudflareTunnelMode.entries.firstOrNull { it.name == cloudflareTunnelModeName }
                 ?: CloudflareTunnelMode.FREE,
         cloudflareTunnelToken = prefs[CLOUDFLARE_TUNNEL_TOKEN_KEY] ?: "",
+        cloudflareTunnelExtraArgs = prefs[CLOUDFLARE_TUNNEL_EXTRA_ARGS_KEY] ?: "",
         fileSizeLimitMb = prefs[FILE_SIZE_LIMIT_KEY] ?: ServerConfig.DEFAULT_FILE_SIZE_LIMIT_MB,
         allowHttpDownloads = prefs[ALLOW_HTTP_DOWNLOADS_KEY] ?: false,
         allowUnverifiedHttpsCerts = prefs[ALLOW_UNVERIFIED_HTTPS_KEY] ?: false,
@@ -459,6 +461,16 @@ class SettingsRepositoryImpl
         override suspend fun updateCloudflareTunnelToken(token: String) =
             logScalarChange(CLOUDFLARE_TUNNEL_TOKEN_KEY, "cloudflare_tunnel_token", token, "") { _, _ ->
                 "Cloudflare tunnel token changed"
+            }
+
+        override suspend fun updateCloudflareTunnelExtraArgs(extraArgs: String) =
+            logScalarChange(
+                CLOUDFLARE_TUNNEL_EXTRA_ARGS_KEY,
+                "cloudflare_tunnel_extra_args",
+                extraArgs,
+                "",
+            ) { o, n ->
+                "Cloudflare tunnel extra arguments changed $o → $n"
             }
 
         override suspend fun updateFileSizeLimit(limitMb: Int) =

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/mcp/AdbConfigHandler.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/mcp/AdbConfigHandler.kt
@@ -60,6 +60,7 @@ class AdbConfigHandler(
         applyTunnelProvider(intent)
         applyCloudflareTunnelMode(intent)
         applyCloudflareTunnelToken(intent)
+        applyCloudflareTunnelExtraArgs(intent)
         applyNgrokAuthtoken(intent)
         applyNgrokDomain(intent)
         applyFileSizeLimit(intent)
@@ -255,6 +256,12 @@ class AdbConfigHandler(
         Log.i(TAG, "Cloudflare tunnel token updated (length=${value.length})")
     }
 
+    private suspend fun applyCloudflareTunnelExtraArgs(intent: Intent) {
+        val value = intent.getStringExtra(EXTRA_CLOUDFLARE_TUNNEL_EXTRA_ARGS) ?: return
+        settingsRepository.updateCloudflareTunnelExtraArgs(value)
+        Log.i(TAG, "Cloudflare tunnel extra arguments updated (length=${value.length})")
+    }
+
     private suspend fun applyNgrokAuthtoken(intent: Intent) {
         val value = intent.getStringExtra(EXTRA_NGROK_AUTHTOKEN) ?: return
         if (value.isEmpty()) {
@@ -392,6 +399,7 @@ class AdbConfigHandler(
         internal const val EXTRA_TUNNEL_PROVIDER = "tunnel_provider"
         internal const val EXTRA_CLOUDFLARE_TUNNEL_MODE = "cloudflare_tunnel_mode"
         internal const val EXTRA_CLOUDFLARE_TUNNEL_TOKEN = "cloudflare_tunnel_token"
+        internal const val EXTRA_CLOUDFLARE_TUNNEL_EXTRA_ARGS = "cloudflare_tunnel_extra_args"
         internal const val EXTRA_NGROK_AUTHTOKEN = "ngrok_authtoken"
         internal const val EXTRA_NGROK_DOMAIN = "ngrok_domain"
         internal const val EXTRA_FILE_SIZE_LIMIT_MB = "file_size_limit_mb"

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/tunnel/CloudflareTunnelProvider.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/tunnel/CloudflareTunnelProvider.kt
@@ -73,7 +73,7 @@ class CloudflareTunnelProvider
                     }
 
                 when (config.cloudflareTunnelMode) {
-                    CloudflareTunnelMode.FREE -> startFreeTunnel(binaryPath, localPort)
+                    CloudflareTunnelMode.FREE -> startFreeTunnel(binaryPath, localPort, config)
                     CloudflareTunnelMode.TOKEN -> startTokenTunnel(binaryPath, localPort, config)
                 }
             }
@@ -82,11 +82,12 @@ class CloudflareTunnelProvider
         private fun startFreeTunnel(
             binaryPath: String,
             localPort: Int,
+            config: ServerConfig,
         ) {
             _status.value = TunnelStatus.Connecting
             try {
-                val pb =
-                    ProcessBuilder(
+                val args =
+                    mutableListOf(
                         binaryPath,
                         "tunnel",
                         "--url",
@@ -94,6 +95,10 @@ class CloudflareTunnelProvider
                         "--output",
                         "json",
                     )
+                if (config.cloudflareTunnelExtraArgs.isNotBlank()) {
+                    args.addAll(parseCommandLineArguments(config.cloudflareTunnelExtraArgs))
+                }
+                val pb = ProcessBuilder(args)
                 pb.redirectErrorStream(false)
                 val proc = pb.start()
                 process = proc
@@ -134,8 +139,8 @@ class CloudflareTunnelProvider
             try {
                 // NOTE: exact argument order; `--output json` MUST come before `run`, and `--url`
                 // MUST NOT be passed (it breaks the control stream of a remotely-managed tunnel).
-                val pb =
-                    ProcessBuilder(
+                val args =
+                    mutableListOf(
                         binaryPath,
                         "tunnel",
                         "--output",
@@ -144,6 +149,10 @@ class CloudflareTunnelProvider
                         "--token",
                         config.cloudflareTunnelToken,
                     )
+                if (config.cloudflareTunnelExtraArgs.isNotBlank()) {
+                    args.addAll(parseCommandLineArguments(config.cloudflareTunnelExtraArgs))
+                }
+                val pb = ProcessBuilder(args)
                 pb.redirectErrorStream(false)
                 val proc = pb.start()
                 process = proc
@@ -341,6 +350,46 @@ class CloudflareTunnelProvider
                     uri.port == expectedPort &&
                     pathIsRoot &&
                     hasNoExtraParts
+            }
+
+            /**
+             * Parses a raw command-line argument string into discrete tokens,
+             * safely handling whitespace and single/double quotes.
+             */
+            internal fun parseCommandLineArguments(raw: String): List<String> {
+                if (raw.isBlank()) return emptyList()
+                val args = mutableListOf<String>()
+                val current = StringBuilder()
+                var inQuote: Char? = null
+                var escapeNext = false
+
+                for (ch in raw.trim()) {
+                    if (escapeNext) {
+                        current.append(ch)
+                        escapeNext = false
+                    } else if (ch == '\\') {
+                        escapeNext = true
+                    } else if (inQuote != null) {
+                        if (ch == inQuote) {
+                            inQuote = null
+                        } else {
+                            current.append(ch)
+                        }
+                    } else if (ch == '\'' || ch == '"') {
+                        inQuote = ch
+                    } else if (ch.isWhitespace()) {
+                        if (current.isNotEmpty()) {
+                            args.add(current.toString())
+                            current.clear()
+                        }
+                    } else {
+                        current.append(ch)
+                    }
+                }
+                if (current.isNotEmpty()) {
+                    args.add(current.toString())
+                }
+                return args
             }
         }
     }

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/settings/TunnelSettingsScreen.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/settings/TunnelSettingsScreen.kt
@@ -71,6 +71,7 @@ fun TunnelSettingsScreen(
     val ngrokAuthtokenInput by viewModel.ngrokAuthtokenInput.collectAsStateWithLifecycle()
     val ngrokDomainInput by viewModel.ngrokDomainInput.collectAsStateWithLifecycle()
     val cloudflareTokenInput by viewModel.cloudflareTokenInput.collectAsStateWithLifecycle()
+    val cloudflareExtraArgsInput by viewModel.cloudflareExtraArgsInput.collectAsStateWithLifecycle()
 
     val isEnabled =
         serverStatus !is ServerStatus.Running &&
@@ -218,6 +219,20 @@ fun TunnelSettingsScreen(
                                 serviceUrl = "http://localhost:${serverConfig.port}",
                                 enabled = sectionEnabled,
                                 onTokenChange = viewModel::updateCloudflareTunnelToken,
+                            )
+                        }
+                    }
+
+                    // Cloudflare extra arguments
+                    AnimatedVisibility(
+                        visible = serverConfig.tunnelProvider == TunnelProviderType.CLOUDFLARE,
+                    ) {
+                        Column {
+                            Spacer(modifier = Modifier.height(8.dp))
+                            CloudflareExtraArgsField(
+                                extraArgs = cloudflareExtraArgsInput,
+                                enabled = sectionEnabled,
+                                onExtraArgsChange = viewModel::updateCloudflareTunnelExtraArgs,
                             )
                         }
                     }
@@ -447,6 +462,37 @@ private fun CloudflareTokenFields(
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun CloudflareExtraArgsField(
+    extraArgs: String,
+    enabled: Boolean,
+    onExtraArgsChange: (String) -> Unit,
+) {
+    Column {
+        Text(
+            text = stringResource(R.string.remote_access_cloudflare_extra_args_label),
+            style = MaterialTheme.typography.labelLarge,
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        OutlinedTextField(
+            value = extraArgs,
+            onValueChange = onExtraArgsChange,
+            singleLine = true,
+            enabled = enabled,
+            placeholder = {
+                Text(text = stringResource(R.string.remote_access_cloudflare_extra_args_hint))
+            },
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = stringResource(R.string.remote_access_cloudflare_extra_args_help),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 }
 

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/viewmodels/MainViewModel.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/viewmodels/MainViewModel.kt
@@ -104,6 +104,9 @@ class MainViewModel
         private val _cloudflareTokenInput = MutableStateFlow("")
         val cloudflareTokenInput: StateFlow<String> = _cloudflareTokenInput.asStateFlow()
 
+        private val _cloudflareExtraArgsInput = MutableStateFlow("")
+        val cloudflareExtraArgsInput: StateFlow<String> = _cloudflareExtraArgsInput.asStateFlow()
+
         private val _storageLocations = MutableStateFlow<List<StorageLocation>>(emptyList())
         val storageLocations: StateFlow<List<StorageLocation>> = _storageLocations.asStateFlow()
 
@@ -147,6 +150,7 @@ class MainViewModel
                     _ngrokAuthtokenInput.value = config.ngrokAuthtoken
                     _ngrokDomainInput.value = config.ngrokDomain
                     _cloudflareTokenInput.value = config.cloudflareTunnelToken
+                    _cloudflareExtraArgsInput.value = config.cloudflareTunnelExtraArgs
                     _fileSizeLimitInput.value = config.fileSizeLimitMb.toString()
                     _fileSizeLimitError.value = null
                     _downloadTimeoutInput.value = config.downloadTimeoutSeconds.toString()
@@ -326,6 +330,13 @@ class MainViewModel
             _cloudflareTokenInput.value = token
             viewModelScope.launch(ioDispatcher) {
                 settingsRepository.updateCloudflareTunnelToken(token)
+            }
+        }
+
+        fun updateCloudflareTunnelExtraArgs(extraArgs: String) {
+            _cloudflareExtraArgsInput.value = extraArgs
+            viewModelScope.launch(ioDispatcher) {
+                settingsRepository.updateCloudflareTunnelExtraArgs(extraArgs)
             }
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -181,6 +181,9 @@
     <string name="remote_access_cloudflare_mode_token">With Token</string>
     <string name="remote_access_cloudflare_mode_token_desc">Static hostname via your Cloudflare account</string>
     <string name="remote_access_cloudflare_token_label">Cloudflare Tunnel Token</string>
+    <string name="remote_access_cloudflare_extra_args_label">Extra Arguments</string>
+    <string name="remote_access_cloudflare_extra_args_hint">--edge region1.v2.argotunnel.com:7844</string>
+    <string name="remote_access_cloudflare_extra_args_help">Optional flags passed to cloudflared (e.g. specify --edge to bypass DNS issues)</string>
     <string name="remote_access_cloudflare_service_url_help">In your Cloudflare dashboard, set this tunnel\'s Public Hostname → Service to:</string>
     <string name="remote_access_cloudflare_service_url_copy">Copy service URL</string>
     <string name="remote_access_https_disabled_warning">Remote access is unavailable while HTTPS is enabled. Disable HTTPS to use a tunnel.</string>

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/data/repository/SettingsRepositoryImplTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/data/repository/SettingsRepositoryImplTest.kt
@@ -640,6 +640,27 @@ class SettingsRepositoryImplTest {
     }
 
     @Nested
+    @DisplayName("updateCloudflareTunnelExtraArgs")
+    inner class UpdateCloudflareTunnelExtraArgs {
+        @Test
+        fun `defaults to empty when unset`() =
+            testScope.runTest {
+                val config = repository.getServerConfig()
+
+                assertEquals("", config.cloudflareTunnelExtraArgs)
+            }
+
+        @Test
+        fun `persists extra args`() =
+            testScope.runTest {
+                repository.updateCloudflareTunnelExtraArgs("--edge region1.v2.argotunnel.com:7844")
+                val config = repository.getServerConfig()
+
+                assertEquals("--edge region1.v2.argotunnel.com:7844", config.cloudflareTunnelExtraArgs)
+            }
+    }
+
+    @Nested
     @DisplayName("updateDeviceSlug")
     inner class UpdateDeviceSlug {
         @Test

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/mcp/AdbConfigHandlerTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/mcp/AdbConfigHandlerTest.kt
@@ -152,8 +152,8 @@ class AdbConfigHandlerTest {
     // ─────────────────────────────────────────────────────────────────────
 
     @Nested
-    @DisplayName("ACTION_CONFIGURE")
-    inner class ConfigureTests {
+    @DisplayName("ACTION_CONFIGURE - Basic Settings")
+    inner class ConfigureBasicTests {
         @Test
         @DisplayName("bearer_token is applied when provided")
         fun bearerTokenApplied() =
@@ -356,7 +356,11 @@ class AdbConfigHandlerTest {
                 handler.handle(context, intent)
                 coVerify(exactly = 0) { settingsRepository.updateCertificateHostname(any()) }
             }
+    }
 
+    @Nested
+    @DisplayName("ACTION_CONFIGURE - Tunnel Settings")
+    inner class ConfigureTunnelTests {
         @Test
         @DisplayName("tunnel_enabled is applied")
         fun tunnelEnabled() =
@@ -466,6 +470,33 @@ class AdbConfigHandlerTest {
             }
 
         @Test
+        @DisplayName("cloudflare_tunnel_extra_args is applied")
+        fun cloudflareTunnelExtraArgs() =
+            runTest {
+                val intent =
+                    createIntent(AdbConfigReceiver.ACTION_CONFIGURE) {
+                        string(
+                            AdbConfigHandler.EXTRA_CLOUDFLARE_TUNNEL_EXTRA_ARGS,
+                            "--edge region1.v2.argotunnel.com:7844",
+                        )
+                    }
+                handler.handle(context, intent)
+                coVerify { settingsRepository.updateCloudflareTunnelExtraArgs("--edge region1.v2.argotunnel.com:7844") }
+            }
+
+        @Test
+        @DisplayName("missing cloudflare_tunnel_extra_args leaves setting untouched")
+        fun missingCloudflareTunnelExtraArgsIgnored() =
+            runTest {
+                val intent =
+                    createIntent(AdbConfigReceiver.ACTION_CONFIGURE) {
+                        string(AdbConfigHandler.EXTRA_CLOUDFLARE_TUNNEL_TOKEN, "eyJhIjoidGVzdCJ9")
+                    }
+                handler.handle(context, intent)
+                coVerify(exactly = 0) { settingsRepository.updateCloudflareTunnelExtraArgs(any()) }
+            }
+
+        @Test
         @DisplayName("ngrok_authtoken is applied")
         fun ngrokAuthtoken() =
             runTest {
@@ -488,7 +519,11 @@ class AdbConfigHandlerTest {
                 handler.handle(context, intent)
                 coVerify { settingsRepository.updateNgrokDomain("my-app.ngrok-free.app") }
             }
+    }
 
+    @Nested
+    @DisplayName("ACTION_CONFIGURE - Storage and Misc Settings")
+    inner class ConfigureStorageAndMiscTests {
         @Test
         @DisplayName("valid file_size_limit_mb is applied")
         fun validFileSizeLimit() =
@@ -596,7 +631,11 @@ class AdbConfigHandlerTest {
                 handler.handle(context, intent)
                 coVerify { settingsRepository.updateDeviceSlug("") }
             }
+    }
 
+    @Nested
+    @DisplayName("ACTION_CONFIGURE - Composite and Edge Cases")
+    inner class ConfigureCompositeTests {
         @Test
         @DisplayName("multiple settings are applied in single broadcast")
         fun multipleSettings() =

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/tunnel/CloudflareTunnelProviderTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/tunnel/CloudflareTunnelProviderTest.kt
@@ -415,6 +415,62 @@ class CloudflareTunnelProviderTest {
             }
     }
 
+    @Nested
+    @DisplayName("parseCommandLineArguments")
+    inner class ParseCommandLineArguments {
+        @Test
+        fun `empty or blank string returns empty list`() {
+            assertEquals(emptyList<String>(), CloudflareTunnelProvider.parseCommandLineArguments(""))
+            assertEquals(emptyList<String>(), CloudflareTunnelProvider.parseCommandLineArguments("   \t  "))
+        }
+
+        @Test
+        fun `single argument returns single token`() {
+            assertEquals(
+                listOf("--edge"),
+                CloudflareTunnelProvider.parseCommandLineArguments("--edge"),
+            )
+        }
+
+        @Test
+        fun `multiple arguments separated by whitespace`() {
+            assertEquals(
+                listOf("--edge", "region1.v2.argotunnel.com:7844", "--protocol", "http2"),
+                CloudflareTunnelProvider.parseCommandLineArguments(
+                    "  --edge   region1.v2.argotunnel.com:7844 \t --protocol http2  ",
+                ),
+            )
+        }
+
+        @Test
+        fun `double quotes preserve internal spaces and flags`() {
+            assertEquals(
+                listOf("--edge", "region1.v2.argotunnel.com:7844", "--custom-flag=hello world"),
+                CloudflareTunnelProvider.parseCommandLineArguments(
+                    "--edge region1.v2.argotunnel.com:7844 --custom-flag=\"hello world\"",
+                ),
+            )
+        }
+
+        @Test
+        fun `single quotes preserve internal spaces and flags`() {
+            assertEquals(
+                listOf("--edge", "region1.v2.argotunnel.com:7844", "--custom-flag=hello world"),
+                CloudflareTunnelProvider.parseCommandLineArguments(
+                    "--edge region1.v2.argotunnel.com:7844 --custom-flag='hello world'",
+                ),
+            )
+        }
+
+        @Test
+        fun `escaped characters are preserved`() {
+            assertEquals(
+                listOf("--custom=hello\"world"),
+                CloudflareTunnelProvider.parseCommandLineArguments("--custom=hello\\\"world"),
+            )
+        }
+    }
+
     companion object {
         private const val AWAIT_TIMEOUT_MS = 10_000L
 

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/ui/viewmodels/MainViewModelTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/ui/viewmodels/MainViewModelTest.kt
@@ -492,6 +492,18 @@ class MainViewModelTest {
         }
 
     @Test
+    fun `updateCloudflareTunnelExtraArgs calls repository and updates input state`() =
+        runTest {
+            advanceUntilIdle()
+
+            viewModel.updateCloudflareTunnelExtraArgs("--edge region1.v2.argotunnel.com:7844")
+            advanceUntilIdle()
+
+            assertEquals("--edge region1.v2.argotunnel.com:7844", viewModel.cloudflareExtraArgsInput.value)
+            coVerify { settingsRepository.updateCloudflareTunnelExtraArgs("--edge region1.v2.argotunnel.com:7844") }
+        }
+
+    @Test
     fun `serverConfig collection sets cloudflare token input`() =
         runTest {
             configFlow.value = configFlow.value.copy(cloudflareTunnelToken = "seeded-token")


### PR DESCRIPTION
## Summary
As discussed in #164, this PR adds an **"Extra Arguments"** configuration field for Cloudflare Tunnel. This allows passing custom command-line flags (such as --edge region1.v2.argotunnel.com:7844 or --protocol http2) to the underlying cloudflared binary, solving edge DNS/connectivity failures on restrictive networks and older Android devices without patching cloudflared source code.

## Changes
- **Data & Settings Layer**:
  - Added `cloudflareTunnelExtraArgs` to `ServerConfig` and `SettingsRepository`.
  - Stored reactively in DataStore preferences.
- **Process Execution & Argument Parsing**:
  - Implemented `parseCommandLineArguments` in `CloudflareTunnelProvider` that safely tokenizes flags while respecting single/double quotes, whitespace, and escape characters.
  - Appended extra arguments to `ProcessBuilder` in both `startFreeTunnel` and `startTokenTunnel`.
- **UI (Jetpack Compose)**:
  - Added an `OutlinedTextField` for "Extra Arguments" in `TunnelSettingsScreen` with placeholder and helpful guidance text.
  - Connected state reactively via `MainViewModel`.
- **ADB Configuration**:
  - Added `--es cloudflare_tunnel_extra_args "<args>"` support in `AdbConfigHandler`.
  - Documented the new extra in `README.md`.
- **Tests & Quality**:
  - Added unit tests in `CloudflareTunnelProviderTest` (argument tokenizer edge cases).
  - Added unit tests in `AdbConfigHandlerTest` (ADB extra injection & validation).
  - Added unit tests in `SettingsRepositoryImplTest` and `MainViewModelTest`.
  - Verified 100% pass on unit tests, `ktlintCheck`, and `detekt`.

Closes #164
