### PR TITLE
feat: add "Hide from Recents" setting to exclude app from recent tasks list

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@ adb shell am broadcast \
   --es binding_address "0.0.0.0" \
   --ei port 8080 \
   --ez auto_start_on_boot true \
+  --ez hide_from_recents false \
   --ez https_enabled false \
   --es certificate_source "AUTO_GENERATED" \
   --es certificate_hostname "mcp.local" \
@@ -475,6 +476,7 @@ Bearer enforcement is controlled by `--ez bearer_token_enabled <bool>`, NOT by c
 | `binding_address` | string | `127.0.0.1` (localhost) or `0.0.0.0` (network) |
 | `port` | int | HTTP/HTTPS server port (1-65535) |
 | `auto_start_on_boot` | boolean | Start MCP server when device boots |
+| `hide_from_recents` | boolean | Exclude the app from the Android Recent Tasks list |
 | `https_enabled` | boolean | Enable HTTPS with TLS |
 | `certificate_source` | string | `AUTO_GENERATED` or `CUSTOM` |
 | `certificate_hostname` | string | Hostname for auto-generated certificate |

--- a/app/src/debug/kotlin/com/danielealbano/androidremotecontrolmcp/debug/E2EConfigReceiver.kt
+++ b/app/src/debug/kotlin/com/danielealbano/androidremotecontrolmcp/debug/E2EConfigReceiver.kt
@@ -9,6 +9,7 @@ import com.danielealbano.androidremotecontrolmcp.data.model.ServerConfig
 import com.danielealbano.androidremotecontrolmcp.data.repository.SettingsRepository
 import com.danielealbano.androidremotecontrolmcp.services.mcp.McpServerService
 import com.danielealbano.androidremotecontrolmcp.services.storage.StorageLocationProvider
+import com.danielealbano.androidremotecontrolmcp.utils.RecentsUtils
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -44,7 +45,8 @@ import javax.inject.Inject
  *   --es bearer_token "test-token-uuid" \
  *   --es binding_address "0.0.0.0" \
  *   --ei port 8080 \
- *   --ez auto_start_on_boot true
+ *   --ez auto_start_on_boot true \
+ *   --ez hide_from_recents false
  *
  * # Start the MCP server (runs inside app process, avoids exported=false restriction)
  * adb shell am broadcast \
@@ -72,7 +74,7 @@ class E2EConfigReceiver : BroadcastReceiver() {
         @Suppress("TooGenericExceptionCaught")
         try {
             when (intent.action) {
-                ACTION_E2E_CONFIGURE -> handleConfigure(intent)
+                ACTION_E2E_CONFIGURE -> handleConfigure(context, intent)
                 ACTION_E2E_START_SERVER -> handleStartServer(context)
                 else -> Log.w(TAG, "Ignoring unexpected action: ${intent.action}")
             }
@@ -81,7 +83,10 @@ class E2EConfigReceiver : BroadcastReceiver() {
         }
     }
 
-    private fun handleConfigure(intent: Intent) {
+    private fun handleConfigure(
+        context: Context,
+        intent: Intent,
+    ) {
         Log.i(TAG, "Received E2E configuration broadcast")
 
         val bearerToken = intent.getStringExtra(EXTRA_BEARER_TOKEN)
@@ -116,6 +121,7 @@ class E2EConfigReceiver : BroadcastReceiver() {
             if (intent.hasExtra(EXTRA_HIDE_FROM_RECENTS)) {
                 val hideFromRecents = intent.getBooleanExtra(EXTRA_HIDE_FROM_RECENTS, false)
                 settingsRepository.updateHideFromRecents(hideFromRecents)
+                RecentsUtils.setExcludeFromRecents(context, hideFromRecents)
                 Log.i(TAG, "Hide from recents updated to $hideFromRecents")
             }
             applyAuthFlags(intent)

--- a/app/src/debug/kotlin/com/danielealbano/androidremotecontrolmcp/debug/E2EConfigReceiver.kt
+++ b/app/src/debug/kotlin/com/danielealbano/androidremotecontrolmcp/debug/E2EConfigReceiver.kt
@@ -113,6 +113,11 @@ class E2EConfigReceiver : BroadcastReceiver() {
                 settingsRepository.updateAutoStartOnBoot(autoStart)
                 Log.i(TAG, "Auto-start on boot updated to $autoStart")
             }
+            if (intent.hasExtra(EXTRA_HIDE_FROM_RECENTS)) {
+                val hideFromRecents = intent.getBooleanExtra(EXTRA_HIDE_FROM_RECENTS, false)
+                settingsRepository.updateHideFromRecents(hideFromRecents)
+                Log.i(TAG, "Hide from recents updated to $hideFromRecents")
+            }
             applyAuthFlags(intent)
             applyDownloadSettings(intent)
             val storageLocationId = intent.getStringExtra(EXTRA_STORAGE_LOCATION_ID)
@@ -184,6 +189,7 @@ class E2EConfigReceiver : BroadcastReceiver() {
         private const val EXTRA_BINDING_ADDRESS = "binding_address"
         private const val EXTRA_PORT = "port"
         private const val EXTRA_AUTO_START_ON_BOOT = "auto_start_on_boot"
+        private const val EXTRA_HIDE_FROM_RECENTS = "hide_from_recents"
         private const val EXTRA_STORAGE_LOCATION_ID = "storage_location_id"
         private const val EXTRA_STORAGE_ALLOW_WRITE = "storage_allow_write"
         private const val EXTRA_STORAGE_ALLOW_DELETE = "storage_allow_delete"

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/data/model/ServerConfig.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/data/model/ServerConfig.kt
@@ -34,6 +34,7 @@ package com.danielealbano.androidremotecontrolmcp.data.model
  *   auto-generates a token.
  * @property publicUrlOverride Optional public base URL that pins the host used for OAuth metadata and
  *   share links (empty = auto-detect from the request).
+ * @property hideFromRecents Whether to exclude the app from Android's Recent Apps / Overview screen.
  */
 data class ServerConfig(
     val port: Int = DEFAULT_PORT,
@@ -61,6 +62,7 @@ data class ServerConfig(
     val publicUrlOverride: String = "",
     val toolPermissionsConfig: ToolPermissionsConfig = ToolPermissionsConfig(),
     val privacyModeConfig: PrivacyModeConfig = PrivacyModeConfig(),
+    val hideFromRecents: Boolean = false,
 ) {
     companion object {
         /** Default server port. */

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/data/repository/SettingsRepository.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/data/repository/SettingsRepository.kt
@@ -105,6 +105,9 @@ interface SettingsRepository : EventChannelSettings {
     /** Updates the auto-start-on-boot preference. */
     suspend fun updateAutoStartOnBoot(enabled: Boolean)
 
+    /** Updates the hide-from-recents preference. */
+    suspend fun updateHideFromRecents(enabled: Boolean)
+
     /** Enables or disables the on-device MCP tool-call activity indicator. */
     suspend fun updateToolCallIndicatorEnabled(enabled: Boolean)
 

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/data/repository/SettingsRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/data/repository/SettingsRepositoryImpl.kt
@@ -46,6 +46,7 @@ private val BEARER_TOKEN_ENABLED_INITIALIZED_KEY =
 private val PUBLIC_URL_OVERRIDE_KEY = stringPreferencesKey("public_url_override")
 private val JWT_SIGNING_SECRET_KEY = stringPreferencesKey("jwt_signing_secret")
 private val AUTO_START_KEY = booleanPreferencesKey("auto_start_on_boot")
+private val HIDE_FROM_RECENTS_KEY = booleanPreferencesKey("hide_from_recents")
 private val TOOL_CALL_INDICATOR_ENABLED_KEY = booleanPreferencesKey("tool_call_indicator_enabled")
 private val SERVER_RUNNING_KEY = booleanPreferencesKey("server_running")
 private val HTTPS_ENABLED_KEY = booleanPreferencesKey("https_enabled")
@@ -142,6 +143,7 @@ private fun mapPreferencesToServerConfig(prefs: Preferences): ServerConfig {
         publicUrlOverride = prefs[PUBLIC_URL_OVERRIDE_KEY] ?: "",
         toolPermissionsConfig = ToolPermissionsConfig.fromJsonOrDefault(prefs[TOOL_PERMISSIONS_KEY]),
         privacyModeConfig = PrivacyModeConfig.fromJsonOrDefault(prefs[PRIVACY_MODE_CONFIG_KEY]),
+        hideFromRecents = prefs[HIDE_FROM_RECENTS_KEY] ?: false,
     )
 }
 
@@ -378,6 +380,14 @@ class SettingsRepositoryImpl
                 val old = prefs[AUTO_START_KEY] ?: false
                 prefs[AUTO_START_KEY] = enabled
                 logToggle("auto_start", old, enabled, "Auto-start on boot")
+            }
+        }
+
+        override suspend fun updateHideFromRecents(enabled: Boolean) {
+            dataStore.edit { prefs ->
+                val old = prefs[HIDE_FROM_RECENTS_KEY] ?: false
+                prefs[HIDE_FROM_RECENTS_KEY] = enabled
+                logToggle("hide_from_recents", old, enabled, "Hide from recents")
             }
         }
 

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/mcp/AdbConfigHandler.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/mcp/AdbConfigHandler.kt
@@ -1,6 +1,5 @@
 package com.danielealbano.androidremotecontrolmcp.services.mcp
 
-import android.app.ActivityManager
 import android.content.Context
 import android.content.Intent
 import android.util.Log
@@ -13,6 +12,7 @@ import com.danielealbano.androidremotecontrolmcp.data.model.TunnelProviderType
 import com.danielealbano.androidremotecontrolmcp.data.repository.ServerLogRepository
 import com.danielealbano.androidremotecontrolmcp.data.repository.SettingsRepository
 import com.danielealbano.androidremotecontrolmcp.services.storage.StorageLocationProvider
+import com.danielealbano.androidremotecontrolmcp.utils.RecentsUtils
 
 /**
  * Handles ADB configuration broadcast intents by parsing extras and
@@ -182,10 +182,7 @@ class AdbConfigHandler(
         if (!intent.hasExtra(EXTRA_HIDE_FROM_RECENTS)) return
         val value = intent.getBooleanExtra(EXTRA_HIDE_FROM_RECENTS, false)
         settingsRepository.updateHideFromRecents(value)
-        val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
-        activityManager?.appTasks?.forEach { task ->
-            task.setExcludeFromRecents(value)
-        }
+        RecentsUtils.setExcludeFromRecents(context, value)
         Log.i(TAG, "Hide from recents updated to $value")
     }
 

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/mcp/AdbConfigHandler.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/mcp/AdbConfigHandler.kt
@@ -1,5 +1,6 @@
 package com.danielealbano.androidremotecontrolmcp.services.mcp
 
+import android.app.ActivityManager
 import android.content.Context
 import android.content.Intent
 import android.util.Log
@@ -34,7 +35,7 @@ class AdbConfigHandler(
         intent: Intent,
     ) {
         when (intent.action) {
-            AdbConfigReceiver.ACTION_CONFIGURE -> handleConfigure(intent)
+            AdbConfigReceiver.ACTION_CONFIGURE -> handleConfigure(context, intent)
             AdbConfigReceiver.ACTION_START_SERVER -> handleStartServer(context)
             AdbConfigReceiver.ACTION_STOP_SERVER -> handleStopServer(context)
             else -> Log.w(TAG, "Ignoring unexpected action: ${intent.action}")
@@ -42,7 +43,10 @@ class AdbConfigHandler(
     }
 
     @Suppress("LongMethod")
-    private suspend fun handleConfigure(intent: Intent) {
+    private suspend fun handleConfigure(
+        context: Context,
+        intent: Intent,
+    ) {
         Log.i(TAG, "Received ADB configuration broadcast")
         serverLogRepository.log(ServerLogEntry.Type.SETTINGS, "Configuration update received via ADB")
 
@@ -53,6 +57,7 @@ class AdbConfigHandler(
         applyBindingAddress(intent)
         applyPort(intent)
         applyAutoStartOnBoot(intent)
+        applyHideFromRecents(context, intent)
         applyHttpsEnabled(intent)
         applyCertificateSource(intent)
         applyCertificateHostname(intent)
@@ -168,6 +173,20 @@ class AdbConfigHandler(
         val value = intent.getBooleanExtra(EXTRA_AUTO_START_ON_BOOT, false)
         settingsRepository.updateAutoStartOnBoot(value)
         Log.i(TAG, "Auto-start on boot updated to $value")
+    }
+
+    private suspend fun applyHideFromRecents(
+        context: Context,
+        intent: Intent,
+    ) {
+        if (!intent.hasExtra(EXTRA_HIDE_FROM_RECENTS)) return
+        val value = intent.getBooleanExtra(EXTRA_HIDE_FROM_RECENTS, false)
+        settingsRepository.updateHideFromRecents(value)
+        val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+        activityManager?.appTasks?.forEach { task ->
+            task.setExcludeFromRecents(value)
+        }
+        Log.i(TAG, "Hide from recents updated to $value")
     }
 
     private suspend fun applyHttpsEnabled(intent: Intent) {
@@ -392,6 +411,7 @@ class AdbConfigHandler(
         internal const val EXTRA_BINDING_ADDRESS = "binding_address"
         internal const val EXTRA_PORT = "port"
         internal const val EXTRA_AUTO_START_ON_BOOT = "auto_start_on_boot"
+        internal const val EXTRA_HIDE_FROM_RECENTS = "hide_from_recents"
         internal const val EXTRA_HTTPS_ENABLED = "https_enabled"
         internal const val EXTRA_CERTIFICATE_SOURCE = "certificate_source"
         internal const val EXTRA_CERTIFICATE_HOSTNAME = "certificate_hostname"

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/mcp/AdbConfigReceiver.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/services/mcp/AdbConfigReceiver.kt
@@ -45,6 +45,7 @@ import javax.inject.Inject
  *   --es binding_address "0.0.0.0" \
  *   --ei port 8080 \
  *   --ez auto_start_on_boot true \
+ *   --ez hide_from_recents false \
  *   --ez https_enabled false \
  *   --es certificate_source "AUTO_GENERATED" \
  *   --es certificate_hostname "android-mcp.local" \

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/MainActivity.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/MainActivity.kt
@@ -1,8 +1,6 @@
 package com.danielealbano.androidremotecontrolmcp.ui
 
 import android.Manifest
-import android.app.ActivityManager
-import android.content.Context
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -17,6 +15,7 @@ import com.danielealbano.androidremotecontrolmcp.services.update.UpdateCheckSche
 import com.danielealbano.androidremotecontrolmcp.ui.screens.MainScreen
 import com.danielealbano.androidremotecontrolmcp.ui.theme.AndroidRemoteControlMcpTheme
 import com.danielealbano.androidremotecontrolmcp.ui.viewmodels.MainViewModel
+import com.danielealbano.androidremotecontrolmcp.utils.RecentsUtils
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 
@@ -34,8 +33,8 @@ class MainActivity : ComponentActivity() {
 
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.serverConfig.collect { config ->
-                    updateExcludeFromRecents(config.hideFromRecents)
+                viewModel.hideFromRecents.collect { hide ->
+                    updateExcludeFromRecents(hide)
                 }
             }
         }
@@ -120,9 +119,6 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun updateExcludeFromRecents(hide: Boolean) {
-        val activityManager = getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
-        activityManager?.appTasks?.forEach { task ->
-            task.setExcludeFromRecents(hide)
-        }
+        RecentsUtils.setExcludeFromRecents(this, hide)
     }
 }

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/MainActivity.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/MainActivity.kt
@@ -1,6 +1,8 @@
 package com.danielealbano.androidremotecontrolmcp.ui
 
 import android.Manifest
+import android.app.ActivityManager
+import android.content.Context
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -8,11 +10,15 @@ import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.danielealbano.androidremotecontrolmcp.services.update.UpdateCheckScheduler
 import com.danielealbano.androidremotecontrolmcp.ui.screens.MainScreen
 import com.danielealbano.androidremotecontrolmcp.ui.theme.AndroidRemoteControlMcpTheme
 import com.danielealbano.androidremotecontrolmcp.ui.viewmodels.MainViewModel
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -25,6 +31,14 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.serverConfig.collect { config ->
+                    updateExcludeFromRecents(config.hideFromRecents)
+                }
+            }
+        }
 
         notificationPermissionLauncher =
             registerForActivityResult(
@@ -103,5 +117,12 @@ class MainActivity : ComponentActivity() {
 
     private fun requestLocationPermission() {
         locationPermissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+    }
+
+    private fun updateExcludeFromRecents(hide: Boolean) {
+        val activityManager = getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+        activityManager?.appTasks?.forEach { task ->
+            task.setExcludeFromRecents(hide)
+        }
     }
 }

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/settings/GeneralSettingsScreen.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/screens/settings/GeneralSettingsScreen.kt
@@ -214,6 +214,31 @@ fun GeneralSettingsScreen(
                     enabled = isEnabled,
                 )
             }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Hide from Recents Toggle
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(R.string.config_hide_from_recents_label),
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                    Text(
+                        text = stringResource(R.string.config_hide_from_recents_description),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Switch(
+                    checked = serverConfig.hideFromRecents,
+                    onCheckedChange = viewModel::updateHideFromRecents,
+                    enabled = isEnabled,
+                )
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/viewmodels/MainViewModel.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/viewmodels/MainViewModel.kt
@@ -547,6 +547,11 @@ class MainViewModel
                 .map { it.toolPermissionsConfig }
                 .stateIn(viewModelScope, SharingStarted.WhileSubscribed(FLOW_TIMEOUT_MS), ToolPermissionsConfig())
 
+        val hideFromRecents: StateFlow<Boolean> =
+            settingsRepository.serverConfig
+                .map { it.hideFromRecents }
+                .stateIn(viewModelScope, SharingStarted.WhileSubscribed(FLOW_TIMEOUT_MS), false)
+
         val pendingApprovalCount: StateFlow<Int> =
             approvalCoordinator
                 .observePending()

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/viewmodels/MainViewModel.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/ui/viewmodels/MainViewModel.kt
@@ -214,6 +214,12 @@ class MainViewModel
             }
         }
 
+        fun updateHideFromRecents(enabled: Boolean) {
+            viewModelScope.launch(ioDispatcher) {
+                settingsRepository.updateHideFromRecents(enabled)
+            }
+        }
+
         fun updateToolCallIndicatorEnabled(enabled: Boolean) {
             viewModelScope.launch(ioDispatcher) {
                 settingsRepository.updateToolCallIndicatorEnabled(enabled)

--- a/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/utils/RecentsUtils.kt
+++ b/app/src/main/kotlin/com/danielealbano/androidremotecontrolmcp/utils/RecentsUtils.kt
@@ -1,0 +1,25 @@
+package com.danielealbano.androidremotecontrolmcp.utils
+
+import android.app.ActivityManager
+import android.content.Context
+
+/**
+ * Utility functions for managing application tasks in the Android Recent Tasks list.
+ */
+object RecentsUtils {
+    /**
+     * Updates all application tasks to exclude or include them in the recent tasks list.
+     *
+     * @param context Application or activity context.
+     * @param exclude `true` to exclude app tasks from recents, `false` to include them.
+     */
+    fun setExcludeFromRecents(
+        context: Context,
+        exclude: Boolean,
+    ) {
+        val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+        activityManager?.appTasks?.forEach { task ->
+            task.setExcludeFromRecents(exclude)
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,6 +83,8 @@
     <string name="config_bearer_token_empty_warning_title">Authentication disabled</string>
     <string name="config_bearer_token_empty_warning_body">The bearer token is empty, so the MCP server accepts unauthenticated requests from anyone who can reach it. Stop the server (if running), then press Regenerate to enable authentication.</string>
     <string name="config_auto_start_label">Auto-start on boot</string>
+    <string name="config_hide_from_recents_label">Hide from recents</string>
+    <string name="config_hide_from_recents_description">Exclude the app from Android\'s recent apps overview.</string>
     <string name="config_tool_call_indicator_label">Show tool-call indicator</string>
     <string name="config_tool_call_indicator_description">Display a privacy-safe overlay while the MCP controls this device.</string>
     <string name="config_https_enabled_label">Enable HTTPS</string>

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/data/model/ServerConfigTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/data/model/ServerConfigTest.kt
@@ -38,6 +38,12 @@ class ServerConfigTest {
         }
 
         @Test
+        fun `default hide from recents is false`() {
+            val config = ServerConfig()
+            assertFalse(config.hideFromRecents)
+        }
+
+        @Test
         fun `tool call indicator is enabled by default`() {
             val config = ServerConfig()
             assertTrue(config.toolCallIndicatorEnabled)

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/data/repository/SettingsRepositoryImplTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/data/repository/SettingsRepositoryImplTest.kt
@@ -100,6 +100,7 @@ class SettingsRepositoryImplTest {
                 assertEquals(ServerConfig.DEFAULT_PORT, config.port)
                 assertEquals(BindingAddress.LOCALHOST, config.bindingAddress)
                 assertFalse(config.autoStartOnBoot)
+                assertFalse(config.hideFromRecents)
                 assertTrue(config.toolCallIndicatorEnabled)
                 assertFalse(config.httpsEnabled)
                 assertEquals(CertificateSource.AUTO_GENERATED, config.certificateSource)
@@ -281,6 +282,29 @@ class SettingsRepositoryImplTest {
                 val config = repository.getServerConfig()
 
                 assertFalse(config.autoStartOnBoot)
+            }
+    }
+
+    @Nested
+    @DisplayName("updateHideFromRecents")
+    inner class UpdateHideFromRecents {
+        @Test
+        fun `enables hide from recents`() =
+            testScope.runTest {
+                repository.updateHideFromRecents(true)
+                val config = repository.getServerConfig()
+
+                assertTrue(config.hideFromRecents)
+            }
+
+        @Test
+        fun `disables hide from recents`() =
+            testScope.runTest {
+                repository.updateHideFromRecents(true)
+                repository.updateHideFromRecents(false)
+                val config = repository.getServerConfig()
+
+                assertFalse(config.hideFromRecents)
             }
     }
 

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/mcp/AdbConfigHandlerTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/mcp/AdbConfigHandlerTest.kt
@@ -1,5 +1,6 @@
 package com.danielealbano.androidremotecontrolmcp.services.mcp
 
+import android.app.ActivityManager
 import android.content.Context
 import android.content.Intent
 import android.util.Log
@@ -286,27 +287,45 @@ class AdbConfigHandlerTest {
             }
 
         @Test
-        @DisplayName("hide_from_recents true is applied")
+        @DisplayName("hide_from_recents true excludes existing app tasks from recents")
         fun hideFromRecentsTrue() =
             runTest {
+                val task = mockk<ActivityManager.AppTask>(relaxed = true)
+                val activityManager =
+                    mockk<ActivityManager> {
+                        every { appTasks } returns listOf(task)
+                    }
+                every { context.getSystemService(Context.ACTIVITY_SERVICE) } returns activityManager
+
                 val intent =
                     createIntent(AdbConfigReceiver.ACTION_CONFIGURE) {
                         boolean(AdbConfigHandler.EXTRA_HIDE_FROM_RECENTS, true)
                     }
                 handler.handle(context, intent)
+
                 coVerify { settingsRepository.updateHideFromRecents(true) }
+                verify { task.setExcludeFromRecents(true) }
             }
 
         @Test
-        @DisplayName("hide_from_recents false is applied")
+        @DisplayName("hide_from_recents false includes existing app tasks in recents")
         fun hideFromRecentsFalse() =
             runTest {
+                val task = mockk<ActivityManager.AppTask>(relaxed = true)
+                val activityManager =
+                    mockk<ActivityManager> {
+                        every { appTasks } returns listOf(task)
+                    }
+                every { context.getSystemService(Context.ACTIVITY_SERVICE) } returns activityManager
+
                 val intent =
                     createIntent(AdbConfigReceiver.ACTION_CONFIGURE) {
                         boolean(AdbConfigHandler.EXTRA_HIDE_FROM_RECENTS, false)
                     }
                 handler.handle(context, intent)
+
                 coVerify { settingsRepository.updateHideFromRecents(false) }
+                verify { task.setExcludeFromRecents(false) }
             }
 
         @Test

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/mcp/AdbConfigHandlerTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/services/mcp/AdbConfigHandlerTest.kt
@@ -286,6 +286,39 @@ class AdbConfigHandlerTest {
             }
 
         @Test
+        @DisplayName("hide_from_recents true is applied")
+        fun hideFromRecentsTrue() =
+            runTest {
+                val intent =
+                    createIntent(AdbConfigReceiver.ACTION_CONFIGURE) {
+                        boolean(AdbConfigHandler.EXTRA_HIDE_FROM_RECENTS, true)
+                    }
+                handler.handle(context, intent)
+                coVerify { settingsRepository.updateHideFromRecents(true) }
+            }
+
+        @Test
+        @DisplayName("hide_from_recents false is applied")
+        fun hideFromRecentsFalse() =
+            runTest {
+                val intent =
+                    createIntent(AdbConfigReceiver.ACTION_CONFIGURE) {
+                        boolean(AdbConfigHandler.EXTRA_HIDE_FROM_RECENTS, false)
+                    }
+                handler.handle(context, intent)
+                coVerify { settingsRepository.updateHideFromRecents(false) }
+            }
+
+        @Test
+        @DisplayName("hide_from_recents is not applied when extra is absent")
+        fun hideFromRecentsAbsent() =
+            runTest {
+                val intent = createIntent(AdbConfigReceiver.ACTION_CONFIGURE)
+                handler.handle(context, intent)
+                coVerify(exactly = 0) { settingsRepository.updateHideFromRecents(any()) }
+            }
+
+        @Test
         @DisplayName("https_enabled is applied")
         fun httpsEnabled() =
             runTest {
@@ -672,6 +705,7 @@ class AdbConfigHandlerTest {
                 coVerify(exactly = 0) { settingsRepository.updateBindingAddress(any()) }
                 coVerify(exactly = 0) { settingsRepository.updatePort(any()) }
                 coVerify(exactly = 0) { settingsRepository.updateAutoStartOnBoot(any()) }
+                coVerify(exactly = 0) { settingsRepository.updateHideFromRecents(any()) }
                 coVerify(exactly = 0) { settingsRepository.updateHttpsEnabled(any()) }
                 coVerify(exactly = 0) { settingsRepository.updateCertificateSource(any()) }
                 coVerify(exactly = 0) { settingsRepository.updateCertificateHostname(any()) }

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/ui/viewmodels/MainViewModelTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/ui/viewmodels/MainViewModelTest.kt
@@ -292,6 +292,17 @@ class MainViewModelTest {
         }
 
     @Test
+    fun `updateHideFromRecents calls repository`() =
+        runTest {
+            advanceUntilIdle()
+
+            viewModel.updateHideFromRecents(true)
+            advanceUntilIdle()
+
+            coVerify { settingsRepository.updateHideFromRecents(true) }
+        }
+
+    @Test
     fun `updateHttpsEnabled calls repository`() =
         runTest {
             advanceUntilIdle()

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/ui/viewmodels/MainViewModelTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/ui/viewmodels/MainViewModelTest.kt
@@ -1348,4 +1348,20 @@ class MainViewModelTest {
             assertEquals(updatedPerms, values.last())
             job.cancel()
         }
+
+    @Test
+    fun `hideFromRecents emits updated config`() =
+        runTest {
+            advanceUntilIdle()
+
+            val values = mutableListOf<Boolean>()
+            val job = launch { viewModel.hideFromRecents.collect { values.add(it) } }
+            advanceUntilIdle()
+
+            configFlow.value = configFlow.value.copy(hideFromRecents = true)
+            advanceUntilIdle()
+
+            assertEquals(true, values.last())
+            job.cancel()
+        }
 }

--- a/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/utils/RecentsUtilsTest.kt
+++ b/app/src/test/kotlin/com/danielealbano/androidremotecontrolmcp/utils/RecentsUtilsTest.kt
@@ -1,0 +1,58 @@
+package com.danielealbano.androidremotecontrolmcp.utils
+
+import android.app.ActivityManager
+import android.content.Context
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("RecentsUtils")
+class RecentsUtilsTest {
+    @Test
+    @DisplayName("setExcludeFromRecents updates all appTasks when ActivityManager is available")
+    fun `setExcludeFromRecents updates all appTasks`() {
+        val mockTask1 = mockk<ActivityManager.AppTask>(relaxed = true)
+        val mockTask2 = mockk<ActivityManager.AppTask>(relaxed = true)
+        val mockActivityManager =
+            mockk<ActivityManager> {
+                every { appTasks } returns listOf(mockTask1, mockTask2)
+            }
+        val mockContext =
+            mockk<Context> {
+                every { getSystemService(Context.ACTIVITY_SERVICE) } returns mockActivityManager
+            }
+
+        RecentsUtils.setExcludeFromRecents(mockContext, true)
+
+        verify { mockTask1.setExcludeFromRecents(true) }
+        verify { mockTask2.setExcludeFromRecents(true) }
+    }
+
+    @Test
+    @DisplayName("setExcludeFromRecents handles null ActivityManager gracefully")
+    fun `setExcludeFromRecents handles null ActivityManager`() {
+        val mockContext =
+            mockk<Context> {
+                every { getSystemService(Context.ACTIVITY_SERVICE) } returns null
+            }
+
+        RecentsUtils.setExcludeFromRecents(mockContext, true)
+    }
+
+    @Test
+    @DisplayName("setExcludeFromRecents handles empty appTasks gracefully")
+    fun `setExcludeFromRecents handles empty appTasks`() {
+        val mockActivityManager =
+            mockk<ActivityManager> {
+                every { appTasks } returns emptyList()
+            }
+        val mockContext =
+            mockk<Context> {
+                every { getSystemService(Context.ACTIVITY_SERVICE) } returns mockActivityManager
+            }
+
+        RecentsUtils.setExcludeFromRecents(mockContext, false)
+    }
+}

--- a/app/src/testDebug/kotlin/com/danielealbano/androidremotecontrolmcp/debug/E2EConfigReceiverTest.kt
+++ b/app/src/testDebug/kotlin/com/danielealbano/androidremotecontrolmcp/debug/E2EConfigReceiverTest.kt
@@ -153,6 +153,27 @@ class E2EConfigReceiverTest {
         }
 
     @Test
+    fun `handleConfigure updates hide from recents`() =
+        runTest {
+            val intent = mockk<Intent>(relaxed = true)
+            every { intent.action } returns E2EConfigReceiver.ACTION_E2E_CONFIGURE
+            every { intent.getStringExtra("bearer_token") } returns null
+            every { intent.getStringExtra("binding_address") } returns null
+            every { intent.getIntExtra("port", -1) } returns -1
+            every { intent.hasExtra("auto_start_on_boot") } returns false
+            every { intent.hasExtra("hide_from_recents") } returns true
+            every { intent.getBooleanExtra("hide_from_recents", false) } returns true
+            every { intent.getStringExtra("storage_location_id") } returns null
+
+            coEvery { mockSettingsRepository.updateHideFromRecents(true) } just Runs
+
+            receiver.onReceive(mockContext, intent)
+            Thread.sleep(COROUTINE_WAIT_MS)
+
+            coVerify { mockSettingsRepository.updateHideFromRecents(true) }
+        }
+
+    @Test
     fun `handleConfigure updates storage location write permission`() =
         runTest {
             val intent = mockk<Intent>(relaxed = true)

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -147,7 +147,7 @@ The typical startup flow: User opens app → enables Accessibility Service in An
   - `data/repository/` — `SettingsRepository.kt`, `SettingsRepositoryImpl.kt`
   - `data/model/` — `ServerConfig.kt`, `ServerStatus.kt`, `ServerLogEntry.kt`, `BindingAddress.kt`, `CertificateSource.kt`, `ScreenshotData.kt`, `TunnelProviderType.kt`, `TunnelStatus.kt`, `StorageLocation.kt`, `FileInfo.kt`, `AppInfo.kt`, `AppFilter.kt`, `CameraInfo.kt`, `CameraResolution.kt`, `LocationData.kt`
   - `di/` — `AppModule.kt`
-  - `utils/` — `NetworkUtils.kt`, `PermissionUtils.kt`, `Logger.kt`
+  - `utils/` — `NetworkUtils.kt`, `PermissionUtils.kt`, `Logger.kt`, `RecentsUtils.kt`
 - `app/src/main/res/` — `values/strings.xml`, `values/themes.xml`, `drawable/`, `mipmap/`, `xml/accessibility_service_config.xml`
 - `app/src/main/AndroidManifest.xml`
 - `app/src/debug/` — `AndroidManifest.xml` (debug overlay), `kotlin/.../debug/E2EConfigReceiver.kt`


### PR DESCRIPTION
## Summary
Adds a "Hide from Recents" toggle in General Settings (and support via ADB broadcast extras) allowing users to exclude the app from Android's Recent Apps / Overview screen dynamically at runtime.

Closes #175

## Motivation
When running Android Remote Control MCP in the background as a long-running remote control / agent bridge service:
- Prevents the app UI from cluttering the system Recent Apps (multitasking) overview.
- Prevents the app activity from being visible in or inadvertently dismissed from the recent tasks list.

## Changes
- **Shared Utility**: Created `RecentsUtils` helper to encapsulate `ActivityManager.AppTask.setExcludeFromRecents(exclude)` iteration across all tasks.
- **Data Layer**: Added `hideFromRecents: Boolean = false` to `ServerConfig` with DataStore persistence and change logging in `SettingsRepositoryImpl`.
- **UI & ViewModel**: Added "Hide from recents" switch row in `GeneralSettingsScreen`, backed by a dedicated `hideFromRecents` StateFlow on `MainViewModel` and collected in `MainActivity`.
- **ADB & E2E**: Supported configuring via `--ez hide_from_recents <true|false>` in `AdbConfigHandler` and `E2EConfigReceiver`, applying task exclusion dynamically at runtime.
- **Documentation**: Updated `AdbConfigReceiver` KDoc usage block, `README.md` Headless Configuration table & example, and `docs/PROJECT.md` project structure.
- **Unit Tests**: Added comprehensive test coverage across `ServerConfigTest`, `SettingsRepositoryImplTest`, `MainViewModelTest`, `AdbConfigHandlerTest` (verifying `task.setExcludeFromRecents` effect), `E2EConfigReceiverTest`, and `RecentsUtilsTest`.

## Verification
- Passed `./gradlew ktlintCheck`
- Passed `./gradlew detekt`
- Passed unit tests across all modified and related modules
