### PR TITLE
security: force netty 4.1.x tooling transitives to 4.1.137.Final (CVE-2026-59903)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ tasks.withType<DependencyUpdatesTask> {
 // AGP-internal tooling configurations, and the forces must apply to :app, :compose-test-app and
 // :e2e-tests alike — so force every affected transitive up to its first patched release across ALL
 // projects and ALL configurations. The shipping runtime is unaffected: Ktor's server engine keeps its
-// netty 4.2.x line (pinned to 4.2.16.Final by :app constraints, which this 4.1.x rule never matches),
+// netty 4.2.x line (pinned to 4.2.17.Final by :app constraints, which this 4.1.x rule never matches),
 // and the app's direct bouncycastle is already 1.85.
 allprojects {
     configurations.configureEach {
@@ -60,8 +60,10 @@ allprojects {
             val name = requested.name
             when {
                 group == "io.netty" && requested.version?.startsWith("4.1.") == true -> {
-                    useVersion("4.1.136.Final")
-                    because("CVE-patched netty; UTP/grpc-netty pulls a vulnerable 4.1.x tooling transitive")
+                    useVersion("4.1.137.Final")
+                    because(
+                        "CVE-2026-59903 (and earlier); UTP/grpc-netty pulls a vulnerable 4.1.x tooling transitive",
+                    )
                 }
                 group == "org.bouncycastle" &&
                     name in setOf("bcprov-jdk18on", "bcutil-jdk18on", "bcpkix-jdk18on") -> {


### PR DESCRIPTION
## Summary

Closes Dependabot alert #103: CVE-2026-59903 (GHSA-8c42-7qj2-3j46) — `netty-codec-http` <= 4.1.136.Final is vulnerable to cache poisoning / information disclosure via CORS `Vary` header overwrite; first patched release is 4.1.137.Final.

The only consumer of the netty 4.1.x line is the AGP Unified Test Platform tooling classpath (`grpc-netty` transitive) — build-time only, never in the APK. The shipping runtime is unaffected: Ktor's server engine uses the netty 4.2.x line, pinned to 4.2.17.Final by `:app` constraints, outside this CVE's vulnerable range.

## Changes

- Root `build.gradle.kts` `eachDependency` force for `io.netty` 4.1.x: `4.1.136.Final` -> `4.1.137.Final`, `because` now cites the CVE
- Corrected the stale comment claiming the app pins netty 4.2.16.Final (constraints moved to 4.2.17.Final in #181)

## Verification

- `4.1.137.Final` confirmed present on Maven Central and is the newest 4.1.x release
- `dependencyInsight`/`dependencies` on the `unified-test-platform-core` configuration: `netty-codec-http` (and every other netty module) resolves uniformly to 4.1.137.Final, no version skew; requested 4.1.93 transitives are rewritten by the force
- App runtime classpath re-checked: netty 4.2.17.Final unchanged (the 4.1-only rule cannot match it)
- ktlint + detekt clean; full GMS and FOSS unit+integration suites green; full E2E suite executed uncached (92 tests, 0 failures, 14 pre-existing camera skips)

The alert auto-resolves after merge when the `submit-gradle` dependency-submission snapshot regenerates.

## Checklist

- [x] All tests pass (`make test-unit`)
- [x] E2E tests pass (`make test-e2e`, forced uncached run)
- [x] Lint passes (`make lint`)
- [x] Build succeeds