### PR TITLE
test: verify cloudflared extra args reach the process argv

### DIFF
--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/tunnel/CloudflareTunnelProviderTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/tunnel/CloudflareTunnelProviderTest.kt
@@ -7,6 +7,7 @@ import com.danielealbano.androidremotecontrolmcp.data.model.TunnelStatus
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -223,6 +224,36 @@ class CloudflareTunnelProviderTest {
 
     private suspend fun CloudflareTunnelProvider.awaitStatus(predicate: (TunnelStatus) -> Boolean): TunnelStatus =
         withTimeout(AWAIT_TIMEOUT_MS) { status.first(predicate) }
+
+    /**
+     * Creates a fake cloudflared script that records its argv (one argument per line) to
+     * [argsFile], then blocks like the real long-running binary. The argv is written to a
+     * temp file and atomically moved into place so readers never observe a partial write.
+     */
+    private fun fakeBinaryRecordingArgs(argsFile: File): String {
+        val script = File.createTempFile("fake-cloudflared", ".sh")
+        script.deleteOnExit()
+        val target = argsFile.absolutePath
+        script.writeText(
+            "#!/bin/sh\n" +
+                "printf '%s\\n' \"\$@\" > \"$target.tmp\"\n" +
+                "mv \"$target.tmp\" \"$target\"\n" +
+                "sleep 60\n",
+        )
+        script.setExecutable(true)
+        return script.absolutePath
+    }
+
+    private fun newArgsFile(): File = File.createTempFile("cloudflared-argv", ".txt").also { it.deleteOnExit() }
+
+    private suspend fun awaitRecordedArgs(argsFile: File): List<String> {
+        withTimeout(AWAIT_TIMEOUT_MS) {
+            while (argsFile.length() == 0L) {
+                delay(ARGS_POLL_INTERVAL_MS)
+            }
+        }
+        return argsFile.readLines()
+    }
 
     @Nested
     @DisplayName("token-mode helpers")
@@ -471,8 +502,137 @@ class CloudflareTunnelProviderTest {
         }
     }
 
+    @Nested
+    @DisplayName("extra args wiring")
+    inner class ExtraArgsWiring {
+        @Test
+        fun `free mode appends extra args after fixed args`() =
+            runBlocking {
+                val argsFile = newArgsFile()
+                every { mockBinaryResolver.resolve() } returns fakeBinaryRecordingArgs(argsFile)
+                val provider = createProvider()
+
+                provider.start(
+                    8080,
+                    ServerConfig(cloudflareTunnelExtraArgs = "--edge region1.v2.argotunnel.com:7844 --protocol http2"),
+                )
+                val argv = awaitRecordedArgs(argsFile)
+
+                assertEquals(
+                    listOf(
+                        "tunnel",
+                        "--url",
+                        "http://localhost:8080",
+                        "--output",
+                        "json",
+                        "--edge",
+                        "region1.v2.argotunnel.com:7844",
+                        "--protocol",
+                        "http2",
+                    ),
+                    argv,
+                )
+                provider.stop()
+            }
+
+        @Test
+        fun `token mode appends extra args after fixed args`() =
+            runBlocking {
+                val argsFile = newArgsFile()
+                every { mockBinaryResolver.resolve() } returns fakeBinaryRecordingArgs(argsFile)
+                val provider = createProvider()
+
+                provider.start(
+                    8080,
+                    tokenConfig().copy(
+                        cloudflareTunnelExtraArgs = "--edge region1.v2.argotunnel.com:7844 --protocol http2",
+                    ),
+                )
+                val argv = awaitRecordedArgs(argsFile)
+
+                assertEquals(
+                    listOf(
+                        "tunnel",
+                        "--output",
+                        "json",
+                        "run",
+                        "--token",
+                        "fake-token",
+                        "--edge",
+                        "region1.v2.argotunnel.com:7844",
+                        "--protocol",
+                        "http2",
+                    ),
+                    argv,
+                )
+                provider.stop()
+            }
+
+        @Test
+        fun `free mode with blank extra args launches fixed args only`() =
+            runBlocking {
+                val argsFile = newArgsFile()
+                every { mockBinaryResolver.resolve() } returns fakeBinaryRecordingArgs(argsFile)
+                val provider = createProvider()
+
+                provider.start(8080, ServerConfig(cloudflareTunnelExtraArgs = "   "))
+                val argv = awaitRecordedArgs(argsFile)
+
+                assertEquals(
+                    listOf("tunnel", "--url", "http://localhost:8080", "--output", "json"),
+                    argv,
+                )
+                provider.stop()
+            }
+
+        @Test
+        fun `token mode with blank extra args launches fixed args only`() =
+            runBlocking {
+                val argsFile = newArgsFile()
+                every { mockBinaryResolver.resolve() } returns fakeBinaryRecordingArgs(argsFile)
+                val provider = createProvider()
+
+                provider.start(8080, tokenConfig().copy(cloudflareTunnelExtraArgs = "   "))
+                val argv = awaitRecordedArgs(argsFile)
+
+                assertEquals(
+                    listOf("tunnel", "--output", "json", "run", "--token", "fake-token"),
+                    argv,
+                )
+                provider.stop()
+            }
+
+        @Test
+        fun `quoted extra arg arrives as a single argv element`() =
+            runBlocking {
+                val argsFile = newArgsFile()
+                every { mockBinaryResolver.resolve() } returns fakeBinaryRecordingArgs(argsFile)
+                val provider = createProvider()
+
+                provider.start(
+                    8080,
+                    ServerConfig(cloudflareTunnelExtraArgs = "--custom-flag=\"hello world\""),
+                )
+                val argv = awaitRecordedArgs(argsFile)
+
+                assertEquals(
+                    listOf(
+                        "tunnel",
+                        "--url",
+                        "http://localhost:8080",
+                        "--output",
+                        "json",
+                        "--custom-flag=hello world",
+                    ),
+                    argv,
+                )
+                provider.stop()
+            }
+    }
+
     companion object {
         private const val AWAIT_TIMEOUT_MS = 10_000L
+        private const val ARGS_POLL_INTERVAL_MS = 50L
 
         /** True for a Connected status that already carries at least one endpoint (route applied). */
         private fun TunnelStatus.connectedWithEndpoints() = this is TunnelStatus.Connected && endpoints.isNotEmpty()


### PR DESCRIPTION
## Summary

Follow-up to #172. That PR added the Cloudflare tunnel "Extra Arguments" setting with tests for the `parseCommandLineArguments` tokenizer, persistence, ViewModel state, and the ADB extra — but nothing verified that the configured extras actually end up on the cloudflared command line, nor their position relative to the fixed arguments. This PR closes that gap; a regression that dropped the extras or inserted them in the wrong position would previously have passed the suite.

## Changes

- New `extra args wiring` test group in `CloudflareTunnelProviderTest`:
  - FREE mode appends extras after the fixed args (`tunnel --url http://localhost:<port> --output json`)
  - TOKEN mode appends extras after the fixed args (`tunnel --output json run --token <token>`), guarding the documented argument-order invariant (`--output json` before `run`, no `--url`)
  - blank extras leave the fixed argv untouched in both modes
  - a quoted extra argument (`--custom-flag="hello world"`) arrives as a single argv element end-to-end
- Supporting helpers following the file's existing fake-binary conventions: a fake cloudflared script that records its argv to a file (written atomically via `mv` to avoid partial reads) and a polling await helper

## Testing

- `CloudflareTunnelProviderTest` passes (all 5 new tests execute and pass)
- Full unit suite passes (`make test-unit`)
- Lint passes (`ktlintCheck` + `detekt`)

## Checklist

- [x] All tests pass (`make test-unit`)
- [x] Lint passes (`make lint`)