### PR TITLE
fix(security): allowBackup=false + path-traversal guard on non-builtin file ops

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -48,7 +48,7 @@
 
     <application
         android:name=".McpApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/FileOperationProviderImpl.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/FileOperationProviderImpl.kt
@@ -48,6 +48,7 @@ class FileOperationProviderImpl
             if (BuiltinStorageLocation.isBuiltinId(locationId)) {
                 return mediaStoreFileOperations.listFiles(locationId, path, offset, limit)
             }
+            BuiltinStorageLocation.validatePath(path)
             val directory =
                 resolveDocumentFile(locationId, path)
                     ?: throw McpToolException.ActionFailed(
@@ -102,6 +103,7 @@ class FileOperationProviderImpl
             if (BuiltinStorageLocation.isBuiltinId(locationId)) {
                 return mediaStoreFileOperations.readFile(locationId, path, offset, limit)
             }
+            BuiltinStorageLocation.validatePath(path)
             require(offset >= 1) { "offset must be >= 1, got $offset" }
             val documentFile = resolveRegularFileOrThrow(locationId, path)
 
@@ -155,6 +157,7 @@ class FileOperationProviderImpl
             if (BuiltinStorageLocation.isBuiltinId(locationId)) {
                 return mediaStoreFileOperations.readFileBytes(locationId, path, maxBytes)
             }
+            BuiltinStorageLocation.validatePath(path)
             val documentFile = resolveRegularFileOrThrow(locationId, path)
 
             val fileName = documentFile.name ?: path.substringAfterLast('/')
@@ -179,6 +182,7 @@ class FileOperationProviderImpl
             if (BuiltinStorageLocation.isBuiltinId(locationId)) {
                 return mediaStoreFileOperations.writeFile(locationId, path, content)
             }
+            BuiltinStorageLocation.validatePath(path)
             val config = settingsRepository.getServerConfig()
             val contentBytes = content.toByteArray(Charsets.UTF_8)
             val limitBytes = config.fileSizeLimitMb.toLong() * BYTES_PER_MB
@@ -214,6 +218,7 @@ class FileOperationProviderImpl
             if (BuiltinStorageLocation.isBuiltinId(locationId)) {
                 return mediaStoreFileOperations.appendFile(locationId, path, content)
             }
+            BuiltinStorageLocation.validatePath(path)
             checkAuthorization(locationId)
             checkWritePermission(locationId)
             val config = settingsRepository.getServerConfig()
@@ -251,6 +256,7 @@ class FileOperationProviderImpl
             if (BuiltinStorageLocation.isBuiltinId(locationId)) {
                 return mediaStoreFileOperations.replaceInFile(locationId, path, oldString, newString, replaceAll)
             }
+            BuiltinStorageLocation.validatePath(path)
             checkAuthorization(locationId)
             checkWritePermission(locationId)
             val documentFile = resolveRegularFileOrThrow(locationId, path)
@@ -300,6 +306,7 @@ class FileOperationProviderImpl
             if (BuiltinStorageLocation.isBuiltinId(locationId)) {
                 return mediaStoreFileOperations.downloadFromUrl(locationId, path, url)
             }
+            BuiltinStorageLocation.validatePath(path)
             checkAuthorization(locationId)
             checkWritePermission(locationId)
             val config = settingsRepository.getServerConfig()
@@ -416,6 +423,7 @@ class FileOperationProviderImpl
             if (BuiltinStorageLocation.isBuiltinId(locationId)) {
                 return mediaStoreFileOperations.deleteFile(locationId, path)
             }
+            BuiltinStorageLocation.validatePath(path)
             checkAuthorization(locationId)
             checkDeletePermission(locationId)
             val documentFile = resolveFileOrThrow(locationId, path)
@@ -449,6 +457,7 @@ class FileOperationProviderImpl
             if (BuiltinStorageLocation.isBuiltinId(locationId)) {
                 return mediaStoreFileOperations.createFileUri(locationId, path, mimeType)
             }
+            BuiltinStorageLocation.validatePath(path)
             checkAuthorization(locationId)
             checkWritePermission(locationId)
             val documentFile = ensureParentDirectoriesAndCreateFile(locationId, path, mimeType)

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/FileOperationProviderTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/storage/FileOperationProviderTest.kt
@@ -1493,6 +1493,91 @@ class FileOperationProviderTest {
             }
     }
 
+    @Nested
+    @DisplayName("path traversal validation (non-builtin locations)")
+    inner class PathTraversalValidation {
+        // The guard runs before authorization and resolution, so a bad path is rejected
+        // for every entry point regardless of mock setup. "loc1" is a non-builtin location.
+
+        @Test
+        fun `listFiles rejects parent traversal segment`() =
+            runTest {
+                val exception =
+                    assertThrows<McpToolException.InvalidParams> {
+                        provider.listFiles("loc1", "../secrets", 0, 10)
+                    }
+                assertTrue(exception.message!!.contains(".."))
+            }
+
+        @Test
+        fun `readFile rejects parent traversal segment`() =
+            runTest {
+                assertThrows<McpToolException.InvalidParams> {
+                    provider.readFile("loc1", "sub/../../etc/hosts", 1, 10)
+                }
+            }
+
+        @Test
+        fun `readFileBytes rejects absolute path`() =
+            runTest {
+                val exception =
+                    assertThrows<McpToolException.InvalidParams> {
+                        provider.readFileBytes("loc1", "/etc/hosts", TEN_MB)
+                    }
+                assertTrue(exception.message!!.contains("absolute"))
+            }
+
+        @Test
+        fun `writeFile rejects parent traversal segment`() =
+            runTest {
+                assertThrows<McpToolException.InvalidParams> {
+                    provider.writeFile("loc1", "../escape.txt", "data")
+                }
+            }
+
+        @Test
+        fun `appendFile rejects current-directory segment`() =
+            runTest {
+                assertThrows<McpToolException.InvalidParams> {
+                    provider.appendFile("loc1", "./relative.txt", "data")
+                }
+            }
+
+        @Test
+        fun `replaceInFile rejects parent traversal segment`() =
+            runTest {
+                assertThrows<McpToolException.InvalidParams> {
+                    provider.replaceInFile("loc1", "../file.txt", "a", "b", false)
+                }
+            }
+
+        @Test
+        fun `downloadFromUrl rejects parent traversal segment`() =
+            runTest {
+                assertThrows<McpToolException.InvalidParams> {
+                    provider.downloadFromUrl("loc1", "../evil.bin", "https://example.com/f")
+                }
+            }
+
+        @Test
+        fun `deleteFile rejects parent traversal segment`() =
+            runTest {
+                assertThrows<McpToolException.InvalidParams> {
+                    provider.deleteFile("loc1", "../../etc/passwd")
+                }
+            }
+
+        @Test
+        fun `createFileUri rejects control-character segment`() =
+            runTest {
+                val exception =
+                    assertThrows<McpToolException.InvalidParams> {
+                        provider.createFileUri("loc1", "bad\u0000name.txt", "text/plain")
+                    }
+                assertTrue(exception.message!!.contains("control"))
+            }
+    }
+
     companion object {
         private const val BYTES_PER_MB = 1024 * 1024
         private const val DEFAULT_FILE_SIZE_LIMIT_MB = 50


### PR DESCRIPTION
## Summary

Two small **defense-in-depth** hardenings for the storage/file-operation surface:

1. **`allowBackup="false"`** in `AndroidManifest.xml` — excludes bearer tokens, OAuth registrations, storage grants, and other DataStore settings from Android auto-backup / `adb backup`. No `fullBackupContent` / `dataExtractionRules` / `BackupAgent` references exist, so nothing dangles.

2. **Path-traversal guard on the non-builtin file-operation path.** The builtin (MediaStore) operations already call `BuiltinStorageLocation.validatePath()` at every entry point, but the **non-builtin** (user-granted SAF tree) branch relied solely on `DocumentFile.findFile()` segment-walking with no explicit guard. This applies the **same existing shared validator** to all nine non-builtin entry points (`listFiles`, `readFile`, `readFileBytes`, `writeFile`, `appendFile`, `replaceInFile`, `downloadFromUrl`, `deleteFile`, `createFileUri`), rejecting `..`, `.`, absolute, and control-character segments before resolution.

### Why

Closes a consistency gap: builtin vs. non-builtin paths were validated inconsistently. SAF's `findFile("..")` doesn't actually traverse upward (no child is literally named `..`), so this is hardening rather than a fix for a live exploit — but it makes the guarantee explicit and uniform across all location types, and also covers the separate MediaStore-delegating branch for user locations. Empty paths (root listing) remain allowed, so no behavior regresses.

## Implementation notes

- Reuses the existing `BuiltinStorageLocation.validatePath()` rather than introducing a duplicate validator, mirroring exactly how `MediaStoreFileOperationsImpl` already calls it. The guard is placed immediately **after** the builtin early-return, so the builtin path is never double-validated and validation runs before authorization/resolution.
- I did **not** additionally reject backslash (`\`), since Android treats `\` as a normal filename character (not a path separator); rejecting it could break legitimate names. All location types now share identical validation semantics.

## Tests

- New `PathTraversalValidation` group in `FileOperationProviderTest` (9 tests, one per entry point) covering `..`, `.`, absolute, and control-character rejection.
- Existing happy-path tests (empty root path, valid nested paths) continue to pass, confirming no regression.
- Quality gates: `make lint` (ktlint + detekt) clean; full unit suite (`make test-unit`, gms + foss) green; `assembleGmsDebug` succeeds and the merged manifest confirms `allowBackup="false"`.

## Credit

The path-traversal guard on the general `FileOperationProvider` was originally identified and implemented by **[@Arvind-dev-india](https://github.com/Arvind-dev-india)** on the `homelab` branch of the fork [`Arvind-dev-india/android-remote-control-mcp`](https://github.com/Arvind-dev-india/android-remote-control-mcp/tree/homelab) (as `validateRelativePath()` in `FileOperationProviderImpl`), along with the `allowBackup="false"` change. This PR ports those two hardenings to upstream, consolidating the path guard onto the existing shared `BuiltinStorageLocation.validatePath()` validator.
